### PR TITLE
refactor: use faker v5

### DIFF
--- a/.changeset/nervous-pumpkins-obey.md
+++ b/.changeset/nervous-pumpkins-obey.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/core': minor
+'@commercetools-test-data/commons': minor
+---
+
+Use `faker` v5

--- a/core/package.json
+++ b/core/package.json
@@ -26,8 +26,11 @@
     "README.md"
   ],
   "dependencies": {
-    "@babel/runtime": "7.13.10",
-    "@babel/runtime-corejs3": "7.13.10",
-    "@jackfranklin/test-data-bot": "1.3.0"
+    "@babel/runtime": "^7.13.10",
+    "@babel/runtime-corejs3": "^7.13.10",
+    "@types/faker": "^5.5.1",
+    "@types/lodash": "^4.14.168",
+    "faker": "^5.5.3",
+    "lodash": "^4.17.21"
   }
 }

--- a/core/src/@jackfranklin/test-data-bot/README.md
+++ b/core/src/@jackfranklin/test-data-bot/README.md
@@ -1,0 +1,1 @@
+This is a local copy of the `@jackfranklin/test-data-bot` as the original library does not seem to be maintained and we want to avoid lacking versions behind of some of the dependencies (for example `faker`).

--- a/core/src/@jackfranklin/test-data-bot/index.spec.ts
+++ b/core/src/@jackfranklin/test-data-bot/index.spec.ts
@@ -1,0 +1,661 @@
+import { build, sequence, fake, oneOf, bool, perBuild } from './';
+
+describe('test-data-bot', () => {
+  it('can build an object with no name', () => {
+    interface User {
+      name: string;
+    }
+
+    const userBuilder = build<User>({
+      fields: {
+        name: 'jack',
+      },
+    });
+
+    const user = userBuilder();
+    expect(user).toEqual({
+      name: 'jack',
+    });
+  });
+
+  it('can build an object with primitive values only', () => {
+    interface User {
+      name: string;
+    }
+
+    const userBuilder = build<User>('User', {
+      fields: {
+        name: 'jack',
+      },
+    });
+
+    const user = userBuilder();
+    expect(user).toEqual({
+      name: 'jack',
+    });
+  });
+
+  it('lets you pass null in as a value', () => {
+    interface User {
+      name: string | null;
+    }
+
+    const userBuilder = build<User>('User', {
+      fields: {
+        name: null,
+      },
+    });
+
+    const user = userBuilder();
+    expect(user).toEqual({
+      name: null,
+    });
+  });
+
+  it('lets you pass undefined in as a value', () => {
+    interface User {
+      name?: string;
+    }
+
+    const userBuilder = build<User>('User', {
+      fields: {
+        name: undefined,
+      },
+    });
+
+    const user = userBuilder();
+    expect(user).toEqual({
+      name: undefined,
+    });
+  });
+
+  it('supports nulls in nested builders', () => {
+    interface Address {
+      street1: string;
+      street2: string | null;
+      city: string;
+      state: string;
+      zipCode: string;
+    }
+    interface Company {
+      id: string;
+      name: string;
+      mailingAddress: Address;
+    }
+
+    const addressBuilder = build<Address>('Address', {
+      fields: {
+        street1: fake((f) => f.address.streetAddress()),
+        street2: null,
+        city: fake((f) => f.address.city()),
+        state: fake((f) => f.address.state()),
+        zipCode: fake((f) => f.address.zipCode()),
+      },
+    });
+
+    const companyBuilder = build<Company>('Company', {
+      fields: {
+        id: '123',
+        name: 'Test',
+        mailingAddress: perBuild(addressBuilder),
+      },
+    });
+
+    const company = companyBuilder();
+    expect(company.mailingAddress.street2).toEqual(null);
+  });
+
+  it('lets a value be overriden when building an instance', () => {
+    interface User {
+      name: string;
+    }
+
+    const userBuilder = build<User>('User', {
+      fields: {
+        name: fake((f) => f.name.findName()),
+      },
+    });
+
+    const user = userBuilder({ overrides: { name: 'customName' } });
+    expect(user).toEqual({
+      name: 'customName',
+    });
+  });
+
+  describe('perBuild', () => {
+    it('generates a new object each time', () => {
+      interface User {
+        data: {};
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          data: perBuild(() => ({})),
+        },
+      });
+
+      const user1 = userBuilder();
+      const user2 = userBuilder();
+
+      expect(user1.data).toEqual({});
+      expect(user2.data).toEqual({});
+      expect(user1.data).not.toBe(user2.data);
+    });
+  });
+
+  describe('sequence', () => {
+    it('increments the sequence value per build', () => {
+      interface User {
+        id: number;
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          id: sequence(),
+        },
+      });
+
+      const users = [userBuilder(), userBuilder()];
+      expect(users).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it('can take a function that returns a string', () => {
+      interface User {
+        id: string;
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          id: sequence((x) => `jack${x}@gmail.com`),
+        },
+      });
+
+      const user = userBuilder();
+      expect(user).toEqual({ id: 'jack1@gmail.com' });
+    });
+    it('can take a function to return a number', () => {
+      interface User {
+        id: number;
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          id: sequence((x) => x * 10),
+        },
+      });
+
+      const users = [userBuilder(), userBuilder()];
+      expect(users).toEqual([{ id: 10 }, { id: 20 }]);
+    });
+  });
+
+  describe('mapping', () => {
+    it('lets you map over the generated object to fully customise it', () => {
+      interface User {
+        name: string;
+        sports: {
+          football: boolean;
+          rugby: boolean;
+        };
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          name: fake((f) => f.name.findName()),
+          sports: {
+            football: true,
+            rugby: false,
+          },
+        },
+      });
+
+      const user = userBuilder({
+        overrides: {
+          name: 'customName',
+        },
+        map: (user) => {
+          user.sports.rugby = true;
+          return user;
+        },
+      });
+      expect(user.name).toEqual('customName');
+      expect(user.sports).toEqual({
+        football: true,
+        rugby: true,
+      });
+    });
+
+    it('lets you define the map on the builder level as postBuild', () => {
+      interface User {
+        name: string;
+      }
+
+      const userBuilder = build<User>('User', {
+        postBuild: (user) => {
+          user.name = user.name.toUpperCase();
+          return user;
+        },
+        fields: {
+          name: perBuild(() => 'jack'),
+        },
+      });
+
+      const user = userBuilder();
+      expect(user.name).toEqual('JACK');
+    });
+
+    it('runs the postBuild function after applying overrides', () => {
+      interface User {
+        name: string;
+      }
+
+      const userBuilder = build<User>('User', {
+        postBuild: (user) => {
+          user.name = user.name.toUpperCase();
+          return user;
+        },
+        fields: {
+          name: fake((f) => f.name.findName()),
+        },
+      });
+
+      const user = userBuilder({
+        overrides: {
+          name: 'jack',
+        },
+      });
+      expect(user.name).toEqual('JACK');
+    });
+
+    it('the build time map function runs after postBuild', () => {
+      expect.assertions(2);
+      interface User {
+        name: string;
+      }
+
+      const userBuilder = build<User>('User', {
+        postBuild: (user) => {
+          user.name = user.name.toUpperCase();
+          return user;
+        },
+        fields: {
+          name: fake((f) => f.name.findName()),
+        },
+      });
+
+      const user = userBuilder({
+        overrides: {
+          name: 'jack',
+        },
+        map: (user) => {
+          expect(user.name).toEqual('JACK');
+          user.name = 'new name';
+          return user;
+        },
+      });
+      expect(user.name).toEqual('new name');
+    });
+  });
+
+  describe('fake', () => {
+    it('generates some fake data', () => {
+      interface User {
+        name: string;
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          name: fake((f) => f.name.findName()),
+        },
+      });
+
+      const user = userBuilder();
+      expect(user.name).toEqual(expect.any(String));
+    });
+  });
+
+  describe('oneOf', () => {
+    test('bool is provided as a shortcut for oneOf(true, false)', () => {
+      interface User {
+        admin: boolean;
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          admin: bool(),
+        },
+      });
+
+      const user = userBuilder();
+      expect(user.admin === true || user.admin === false).toEqual(true);
+    });
+
+    it('picks a random entry from the given selection', () => {
+      interface User {
+        name: string;
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          name: oneOf('a', 'b', 'c'),
+        },
+      });
+
+      const user = userBuilder();
+      expect(['a', 'b', 'c'].includes(user.name)).toEqual(true);
+    });
+  });
+
+  describe('nested objects', () => {
+    it('fully expands arrays', () => {
+      interface User {
+        friends: {
+          names: string[];
+        };
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          friends: {
+            names: [
+              fake((f) => f.name.findName()),
+              fake((f) => f.name.findName()),
+            ],
+          },
+        },
+      });
+
+      const user = userBuilder();
+      expect(user.friends.names).toEqual([
+        expect.any(String),
+        expect.any(String),
+      ]);
+    });
+
+    it('fully expands super nested awkward things', () => {
+      interface Friend {
+        name: string;
+        sports: {
+          [x: string]: boolean;
+        };
+      }
+
+      interface User {
+        name: string;
+        friends: {
+          names: Friend[];
+        };
+      }
+
+      const friendBuilder = build<Friend>('Friend', {
+        fields: {
+          name: fake((f) => f.name.findName()),
+          sports: {
+            football: bool(),
+            basketball: false,
+            rugby: true,
+          },
+        },
+      });
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          name: 'jack',
+          friends: [
+            friendBuilder({ overrides: { name: 'customName' } }),
+            friendBuilder({
+              overrides: {
+                sports: {
+                  rugby: false,
+                },
+              },
+            }),
+          ],
+        },
+      });
+
+      const user = userBuilder();
+      expect(user.name).toEqual('jack');
+      expect(user.friends).toEqual([
+        {
+          name: 'customName',
+          sports: {
+            football: expect.any(Boolean),
+            basketball: false,
+            rugby: true,
+          },
+        },
+        {
+          name: expect.any(String),
+          sports: {
+            rugby: false,
+          },
+        },
+      ]);
+    });
+
+    it('fully expands objects to ensure all builders are executed', () => {
+      interface User {
+        details: {
+          name: string;
+        };
+        admin: boolean;
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          details: {
+            name: fake((f) => f.name.findName()),
+          },
+          admin: bool(),
+        },
+      });
+
+      const user = userBuilder();
+      expect(user).toEqual({
+        details: {
+          name: expect.any(String),
+        },
+        admin: expect.any(Boolean),
+      });
+    });
+
+    it('does not call postBuild on nested objects', () => {
+      expect.assertions(1);
+      interface User {
+        name: string;
+        sports: {
+          football: boolean;
+          basketball: boolean;
+          rugby: boolean;
+        };
+      }
+
+      const userBuilder = build<User>('User', {
+        postBuild: (user) => ({
+          ...user,
+          name: 'new name',
+        }),
+        fields: {
+          name: 'old name',
+          sports: {
+            football: true,
+            basketball: false,
+            rugby: true,
+          },
+        },
+      });
+
+      const user = userBuilder();
+
+      expect(user).toEqual({
+        name: 'new name',
+        sports: {
+          football: true,
+          basketball: false,
+          rugby: true,
+        },
+      });
+    });
+  });
+
+  describe('traits', () => {
+    it('allows a trait to be defined and then used', () => {
+      interface User {
+        name: string;
+        admin: boolean;
+      }
+
+      const userBuilder = build<User>({
+        fields: {
+          name: 'jack',
+          admin: perBuild(() => false),
+        },
+        traits: {
+          admin: {
+            overrides: { admin: perBuild(() => true) },
+          },
+        },
+      });
+
+      const userNoTrait = userBuilder();
+      const userWithTrait = userBuilder({ traits: 'admin' });
+      expect(userNoTrait.admin).toEqual(false);
+      expect(userWithTrait.admin).toEqual(true);
+    });
+
+    it('allows a trait to define a postBuild function', () => {
+      interface User {
+        name: string;
+        admin: boolean;
+      }
+
+      const userBuilder = build<User>({
+        fields: {
+          name: 'jack',
+          admin: perBuild(() => false),
+        },
+        traits: {
+          admin: {
+            overrides: { admin: perBuild(() => true) },
+            postBuild: (user) => {
+              user.name = 'postBuildTrait';
+              return user;
+            },
+          },
+        },
+      });
+
+      const userNoTrait = userBuilder();
+      const userWithTrait = userBuilder({ traits: 'admin' });
+      expect(userNoTrait.name).toEqual('jack');
+      expect(userWithTrait.name).toEqual('postBuildTrait');
+    });
+
+    it('applies build time overrides over traits', () => {
+      interface User {
+        name: string;
+        admin: boolean;
+      }
+
+      const userBuilder = build<User>({
+        fields: {
+          name: 'jack',
+          admin: perBuild(() => false),
+        },
+        traits: {
+          admin: {
+            overrides: { admin: perBuild(() => true) },
+          },
+        },
+      });
+
+      const userWithTrait = userBuilder({
+        traits: 'admin',
+        overrides: {
+          admin: perBuild(() => false),
+        },
+      });
+      expect(userWithTrait.admin).toEqual(false);
+    });
+
+    it('supports multiple traits', () => {
+      interface User {
+        name: string;
+        admin: boolean;
+      }
+
+      const userBuilder = build<User>({
+        fields: {
+          name: 'jack',
+          admin: perBuild(() => false),
+        },
+        traits: {
+          admin: {
+            overrides: { admin: perBuild(() => true) },
+          },
+          bob: {
+            overrides: { name: 'bob' },
+          },
+        },
+      });
+
+      const userWithTrait = userBuilder({
+        traits: ['admin', 'bob'],
+      });
+      expect(userWithTrait).toEqual({
+        name: 'bob',
+        admin: true,
+      });
+    });
+
+    it('traits passed later override earlier ones', () => {
+      interface User {
+        name: string;
+      }
+
+      const userBuilder = build<User>({
+        fields: {
+          name: 'jack',
+        },
+        traits: {
+          alice: {
+            overrides: { name: 'alice' },
+          },
+          bob: {
+            overrides: { name: 'bob' },
+          },
+        },
+      });
+
+      const userWithTrait = userBuilder({
+        traits: ['alice', 'bob'],
+      });
+      expect(userWithTrait).toEqual({
+        name: 'bob',
+      });
+    });
+
+    it('logs a warning if you pass a trait that was not defined', () => {
+      interface User {
+        name: string;
+      }
+
+      jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
+
+      const userBuilder = build<User>({
+        fields: {
+          name: 'jack',
+        },
+      });
+      const userWithTrait = userBuilder({
+        traits: 'not-passed',
+      });
+
+      expect(userWithTrait).toEqual({ name: 'jack' });
+      expect(console.warn).toHaveBeenCalledWith(
+        "Warning: trait 'not-passed' not found."
+      );
+    });
+  });
+});

