### PR TITLE
fix(commons/reference): distinguish expanded rest reference and graphql

### DIFF
--- a/.changeset/shaggy-falcons-hug.md
+++ b/.changeset/shaggy-falcons-hug.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/commons': minor
+---
+
+Fix Reference to distinguish expanded `graphql and`rest` shape respectively

--- a/models/commons/package.json
+++ b/models/commons/package.json
@@ -8,7 +8,11 @@
     "url": "https://github.com/commercetools/test-data.git",
     "directory": "models/commons"
   },
-  "keywords": ["javascript", "typescript", "test-data"],
+  "keywords": [
+    "javascript",
+    "typescript",
+    "test-data"
+  ],
   "license": "MIT",
   "private": false,
   "publishConfig": {
@@ -16,12 +20,18 @@
   },
   "main": "dist/commercetools-test-data-commons.cjs.js",
   "module": "dist/commercetools-test-data-commons.esm.js",
-  "files": ["dist", "package.json", "LICENSE", "README.md"],
+  "files": [
+    "dist",
+    "package.json",
+    "LICENSE",
+    "README.md"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
     "@commercetools-test-data/core": "2.3.0",
     "@types/faker": "^5.5.1",
-    "faker": "^5.5.3"
+    "faker": "^5.5.3",
+    "lodash": "^4.17.21"
   }
 }

--- a/models/commons/src/reference/builder.spec.ts
+++ b/models/commons/src/reference/builder.spec.ts
@@ -1,4 +1,4 @@
-import type { TReference, TReferenceGraphql } from './types';
+import { TReference, TReferenceGraphql, TReferenceRest } from './types';
 
 import Reference from './builder';
 
@@ -20,5 +20,18 @@ describe('building as GraphQL', () => {
         __typename: 'Reference',
       })
     );
+  });
+});
+
+describe('building as REST', () => {
+  it('should add `obj` as expanded reference', () => {
+    const built = Reference().typeId('category').buildRest<TReferenceRest>();
+    expect(built).toEqual({
+      id: expect.any(String),
+      typeId: expect.any(String),
+      obj: expect.objectContaining({
+        id: expect.any(String),
+      }),
+    });
   });
 });

--- a/models/commons/src/reference/transformers.ts
+++ b/models/commons/src/reference/transformers.ts
@@ -1,4 +1,5 @@
-import type { TReference, TReferenceGraphql } from './types';
+import type { TReference, TReferenceGraphql, TReferenceRest } from './types';
+import omit from 'lodash/omit';
 import { Transformer } from '@commercetools-test-data/core';
 
 const transformers = {
@@ -8,6 +9,12 @@ const transformers = {
   graphql: Transformer<TReference, TReferenceGraphql>('graphql', {
     addFields: () => ({
       __typename: 'Reference',
+    }),
+  }),
+  rest: Transformer<TReferenceRest, TReferenceRest>('rest', {
+    replaceFields: ({ fields }) => ({
+      ...fields,
+      obj: omit(fields, ['typeId']),
     }),
   }),
 };

--- a/models/commons/src/reference/types.ts
+++ b/models/commons/src/reference/types.ts
@@ -1,24 +1,24 @@
 import type { TBuilder } from '@commercetools-test-data/core';
 
-export type TReferenceBuilder = TBuilder<TReference<TExpandedReferenceObject>>;
+export type TReferenceBuilder = TBuilder<TReference>;
 
-export type TCreateReferenceBuilder = () => TReferenceBuilder;
-
-type TExpandedReferenceObject = {
+export type TReference = {
+  typeId: string;
   id: string;
+};
+
+export type Versioned = {
+  id: TReference['id'];
+  version?: number;
   [key: string]: unknown;
 };
 
-export type TReference<
-  T extends TExpandedReferenceObject = TExpandedReferenceObject
-> = {
-  typeId: string;
-  id: T['id'];
-  obj?: T;
+export type TCreateReferenceBuilder = () => TReferenceBuilder;
+
+export type TReferenceRest<T extends Versioned = Versioned> = TReference & {
+  obj: T;
 };
 
-export type TReferenceGraphql = TReference<TExpandedReferenceObject> & {
+export type TReferenceGraphql = Versioned & {
   __typename: 'Reference';
 };
-
-export type TReferenceRest = TReference<TExpandedReferenceObject>;


### PR DESCRIPTION
### Summary

- Correct `ExpandedRest` and `ExpandedGraphql` shapes.

Previous implementation implied that both types exposed the same shape: 

```
 {
   id: string
   typeId: string
   obj: {}
 }
```

which is not the case.
I introduced now `Versioned` which is simply a "unified" object that includes `id` and maybe `version` to clarify that this object is used to pass into `obj`