### PR TITLE
feat(core): to add typename support to graphql list building

### DIFF
--- a/.changeset/smart-ways-yawn.md
+++ b/.changeset/smart-ways-yawn.md
@@ -2,14 +2,14 @@
 "@commercetools-test-data/core": patch
 ---
 
-Add support for a `typename` property when building a GraphQL list
+Add support for a `__typename` property when building a GraphQL list
 
 ```js
 const list = buildGraphqlList([builder, builder], {
   total: 10,
   offset: 2,
-  typename: 'OrganizationPaginatedResultList',
+  __typename: 'OrganizationPaginatedResultList',
 });
 ```
 
-Please note that whenever a `name` is specified the old behaviour of concatinating the `name` with `QueryResult` will remain. If that behaviour is not adequate for your use case feel free to use `typename`.
+Please note that whenever a `name` is specified the old behaviour of concatinating the `name` with `QueryResult` will remain. If that behaviour is not adequate for your use case feel free to use `__typename`.

--- a/.changeset/smart-ways-yawn.md
+++ b/.changeset/smart-ways-yawn.md
@@ -1,0 +1,15 @@
+---
+"@commercetools-test-data/core": patch
+---
+
+Add support for a `typename` property when building a GraphQL list
+
+```js
+const list = buildGraphqlList([builder, builder], {
+  total: 10,
+  offset: 2,
+  typename: 'OrganizationPaginatedResultList',
+});
+```
+
+Please note that whenever a `name` is specified the old behaviour of concatinating the `name` with `QueryResult` will remain. If that behaviour is not adequate for your use case feel free to use `typename`.

--- a/core/src/builder.spec.ts
+++ b/core/src/builder.spec.ts
@@ -414,9 +414,8 @@ describe('building', () => {
                 }
               ),
             };
-            const userBuilder = Builder<TestExpandedUserReference>().name(
-              'My name'
-            );
+            const userBuilder =
+              Builder<TestExpandedUserReference>().name('My name');
             const built = Builder<TestUserReference>({
               transformers,
             })
@@ -445,9 +444,8 @@ describe('building', () => {
                 }
               ),
             };
-            const userBuilder = Builder<TestExpandedUserReference>().name(
-              'My name'
-            );
+            const userBuilder =
+              Builder<TestExpandedUserReference>().name('My name');
             const built = Builder<TestUserReference>({
               transformers,
             })
@@ -526,9 +524,8 @@ describe('building', () => {
               }
             ),
           };
-          const userBuilder = Builder<TestExpandedUserReference>().name(
-            'My name'
-          );
+          const userBuilder =
+            Builder<TestExpandedUserReference>().name('My name');
           const built = Builder<TestUserReference>({ transformers })
             .id('my-id')
             .user<TestExpandedUserReference>(userBuilder)