--- a/core/src/@jackfranklin/test-data-bot/index.ts
+++ b/core/src/@jackfranklin/test-data-bot/index.ts
@@ -1,0 +1,250 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as faker from 'faker';
+import { mapValues } from 'lodash';
+
+export type SequenceFunction = (counter: number) => unknown;
+
+export interface SequenceGenerator {
+  generatorType: 'sequence';
+  userProvidedFunction: SequenceFunction;
+  call: (userProvidedFunction: SequenceFunction, counter: number) => unknown;
+}
+
+export interface FakerGenerator {
+  generatorType: 'faker';
+  call: (fake: Faker.FakerStatic) => any;
+}
+
+export interface PerBuildGenerator {
+  generatorType: 'perBuild';
+  func: () => any;
+  call: (f: () => any) => any;
+}
+
+export interface OneOfGenerator {
+  generatorType: 'oneOf';
+  options: any[];
+  call: <T>(options: T[]) => T;
+}
+
+export type FieldGenerator =
+  | FakerGenerator
+  | SequenceGenerator
+  | OneOfGenerator
+  | PerBuildGenerator;
+
+export type Field =
+  | string
+  | number
+  | null
+  | FieldGenerator
+  | { [x: string]: Field | {} }
+  | any[];
+
+export type FieldsConfiguration<FactoryResultType> = {
+  readonly [x in keyof FactoryResultType]: Field;
+};
+
+export interface Overrides {
+  [x: string]: Field;
+}
+
+export interface BuildTimeConfig<FactoryResultType> {
+  overrides?: Overrides;
+  map?: (builtThing: FactoryResultType) => FactoryResultType;
+  traits?: string | string[];
+}
+
+export interface TraitsConfiguration<FactoryResultType> {
+  readonly [traitName: string]: {
+    overrides?: Overrides;
+    postBuild?: (builtThing: FactoryResultType) => FactoryResultType;
+  };
+}
+
+export interface BuildConfiguration<FactoryResultType> {
+  readonly fields: FieldsConfiguration<FactoryResultType>;
+  readonly traits?: TraitsConfiguration<FactoryResultType>;
+  readonly postBuild?: (x: FactoryResultType) => FactoryResultType;
+}
+
+const isGenerator = (field: Field): field is FieldGenerator => {
+  if (!field) return false;
+
+  return (field as FieldGenerator).generatorType !== undefined;
+};
+
+export type ValueOf<T> = T[keyof T];
+
+const identity = <T>(x: T): T => x;
+
+const buildTimeTraitsArray = <FactoryResultType>(
+  buildTimeConfig: BuildTimeConfig<FactoryResultType>
+): string[] => {
+  const { traits = [] } = buildTimeConfig;
+  return Array.isArray(traits) ? traits : [traits];
+};
+
+export const build = <FactoryResultType>(
+  factoryNameOrConfig: string | BuildConfiguration<FactoryResultType>,
+  configObject?: BuildConfiguration<FactoryResultType>
+): ((
+  buildTimeConfig?: BuildTimeConfig<FactoryResultType>
+) => FactoryResultType) => {
+  const config = (typeof factoryNameOrConfig === 'string'
+    ? configObject
+    : factoryNameOrConfig) as BuildConfiguration<FactoryResultType>;
+
+  let sequenceCounter = 0;
+
+  const expandConfigFields = (
+    fields: FieldsConfiguration<FactoryResultType>,
+    buildTimeConfig: BuildTimeConfig<FactoryResultType> = {}
+  ): { [P in keyof FieldsConfiguration<FactoryResultType>]: any } => {
+    const finalBuiltThing = mapValues(fields, (fieldValue, fieldKey) => {
+      const overrides = buildTimeConfig.overrides || {};
+
+      const traitsArray = buildTimeTraitsArray(buildTimeConfig);
+
+      const traitOverrides: Overrides = traitsArray.reduce<Overrides>(
+        (overrides, currentTraitKey) => {
+          const hasTrait = config.traits && config.traits[currentTraitKey];
+          if (!hasTrait) {
+            console.warn(`Warning: trait '${currentTraitKey}' not found.`);
+          }
+          const traitsConfig = config.traits
+            ? config.traits[currentTraitKey]
+            : {};
+          return { ...overrides, ...(traitsConfig.overrides || {}) };
+        },
+        {}
+      );
+
+      const valueOrOverride =
+        overrides[fieldKey] || traitOverrides[fieldKey] || fieldValue;
+
+      /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+      return expandConfigField(valueOrOverride);
+    });
+
+    return finalBuiltThing;
+  };
+
+  const expandConfigField = (
+    fieldValue: ValueOf<FieldsConfiguration<FactoryResultType>>
+  ): any => {
+    let calculatedValue;
+
+    if (isGenerator(fieldValue)) {
+      switch (fieldValue.generatorType) {
+        case 'sequence': {
+          ++sequenceCounter;
+          calculatedValue = fieldValue.call(
+            fieldValue.userProvidedFunction,
+            sequenceCounter
+          );
+          break;
+        }
+
+        case 'faker': {
+          calculatedValue = fieldValue.call(faker);
+          break;
+        }
+
+        case 'oneOf': {
+          calculatedValue = fieldValue.call(fieldValue.options);
+          break;
+        }
+
+        case 'perBuild': {
+          calculatedValue = fieldValue.call(fieldValue.func);
+          break;
+        }
+      }
+    } else if (Array.isArray(fieldValue)) {
+      calculatedValue = fieldValue.map((v) => expandConfigField(v));
+      return calculatedValue;
+    } else if (fieldValue === null || fieldValue === undefined) {
+      // has to be before typeof fieldValue === 'object'
+      // as typeof null === 'object'
+      calculatedValue = fieldValue;
+    } else if (typeof fieldValue === 'object') {
+      const nestedFieldsObject = fieldValue as FieldsConfiguration<FactoryResultType>;
+
+      calculatedValue = expandConfigFields(nestedFieldsObject);
+    } else {
+      calculatedValue = fieldValue;
+    }
+
+    return calculatedValue;
+  };
+
+  return (buildTimeConfig = {}) => {
+    const fieldsToReturn = expandConfigFields(config.fields, buildTimeConfig);
+
+    const traitsArray = buildTimeTraitsArray(buildTimeConfig);
+    const traitPostBuilds = traitsArray.map((traitName) => {
+      const traitConfig = (config.traits && config.traits[traitName]) || {};
+      const postBuild = traitConfig.postBuild || identity;
+      return postBuild;
+    });
+
+    const afterTraitPostBuildFields = traitPostBuilds.reduce(
+      (fields, traitPostBuild) => {
+        return traitPostBuild(fields);
+      },
+      fieldsToReturn
+    );
+    const postBuild = config.postBuild || identity;
+    const buildTimeMapFunc = buildTimeConfig.map || identity;
+
+    return buildTimeMapFunc(postBuild(afterTraitPostBuildFields));
+  };
+};
+
+export const oneOf = <T>(...options: T[]): OneOfGenerator => {
+  return {
+    generatorType: 'oneOf',
+    options,
+    call: <T>(options: T[]): T => {
+      const randomIndex = Math.floor(Math.random() * options.length);
+
+      return options[randomIndex];
+    },
+  };
+};
+
+export const bool = (): OneOfGenerator => oneOf(true, false);
+
+export const sequence = (
+  userProvidedFunction: SequenceFunction = (x) => x
+): SequenceGenerator => {
+  return {
+    generatorType: 'sequence',
+    userProvidedFunction,
+    call: (userProvidedFunction: SequenceFunction, counter: number) => {
+      return userProvidedFunction(counter);
+    },
+  };
+};
+
+export const perBuild = <T>(func: () => T): PerBuildGenerator => {
+  return {
+    generatorType: 'perBuild',
+    func,
+    call: (f: () => T): T => {
+      return f();
+    },
+  };
+};
+
+export type FakerUserArgs = (fake: Faker.FakerStatic) => any;
+
+export const fake = (userDefinedUsage: FakerUserArgs): FakerGenerator => {
+  return {
+    generatorType: 'faker',
+    call: (faker) => {
+      return userDefinedUsage(faker);
+    },
+  };
+};

