### PR TITLE
feat: drop `defaults` prop from builder

### DIFF
--- a/.changeset/quick-eagles-notice.md
+++ b/.changeset/quick-eagles-notice.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/core': major
+'@commercetools-test-data/commons': major
+---
+
+drop `default` prop from builder initializer

--- a/core/src/builder.spec.ts
+++ b/core/src/builder.spec.ts
@@ -54,45 +54,20 @@ type TestTeam = {
 
 describe('building', () => {
   describe('without generator', () => {
-    describe('without defaults', () => {
-      it('should build all properties', () => {
-        const built = Builder<TestUser>()
-          .id(1)
-          .userName('Fred')
-          .email('fred@foo.com')
-          .build();
+    it('should build all properties', () => {
+      const built = Builder<TestUser>()
+        .id(1)
+        .userName('Fred')
+        .email('fred@foo.com')
+        .build();
 
-        expect(built).toEqual(
-          expect.objectContaining({
-            id: 1,
-            userName: 'Fred',
-            email: 'fred@foo.com',
-          })
-        );
-      });
-    });
-
-    describe('with defaults', () => {
-      it('should include defaults in all build properties', () => {
-        const defaults = {
-          street: 'Homestreet 14',
-        };
-
-        const built = Builder<TestUser>({ defaults })
-          .id(1)
-          .userName('Fred')
-          .email('fred@foo.com')
-          .build();
-
-        expect(built).toEqual(
-          expect.objectContaining({
-            ...defaults,
-            id: 1,
-            userName: 'Fred',
-            email: 'fred@foo.com',
-          })
-        );
-      });
+      expect(built).toEqual(
+        expect.objectContaining({
+          id: 1,
+          userName: 'Fred',
+          email: 'fred@foo.com',
+        })
+      );
     });
 
     describe('with transformer', () => {
@@ -349,25 +324,22 @@ describe('building', () => {
       const built = Builder<TestOrganization>({
         generator,
         transformers,
-        defaults: {
-          version: 2,
-        },
       })
         .name('My name')
         .buildGraphql<TestOrganizationTransformed>();
 
-      // Should keep non defaulted and non overwritten properties
+      // Should keep non overwritten properties
       expect(built).toEqual(
         expect.objectContaining({
           name: 'My name',
         })
       );
 
-      // Should allow overwriting while using defaults
+      // Should allow overwriting generated properties
       expect(built).toEqual(
         expect.objectContaining({
           identifier: 1,
-          v: '2-1',
+          v: '3-1',
         })
       );
 

--- a/core/src/builder.ts
+++ b/core/src/builder.ts
@@ -44,10 +44,8 @@ const createState = <Model extends Json>({
   };
 };
 
-function PropertyBuilder<Model extends Json>({
-  defaults,
-}: { defaults?: Partial<Model> } = {}) {
-  const state = createState<Model>({ initial: defaults });
+function PropertyBuilder<Model extends Json>(initialProps?: Partial<Model>) {
+  const state = createState<Model>({ initial: initialProps });
 
   const builder: TPropertyBuilder<Model> = new CustomProxy<
     Partial<Model>,
@@ -59,12 +57,6 @@ function PropertyBuilder<Model extends Json>({
         switch (prop) {
           case 'get': {
             return () => state.get();
-          }
-          case 'update': {
-            return (update: Partial<Model>) => {
-              state.merge(update);
-              return builder;
-            };
           }
           default: {
             return (fnOrValue: TBuilderMapStateFunction<Model> | unknown) => {
@@ -84,39 +76,44 @@ function PropertyBuilder<Model extends Json>({
 }
 
 function Builder<Model extends Json>({
-  defaults,
   generator,
   transformers,
 }: TBuilderOptions<Model> = {}): TBuilder<Model> {
-  const propertyBuilder = PropertyBuilder<Model>({ defaults });
   const applyGeneratorIfExists = (): Partial<Model> => {
     if (!generator) return {};
-    return generator.generate({ defaults });
+    return generator.generate();
   };
 
+  const propertyBuilder = PropertyBuilder<Model>(applyGeneratorIfExists());
+
   const builder: {
-    generated: Partial<Model> | null;
     proxy: TBuilder<Model>;
   } = {
-    generated: null,
     proxy: new CustomProxy<Partial<Model>, TBuilder<Model>>(
       {},
       {
         get(_target, propToSet) {
-          if (isBuilderFunction(propToSet)) {
-            if (!builder.generated) {
-              builder.generated = applyGeneratorIfExists();
-            }
+          // Cypress specs and files that they import are now bundled with
+          // webpack starting from Cypress 5 (webpack is now the default preprocessor).
+          // This result in non-null check of
+          // properties like `__esModule` and `default` to decide what has to be
+          // provided as a module export. This means that e.g
+          // `empty` in `LocalizedString.presets.empty.en` will be evaluated
+          // to the returned function below this check, instead of `Proxy`. To avoid this
+          // we need to check against these special properties.
+          if (
+            isString(propToSet) &&
+            ['__esModule', 'default'].includes(propToSet)
+          ) {
+            return builder.proxy;
+          }
 
+          if (isBuilderFunction(propToSet)) {
             return ({
               omitFields = [],
               keepFields = [],
             }: TFieldBuilderArgs<Model> = {}) => {
-              const built = {
-                ...builder.generated,
-                ...propertyBuilder.get(),
-              } as Model;
-
+              const built = propertyBuilder.get() as Model;
               let transformed = built;
 
               switch (propToSet) {
@@ -149,28 +146,7 @@ function Builder<Model extends Json>({
             };
           }
 
-          // Cypress specs and files that they import are now bundled with
-          // webpack starting from Cypress 5 (webpack is now the default preprocessor).
-          // This result in non-null check of
-          // properties like `__esModule` and `default` to decide what has to be
-          // provided as a module export. This means that e.g
-          // `empty` in `LocalizedString.presets.empty.en` will be evaluated
-          // to the returned function below this check, instead of `Proxy`. To avoid this
-          // we need to check against these special properties.
-          if (
-            isString(propToSet) &&
-            ['__esModule', 'default'].includes(propToSet)
-          ) {
-            return builder.proxy;
-          }
-
           return (fnOrValue: string | TBuilderMapStateFunction<Model>) => {
-            if (!builder.generated) {
-              builder.generated = applyGeneratorIfExists();
-              // Make the generated data available as functional chaining of the builder.
-              propertyBuilder.update(builder.generated);
-            }
-
             if (isString(propToSet)) {
               propertyBuilder[propToSet](fnOrValue);
             }

--- a/core/src/generator.ts
+++ b/core/src/generator.ts
@@ -1,4 +1,3 @@
-// import type { Overrides } from '@jackfranklin/test-data-bot';
 import type { TGeneratorResult } from './types';
 
 import { build } from '@jackfranklin/test-data-bot';
@@ -41,12 +40,8 @@ export type Field =
 export type FieldsConfiguration<FactoryResultType> = {
   readonly [x in keyof FactoryResultType]: Field;
 };
-export interface Overrides {
-  [x: string]: Field;
-}
 export interface TraitsConfiguration<FactoryResultType> {
   readonly [traitName: string]: {
-    overrides?: Overrides;
     postBuild?: (builtThing: FactoryResultType) => FactoryResultType;
   };
 }
@@ -69,10 +64,8 @@ function Generator<FactoryResultType>({
   const originalGenerate = build<FactoryResultType>({ fields, postBuild });
 
   return {
-    generate({ defaults = {} } = {}) {
-      return originalGenerate({
-        overrides: (defaults as unknown) as Overrides,
-      });
+    generate() {
+      return originalGenerate();
     },
   };
 }

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -41,7 +41,7 @@ export type TBuilderMapStateFunction<Model extends Json> = (
 ) => Partial<Model>;
 
 export type TGeneratorResult<Model> = {
-  generate: (options: { defaults?: Partial<Model> }) => Model;
+  generate: () => Model;
 };
 
 export type TTransformType = 'default' | 'graphql' | 'rest';
@@ -123,7 +123,6 @@ export type TRestTransformer<
 > = 'rest' extends TransformerType ? { rest: TTransformer<Model> } : never;
 
 export type TBuilderOptions<Model extends Json> = {
-  defaults?: Partial<Model>;
   generator?: TGeneratorResult<Model>;
   transformers?: {
     [Key in TTransformType]?: TTransformer<Model>;

--- a/models/commons/src/localized-string/builder.ts
+++ b/models/commons/src/localized-string/builder.ts
@@ -4,11 +4,10 @@ import { Builder } from '@commercetools-test-data/core';
 import generator from './generator';
 import transformers from './transformers';
 
-const LocalizedString: TCreateLocalizedStringBuilder = ({ defaults } = {}) =>
+const LocalizedString: TCreateLocalizedStringBuilder = () =>
   Builder<TLocalizedString>({
     generator,
     transformers,
-    defaults,
   });
 
 export default LocalizedString;

--- a/models/commons/src/localized-string/types.ts
+++ b/models/commons/src/localized-string/types.ts
@@ -2,9 +2,7 @@ import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TLocalizedStringBuilder = TBuilder<TLocalizedString>;
 
-export type TCreateLocalizedStringBuilder = (args?: {
-  defaults?: Partial<TLocalizedString>;
-}) => TLocalizedStringBuilder;
+export type TCreateLocalizedStringBuilder = () => TLocalizedStringBuilder;
 
 export type TLocalizedString = {
   [locale: string]: string | undefined;


### PR DESCRIPTION
As we collected some experience with using test-data, it's turned out people never use an option to provide `defaults` prop to `Builder` instance, which current implementation provides, because facilities provided by `generator` prop are just enough. So, in order to shrink the API surface a bit, we decided to drop this prop (https://github.com/commercetools/test-data/issues/23). 

Apart from mentioned above, this PR reorganizes how `Builder` invokes the provided generator internally. Namely, there is no reason to wait for `buildXXX` or setter function to be invoked and generation can be performed right away. Which simplifies code a bit.