### PR TITLE
chore: upgrade to preconstruct v2

### DIFF
--- a/.changeset/ten-waves-obey.md
+++ b/.changeset/ten-waves-obey.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/core': patch
+'@commercetools-test-data/commons': patch
+---
+
+Upgrade preconstruct CLI to v2 for bundling.

--- a/core/package.json
+++ b/core/package.json
@@ -17,8 +17,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/core.cjs.js",
-  "module": "dist/core.esm.js",
+  "main": "dist/commercetools-test-data-core.cjs.js",
+  "module": "dist/commercetools-test-data-core.esm.js",
   "files": [
     "dist",
     "package.json",

--- a/models/commons/package.json
+++ b/models/commons/package.json
@@ -18,8 +18,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/commons.cjs.js",
-  "module": "dist/commons.esm.js",
+  "main": "dist/commercetools-test-data-commons.cjs.js",
+  "module": "dist/commercetools-test-data-commons.esm.js",
   "files": [
     "dist",
     "package.json",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@commitlint/cli": "11.0.0",
     "@commitlint/config-conventional": "11.0.0",
     "@manypkg/cli": "0.16.1",
-    "@preconstruct/cli": "1.1.34",
+    "@preconstruct/cli": "2.0.0",
     "@types/node": "14.14.6",
     "@typescript-eslint/eslint-plugin": "4.6.1",
     "@typescript-eslint/parser": "4.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1537,10 +1537,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@preconstruct/cli@1.1.34":
-  version "1.1.34"
-  resolved "https://registry.yarnpkg.com/@preconstruct/cli/-/cli-1.1.34.tgz#092416a936c4915777fa4560c2bcb16fb1f274cc"
-  integrity sha512-yrKUxDzHskWqcyLqhUFQpxkvKo+xnpkMmXso0c/u6AKn9dvTSbcBx7fdcMshDk5tzW1nR+M/xn0Eb+CtLcGT7w==
+"@preconstruct/cli@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@preconstruct/cli/-/cli-2.0.0.tgz#bface3fb95da6dabc8da6eae60802b6867f3fb72"
+  integrity sha512-PZQtozf3gv6tN7KJg0Tq3xhHx/NZMka24HPMj/E6NJFhfYropyTB7G6M69hEMnW9E3Adz6qTq85PDA1I1M5CMg==
   dependencies:
     "@babel/code-frame" "^7.5.5"
     "@babel/core" "^7.7.7"
@@ -1559,14 +1559,13 @@
     enquirer "^2.3.6"
     estree-walker "^2.0.1"
     fast-deep-equal "^2.0.1"
+    fast-glob "^3.2.4"
     fs-extra "^9.0.1"
-    globby "^11.0.1"
     is-ci "^2.0.0"
     is-reference "^1.2.1"
     jest-worker "^26.3.0"
     magic-string "^0.25.7"
     meow "^7.1.0"
-    micromatch "^4.0.2"
     ms "^2.1.2"
     normalize-path "^3.0.0"
     npm-packlist "^2.1.2"
@@ -3530,7 +3529,7 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.1.1:
+fast-glob@^3.1.1, fast-glob@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
   integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==


### PR DESCRIPTION
https://github.com/preconstruct/preconstruct/releases/tag/%40preconstruct%2Fcli%402.0.0

I run `yarn preconstruct fix`