--- a/core/src/builder.spec.ts
+++ b/core/src/builder.spec.ts
@@ -1,4 +1,4 @@
-import { sequence, fake } from '@jackfranklin/test-data-bot';
+import { sequence, fake } from './@jackfranklin/test-data-bot';
 import {
   buildField,
   buildFields,
@@ -268,7 +268,7 @@ describe('building', () => {
   describe('with generator', () => {
     const generator = Generator<TestOrganization>({
       fields: {
-        id: fake((f) => f.random.uuid()),
+        id: fake((f) => f.datatype.uuid()),
         version: sequence(),
         name: fake((f) => f.company.companyName()),
       },
@@ -603,7 +603,7 @@ describe('building', () => {
   describe('paginated list', () => {
     const generator = Generator<TestOrganization>({
       fields: {
-        id: fake((f) => f.random.uuid()),
+        id: fake((f) => f.datatype.uuid()),
         version: sequence(),
         name: fake((f) => f.company.companyName()),
       },

--- a/core/src/generator.ts
+++ b/core/src/generator.ts
@@ -1,56 +1,7 @@
 import type { TGeneratorResult } from './types';
+import type { BuildConfiguration } from './@jackfranklin/test-data-bot';
 
-import { build } from '@jackfranklin/test-data-bot';
-
-/* TYPES DECLARATIONS FROM @jackfranklin/test-data-bot */
-export type SequenceFunction = (counter: number) => unknown;
-export interface SequenceGenerator {
-  generatorType: 'sequence';
-  userProvidedFunction: SequenceFunction;
-  call: (userProvidedFunction: SequenceFunction, counter: number) => unknown;
-}
-export interface FakerGenerator {
-  generatorType: 'faker';
-  call: (fake: Faker.FakerStatic) => unknown;
-}
-export interface PerBuildGenerator {
-  generatorType: 'perBuild';
-  func: () => unknown;
-  call: (f: () => unknown) => unknown;
-}
-export interface OneOfGenerator {
-  generatorType: 'oneOf';
-  options: unknown[];
-  call: <T>(options: T[]) => T;
-}
-export type FieldGenerator =
-  | FakerGenerator
-  | SequenceGenerator
-  | OneOfGenerator
-  | PerBuildGenerator;
-export type Field =
-  | string
-  | number
-  | null
-  | FieldGenerator
-  | {
-      [x: string]: Field | {};
-    }
-  | unknown[];
-export type FieldsConfiguration<FactoryResultType> = {
-  readonly [x in keyof FactoryResultType]: Field;
-};
-export interface TraitsConfiguration<FactoryResultType> {
-  readonly [traitName: string]: {
-    postBuild?: (builtThing: FactoryResultType) => FactoryResultType;
-  };
-}
-export interface BuildConfiguration<FactoryResultType> {
-  readonly fields: FieldsConfiguration<FactoryResultType>;
-  readonly traits?: TraitsConfiguration<FactoryResultType>;
-  readonly postBuild?: (x: FactoryResultType) => FactoryResultType;
-}
-/* --- */
+import { build } from './@jackfranklin/test-data-bot';
 
 type TGeneratorOptions<Model> = {
   fields: BuildConfiguration<Model>['fields'];

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -15,4 +15,4 @@ export {
 export * from './types';
 
 // Re-export from `@jackfranklin/test-data-bot`
-export { fake, sequence, oneOf, bool } from '@jackfranklin/test-data-bot';
+export { fake, sequence, oneOf, bool } from './@jackfranklin/test-data-bot';

--- a/models/commons/package.json
+++ b/models/commons/package.json
@@ -27,9 +27,10 @@
     "README.md"
   ],
   "dependencies": {
-    "@babel/runtime": "7.13.10",
-    "@babel/runtime-corejs3": "7.13.10",
+    "@babel/runtime": "^7.13.10",
+    "@babel/runtime-corejs3": "^7.13.10",
     "@commercetools-test-data/core": "2.1.2",
-    "faker": "^4.1.0"
+    "@types/faker": "^5.5.1",
+    "faker": "^5.5.3"
   }
 }

--- a/models/commons/src/initiator/generator.ts
+++ b/models/commons/src/initiator/generator.ts
@@ -1,14 +1,14 @@
 import type { TInitiator } from './types';
-import Reference from '../reference';
 import { Generator, fake } from '@commercetools-test-data/core';
+import Reference from '../reference';
 
 // https://docs.commercetools.com/api/types#client-logging
 const generator = Generator<TInitiator>({
   fields: {
-    isPlatformClient: fake((f) => f.random.boolean()),
-    externalUserId: fake((f) => f.random.uuid()),
-    anonymousId: fake((f) => f.random.uuid()),
-    clientId: fake((f) => f.random.uuid()),
+    isPlatformClient: fake((f) => f.datatype.boolean()),
+    externalUserId: fake((f) => f.datatype.uuid()),
+    anonymousId: fake((f) => f.datatype.uuid()),
+    clientId: fake((f) => f.datatype.uuid()),
     customerRef: Reference.random().typeId('customer').build(),
     userRef: Reference.random().typeId('user').build(),
   },

--- a/models/commons/src/reference/generator.ts
+++ b/models/commons/src/reference/generator.ts
@@ -5,7 +5,7 @@ import { Generator, fake } from '@commercetools-test-data/core';
 // https://docs.commercetools.com/api/types#referencetype
 const generator = Generator<TReference>({
   fields: {
-    id: fake((f) => f.random.uuid()),
+    id: fake((f) => f.datatype.uuid()),
     typeId: null,
   },
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postinstall": "preconstruct dev && manypkg check",
     "build": "preconstruct build",
     "watch": "preconstruct watch",
-    "clean": "yarn workspaces run prebuild",
+    "clean": "manypkg exec rm -rf build dist",
     "lint": "jest --projects jest.eslint.config.js",
     "lint:js": "jest --config jest.eslint.config.js",
     "format": "yarn format:js && yarn format:md",

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,14 +944,6 @@
     "@babel/helper-validator-option" "^7.12.17"
     "@babel/plugin-transform-typescript" "^7.13.0"
 
-"@babel/runtime-corejs3@7.13.10", "@babel/runtime-corejs3@^7.10.2":
-  version "7.13.10"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz#14c3f4c85de22ba88e8e86685d13e8861a82fe86"
-  integrity sha512-x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==
-  dependencies:
-    core-js-pure "^3.0.0"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime-corejs3@7.13.9":
   version "7.13.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.13.9.tgz#b2fa9a6e5690ef8d4c4f2d30cac3ec1a8bb633ce"
@@ -960,17 +952,25 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.13.10", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
+"@babel/runtime-corejs3@^7.10.2", "@babel/runtime-corejs3@^7.13.10":
   version "7.13.10"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
-  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz#14c3f4c85de22ba88e8e86685d13e8861a82fe86"
+  integrity sha512-x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==
   dependencies:
+    core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@7.13.9":
   version "7.13.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
   integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1512,15 +1512,6 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jackfranklin/test-data-bot@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@jackfranklin/test-data-bot/-/test-data-bot-1.3.0.tgz#bf8fa6439500e6b7b2959ed1613b715889ae6869"
-  integrity sha512-68OfPjgHT58ftfd0XKVWOp0p/1K+bbxSPu3wdH9N+/Ox9a3aM/d8sS0AFSJ48Vuoww+MkbHDH1cEE5tTkpTPlw==
-  dependencies:
-    "@types/faker" "^4.1.9"
-    faker "4.1.0"
-    lodash "^4.17.15"
-
 "@jest/console@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-26.6.2.tgz#4e04bc464014358b03ab4937805ee36a0aeb98f2"
@@ -1966,10 +1957,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/faker@^4.1.9":
-  version "4.1.12"
-  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-4.1.12.tgz#065d37343677df1aa757c622650bd14666c42602"
-  integrity sha512-0MEyzJrLLs1WaOCx9ULK6FzdCSj2EuxdSP9kvuxxdBEGujZYUOZ4vkPXdgu3dhyg/pOdn7VCatelYX7k0YShlA==
+"@types/faker@^5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.1.tgz#9fff6bf7bbaa13b1069c4e534c45610603a48bc5"
+  integrity sha512-JXGjV76oEUZUOSAr3bP5txETYoq0XDOQA8BpOz8Wc3EuvfF7sUVquf/EvM3aphuVKuVaYDSDu523/mAHnqrcvg==
 
 "@types/glob@^7.1.1":
   version "7.1.3"
@@ -2022,6 +2013,11 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/lodash@^4.14.168":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
 "@types/minimatch@*":
   version "3.0.4"
@@ -3996,10 +3992,10 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-faker@4.1.0, faker@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
-  integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=
+faker@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
+  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Given that `@jackfranklin/test-data-bot` seems unmaintained and still uses `faker` v4, I decided to drop its dependency and include the source code directly here, so that we can use `faker` v5 at our own pace.

We also had the workaround with the types (https://github.com/jackfranklin/test-data-bot/pull/344).

So essentially, we can now ship `faker` v5.