@@ -655,7 +652,7 @@ describe('building', () => {
         const list = buildGraphqlList([builder, builder], {
           total: 10,
           offset: 2,
-          typename: 'OrganizationPaginatedResultList',
+          __typename: 'OrganizationPaginatedResultList',
         });
 
         expect(list).toEqual({

--- a/core/src/builder.spec.ts
+++ b/core/src/builder.spec.ts
@@ -414,8 +414,9 @@ describe('building', () => {
                 }
               ),
             };
-            const userBuilder =
-              Builder<TestExpandedUserReference>().name('My name');
+            const userBuilder = Builder<TestExpandedUserReference>().name(
+              'My name'
+            );
             const built = Builder<TestUserReference>({
               transformers,
             })
@@ -444,8 +445,9 @@ describe('building', () => {
                 }
               ),
             };
-            const userBuilder =
-              Builder<TestExpandedUserReference>().name('My name');
+            const userBuilder = Builder<TestExpandedUserReference>().name(
+              'My name'
+            );
             const built = Builder<TestUserReference>({
               transformers,
             })
@@ -524,8 +526,9 @@ describe('building', () => {
               }
             ),
           };
-          const userBuilder =
-            Builder<TestExpandedUserReference>().name('My name');
+          const userBuilder = Builder<TestExpandedUserReference>().name(
+            'My name'
+          );
           const built = Builder<TestUserReference>({ transformers })
             .id('my-id')
             .user<TestExpandedUserReference>(userBuilder)
@@ -636,6 +639,27 @@ describe('building', () => {
         });
 
         expect(list).toEqual({
+          total: 10,
+          offset: 2,
+          count: 2,
+          results: expect.arrayContaining([
+            expect.objectContaining({ id: 'my-id' }),
+          ]),
+        });
+      });
+    });
+
+    describe('with typename overwrite', () => {
+      it('should build a paginated list with an overwritten typename', () => {
+        const builder = Builder<TestOrganization>({ generator }).id('my-id');
+        const list = buildGraphqlList([builder, builder], {
+          total: 10,
+          offset: 2,
+          typename: 'OrganizationPaginatedResultList',
+        });
+
+        expect(list).toEqual({
+          __typename: 'OrganizationPaginatedResultList',
           total: 10,
           offset: 2,
           count: 2,

--- a/core/src/helpers.ts
+++ b/core/src/helpers.ts
@@ -108,10 +108,10 @@ const toRestPaginatedQueryResult = <Model extends Json>(
 
 const toGraphqlPaginatedQueryResult = <Model extends Json>(
   list: Model[],
-  { name, typename, ...remainingOptions }: TGraphqlPaginatedQueryResultOptions
+  { name, __typename, ...remainingOptions }: TGraphqlPaginatedQueryResultOptions
 ): TGraphqlPaginatedQueryResult<Model> => {
   return {
-    __typename: typename ?? `${name}QueryResult`,
+    __typename: __typename ?? `${name}QueryResult`,
     ...toRestPaginatedQueryResult(list, remainingOptions),
   };
 };
@@ -141,13 +141,13 @@ const buildFields = <Model extends Json>(
 
 const buildGraphqlList = <Model extends Json>(
   builders: TBuilder<Model>[],
-  { name, total, offset, typename }: TGraphqlPaginatedQueryResultOptions
+  { name, total, offset, __typename }: TGraphqlPaginatedQueryResultOptions
 ): TGraphqlPaginatedQueryResult<Model> => {
   return toGraphqlPaginatedQueryResult<Model>(
     buildFields<Model>(builders, 'graphql'),
     {
       name,
-      typename,
+      __typename,
       total,
       offset,
     }

--- a/core/src/helpers.ts
+++ b/core/src/helpers.ts
@@ -108,10 +108,10 @@ const toRestPaginatedQueryResult = <Model extends Json>(
 
 const toGraphqlPaginatedQueryResult = <Model extends Json>(
   list: Model[],
-  { name, ...remainingOptions }: TGraphqlPaginatedQueryResultOptions
+  { name, typename, ...remainingOptions }: TGraphqlPaginatedQueryResultOptions
 ): TGraphqlPaginatedQueryResult<Model> => {
   return {
-    __typename: `${name}QueryResult`,
+    __typename: typename ?? `${name}QueryResult`,
     ...toRestPaginatedQueryResult(list, remainingOptions),
   };
 };
@@ -141,12 +141,13 @@ const buildFields = <Model extends Json>(
 
 const buildGraphqlList = <Model extends Json>(
   builders: TBuilder<Model>[],
-  { name, total, offset }: TGraphqlPaginatedQueryResultOptions
+  { name, total, offset, typename }: TGraphqlPaginatedQueryResultOptions
 ): TGraphqlPaginatedQueryResult<Model> => {
   return toGraphqlPaginatedQueryResult<Model>(
     buildFields<Model>(builders, 'graphql'),
     {
       name,
+      typename,
       total,
       offset,
     }

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -26,7 +26,7 @@ export type TPaginatedQueryResult<Model extends Json> = {
 
 export type TGraphqlPaginatedQueryResultOptions = {
   name?: string;
-  typename?: string;
+  __typename?: string;
 } & TPaginatedQueryResultOptions;
 
 export type TGraphqlPaginatedQueryResult<Model extends Json> = {

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -25,7 +25,8 @@ export type TPaginatedQueryResult<Model extends Json> = {
 };
 
 export type TGraphqlPaginatedQueryResultOptions = {
-  name: string;
+  name?: string;
+  typename?: string;
 } & TPaginatedQueryResultOptions;
 
 export type TGraphqlPaginatedQueryResult<Model extends Json> = {


### PR DESCRIPTION
- Closes https://github.com/commercetools/test-data/issues/85

The exact `__typename` on any list within all services and parts of GraphQL schemas of the CT can't be inferred by `${name}QueryResult`. 

As a solution, I propose to have an explicit `typename` overwrite. Over time we could even argue to remove the `name` altogether.

Closes https://github.com/commercetools/test-data/issues/85.