### PR TITLE
fix: bundles compat with browser environments

### DIFF
--- a/.changeset/shy-suits-cover.md
+++ b/.changeset/shy-suits-cover.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/core': patch
+'@commercetools-test-data/commons': patch
+---
+
+Fix bundle compatibility with browser environments

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,14 @@
 module.exports = {
   presets: [
-    ['@babel/preset-env', { targets: { node: 'current' } }],
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          browsers: ['last 2 versions'],
+          node: 'current',
+        },
+      },
+    ],
     '@babel/preset-typescript',
   ],
   plugins: [


### PR DESCRIPTION
To compile for example optional chaining and so on.