### PR TITLE
fix(core): transformer types, replaceFields option takes higher precedence now

### DIFF
--- a/.changeset/real-donkeys-trade.md
+++ b/.changeset/real-donkeys-trade.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/core': patch
+---
+
+Fix transformer types. Now the `replaceFields` option takes precedence as the return value can be of any type.
+If the `addFields` and `removeFields` options are also provided together with the `replaceFields` option, a warning will be logged.

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -48,13 +48,10 @@ export type TTransformType = 'default' | 'graphql' | 'rest';
 
 export type TTransformBuildName = 'build' | 'buildGraphql' | 'buildRest';
 
-export type TTransformerOptions<
-  Model extends Json,
-  TransformedModel extends Json
-> = {
+export type TTransformerOptions<Model extends Json, TransformedModel> = {
   addFields?: (args: { fields: Model }) => Partial<TransformedModel>;
-  replaceFields?: (args: { fields: Model }) => Partial<Model>;
   removeFields?: (keyof Model)[];
+  replaceFields?: (args: { fields: Model }) => TransformedModel;
   buildFields?: (keyof Model)[];
 };
 
@@ -95,13 +92,13 @@ export type TBuilder<OriginalModel extends Json> = {
     OriginalModel[K]
   >;
 } & {
-  build<TransformedModel extends Json>(
+  build<TransformedModel>(
     args?: TFieldBuilderArgs<OriginalModel>
   ): TransformedModel;
-  buildGraphql<TransformedModel extends Json>(
+  buildGraphql<TransformedModel>(
     args?: TFieldBuilderArgs<OriginalModel>
   ): TransformedModel;
-  buildRest<TransformedModel extends Json>(
+  buildRest<TransformedModel>(
     args?: TFieldBuilderArgs<OriginalModel>
   ): TransformedModel;
 };


### PR DESCRIPTION
We started implementing some models in appkit (https://github.com/commercetools/merchant-center-application-kit/pull/1743) and bumped into some small issues.
This PR fixes that.