### PR TITLE
fix(localized-string): filter out empty translations

### DIFF
--- a/.changeset/strong-candles-clean.md
+++ b/.changeset/strong-candles-clean.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/commons': patch
+---
+
+Filter out empty translations from LocalizedString

--- a/models/commons/src/localized-string/builder.spec.ts
+++ b/models/commons/src/localized-string/builder.spec.ts
@@ -57,6 +57,20 @@ describe('building as GraphQL', () => {
     );
   });
 
+  it('should drop undefined locales', () => {
+    const built = LocalizedString()
+      .en(undefined)
+      .buildGraphql<TLocalizedString>();
+
+    expect(built).toEqual(
+      expect.not.arrayContaining([
+        expect.objectContaining({
+          locale: 'en',
+        }),
+      ])
+    );
+  });
+
   it('should remove all language keys', () => {
     const built = LocalizedString().buildGraphql<TLocalizedString>();
 

--- a/models/commons/src/localized-string/transformers.ts
+++ b/models/commons/src/localized-string/transformers.ts
@@ -1,15 +1,19 @@
 import type { TLocalizedString, TLocalizedStringGraphql } from './types';
-
 import { Transformer } from '@commercetools-test-data/core';
+
+const isNil = (value: string | undefined) =>
+  value === undefined || value === null;
 
 const transformers = {
   graphql: Transformer<TLocalizedString, TLocalizedStringGraphql>('graphql', {
     replaceFields: ({ fields }) =>
-      Object.entries(fields).map(([locale, value]) => ({
-        locale,
-        value,
-        __typename: 'LocalizedString',
-      })),
+      Object.entries(fields)
+        .filter(([, value]) => !isNil(value))
+        .map(([locale, value]) => ({
+          locale,
+          value,
+          __typename: 'LocalizedString',
+        })),
   }),
 };
 


### PR DESCRIPTION
LocalizedString can't have an undefined as it's translation value, but we use it in some cases to override one created by `random()` builder (e.g. `LocalizedString.presets().empty`). That leads to warnings in tests, using such test data.

This PR fixes this by filtering out empty translations in transform step.