### PR TITLE
refactor(fakerjs): use the new fakerjs community package

### DIFF
--- a/.changeset/modern-bulldogs-sell.md
+++ b/.changeset/modern-bulldogs-sell.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-test-data/core': patch
+'@commercetools-test-data/category': patch
+'@commercetools-test-data/commons': patch
+'@commercetools-test-data/utils': patch
+---
+
+Replace deleted fakerjs library with the new community package (fakerjs.dev)

--- a/core/README.md
+++ b/core/README.md
@@ -187,7 +187,7 @@ For example:
 ```ts
 // presets/author-with-one-book.ts
 import type { TAuthorBuilder } from './types';
-import * as faker from 'faker';
+import faker from '@faker-js/faker';
 import * as Book from '../../book';
 import Author from './builder';
 

--- a/core/package.json
+++ b/core/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
-    "@faker-js/faker": "^6.0.0-alpha.3",
+    "@faker-js/faker": "^6.0.0-alpha.5",
     "@types/lodash": "^4.14.168",
     "lodash": "^4.17.21"
   }

--- a/core/package.json
+++ b/core/package.json
@@ -19,9 +19,8 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
-    "@types/faker": "^5.5.1",
+    "@faker-js/faker": "^6.0.0-alpha.3",
     "@types/lodash": "^4.14.168",
-    "faker": "^5.5.3",
     "lodash": "^4.17.21"
   }
 }

--- a/core/src/@jackfranklin/test-data-bot/index.ts
+++ b/core/src/@jackfranklin/test-data-bot/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as faker from 'faker';
+import type { Faker } from '@faker-js/faker';
+import faker from '@faker-js/faker';
 import { mapValues } from 'lodash';
 
 export type SequenceFunction = (counter: number) => unknown;
@@ -12,7 +13,7 @@ export interface SequenceGenerator {
 
 export interface FakerGenerator {
   generatorType: 'faker';
-  call: (fake: Faker.FakerStatic) => any;
+  call: (fake: Faker) => any;
 }
 
 export interface PerBuildGenerator {
@@ -239,7 +240,7 @@ export const perBuild = <T>(func: () => T): PerBuildGenerator => {
   };
 };
 
-export type FakerUserArgs = (fake: Faker.FakerStatic) => any;
+export type FakerUserArgs = (fake: Faker) => any;
 
 export const fake = (userDefinedUsage: FakerUserArgs): FakerGenerator => {
   return {

--- a/models/category/package.json
+++ b/models/category/package.json
@@ -21,7 +21,7 @@
     "@babel/runtime-corejs3": "^7.13.10",
     "@commercetools-test-data/core": "2.4.1",
     "@commercetools-test-data/utils": "2.4.0",
-    "@faker-js/faker": "^6.0.0-alpha.3",
+    "@faker-js/faker": "^6.0.0-alpha.5",
     "lodash": "^4.17.21"
   }
 }

--- a/models/category/package.json
+++ b/models/category/package.json
@@ -21,8 +21,7 @@
     "@babel/runtime-corejs3": "^7.13.10",
     "@commercetools-test-data/core": "2.4.1",
     "@commercetools-test-data/utils": "2.4.0",
-    "@types/faker": "^5.5.1",
-    "faker": "^5.5.3",
+    "@faker-js/faker": "^6.0.0-alpha.3",
     "lodash": "^4.17.21"
   }
 }

--- a/models/commons/package.json
+++ b/models/commons/package.json
@@ -20,7 +20,7 @@
     "@babel/runtime": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
     "@commercetools-test-data/core": "2.4.1",
-    "@faker-js/faker": "^6.0.0-alpha.3",
+    "@faker-js/faker": "^6.0.0-alpha.5",
     "lodash": "^4.17.21"
   }
 }

--- a/models/commons/package.json
+++ b/models/commons/package.json
@@ -20,8 +20,7 @@
     "@babel/runtime": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
     "@commercetools-test-data/core": "2.4.1",
-    "@types/faker": "^5.5.1",
-    "faker": "^5.5.3",
+    "@faker-js/faker": "^6.0.0-alpha.3",
     "lodash": "^4.17.21"
   }
 }

--- a/models/commons/src/localized-string/presets/of-slugs.ts
+++ b/models/commons/src/localized-string/presets/of-slugs.ts
@@ -1,6 +1,6 @@
 import type { TLocalizedStringBuilder } from '../types';
 
-import * as faker from 'faker';
+import faker from '@faker-js/faker';
 import LocalizedString from '../builder';
 
 const ofSlugs = (): TLocalizedStringBuilder =>

--- a/utils/package.json
+++ b/utils/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
-    "@types/faker": "^5.5.1",
-    "faker": "^5.5.3"
+    "@faker-js/faker": "^6.0.0-alpha.3"
   }
 }

--- a/utils/package.json
+++ b/utils/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
-    "@faker-js/faker": "^6.0.0-alpha.3"
+    "@faker-js/faker": "^6.0.0-alpha.5"
   }
 }

--- a/utils/src/create-related-dates.ts
+++ b/utils/src/create-related-dates.ts
@@ -1,3 +1,5 @@
+import type { Faker } from '@faker-js/faker';
+
 /**
  * Create two related dates (one comes before the other) by using a reference
  * in the past. The reference will be the result of invoking `Date.now()` when this
@@ -32,15 +34,15 @@
  */
 const createRelatedDates = (recentDaysFromPastReference: number = 10) => {
   const pastReference = new Date();
-  const getOlderDate = (f: Faker.FakerStatic) =>
+  const getOlderDate = (f: Faker) =>
     f.date.recent(recentDaysFromPastReference, pastReference.toISOString());
 
-  const getNewerDate = (f: Faker.FakerStatic) =>
+  const getNewerDate = (f: Faker) =>
     f.date.between(
       new Date(pastReference).toISOString(),
       new Date().toISOString()
     );
-  const getFutureDate = (f: Faker.FakerStatic) => f.date.future();
+  const getFutureDate = (f: Faker) => f.date.future();
   return [getOlderDate, getNewerDate, getFutureDate];
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1883,8 +1883,7 @@ __metadata:
     "@babel/runtime-corejs3": ^7.13.10
     "@commercetools-test-data/core": 2.4.1
     "@commercetools-test-data/utils": 2.4.0
-    "@types/faker": ^5.5.1
-    faker: ^5.5.3
+    "@faker-js/faker": ^6.0.0-alpha.3
     lodash: ^4.17.21
   languageName: unknown
   linkType: soft
@@ -1896,8 +1895,7 @@ __metadata:
     "@babel/runtime": ^7.13.10
     "@babel/runtime-corejs3": ^7.13.10
     "@commercetools-test-data/core": 2.4.1
-    "@types/faker": ^5.5.1
-    faker: ^5.5.3
+    "@faker-js/faker": ^6.0.0-alpha.3
     lodash: ^4.17.21
   languageName: unknown
   linkType: soft
@@ -1908,9 +1906,8 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@babel/runtime-corejs3": ^7.13.10
-    "@types/faker": ^5.5.1
+    "@faker-js/faker": ^6.0.0-alpha.3
     "@types/lodash": ^4.14.168
-    faker: ^5.5.3
     lodash: ^4.17.21
   languageName: unknown
   linkType: soft
@@ -1953,8 +1950,7 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@babel/runtime-corejs3": ^7.13.10
-    "@types/faker": ^5.5.1
-    faker: ^5.5.3
+    "@faker-js/faker": ^6.0.0-alpha.3
   languageName: unknown
   linkType: soft
 
@@ -2248,6 +2244,13 @@ __metadata:
     minimatch: ^3.0.4
     strip-json-comments: ^3.1.1
   checksum: 03a7704150b868c318aab6a94d87a33d30dc2ec579d27374575014f06237ba1370ae11178db772f985ef680d469dc237e7b16a1c5d8edaaeb8c3733e7a95a6d3
+  languageName: node
+  linkType: hard
+
+"@faker-js/faker@npm:^6.0.0-alpha.3":
+  version: 6.0.0-alpha.4
+  resolution: "@faker-js/faker@npm:6.0.0-alpha.4"
+  checksum: afcb4651cf4328e7982e54956ba11e0f0a2c0bd52b16d7431c730dcd4e8fc2cefdc821f7ba12b0f2cba96248bfa33de7f5fa1cfbb181b4038907bfa4185255b4
   languageName: node
   linkType: hard
 
@@ -2890,13 +2893,6 @@ __metadata:
   version: 0.0.39
   resolution: "@types/estree@npm:0.0.39"
   checksum: 412fb5b9868f2c418126451821833414189b75cc6bf84361156feed733e3d92ec220b9d74a89e52722e03d5e241b2932732711b7497374a404fad49087adc248
-  languageName: node
-  linkType: hard
-
-"@types/faker@npm:^5.5.1":
-  version: 5.5.9
-  resolution: "@types/faker@npm:5.5.9"
-  checksum: c2cbd082abe29047c89cf29b86257e582d2a177a9d1ed3abf99aa1cc025d5e8a3d201dfaddf8441bfcc57ed43e4da80e666951e1c23a5b759ac441a5855b5c36
   languageName: node
   linkType: hard
 
@@ -5666,13 +5662,6 @@ __metadata:
     snapdragon: ^0.8.1
     to-regex: ^3.0.1
   checksum: a41531b8934735b684cef5e8c5a01d0f298d7d384500ceca38793a9ce098125aab04ee73e2d75d5b2901bc5dddd2b64e1b5e3bf19139ea48bac52af4a92f1d00
-  languageName: node
-  linkType: hard
-
-"faker@npm:^5.5.3":
-  version: 5.5.3
-  resolution: "faker@npm:5.5.3"
-  checksum: 684fd64c8d3897e54248f95b4f6319f75d97691b8500cd13adf4af2c28f9204f766c1d1aaa6b41338f0beaaa87256c3132f8708a1a8f189d122b92f6b98081c3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1883,7 +1883,7 @@ __metadata:
     "@babel/runtime-corejs3": ^7.13.10
     "@commercetools-test-data/core": 2.4.1
     "@commercetools-test-data/utils": 2.4.0
-    "@faker-js/faker": ^6.0.0-alpha.3
+    "@faker-js/faker": ^6.0.0-alpha.5
     lodash: ^4.17.21
   languageName: unknown
   linkType: soft
@@ -1895,7 +1895,7 @@ __metadata:
     "@babel/runtime": ^7.13.10
     "@babel/runtime-corejs3": ^7.13.10
     "@commercetools-test-data/core": 2.4.1
-    "@faker-js/faker": ^6.0.0-alpha.3
+    "@faker-js/faker": ^6.0.0-alpha.5
     lodash: ^4.17.21
   languageName: unknown
   linkType: soft
@@ -1906,7 +1906,7 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@babel/runtime-corejs3": ^7.13.10
-    "@faker-js/faker": ^6.0.0-alpha.3
+    "@faker-js/faker": ^6.0.0-alpha.5
     "@types/lodash": ^4.14.168
     lodash: ^4.17.21
   languageName: unknown
@@ -1950,7 +1950,7 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@babel/runtime-corejs3": ^7.13.10
-    "@faker-js/faker": ^6.0.0-alpha.3
+    "@faker-js/faker": ^6.0.0-alpha.5
   languageName: unknown
   linkType: soft
 
@@ -2247,10 +2247,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@faker-js/faker@npm:^6.0.0-alpha.3":
-  version: 6.0.0-alpha.4
-  resolution: "@faker-js/faker@npm:6.0.0-alpha.4"
-  checksum: afcb4651cf4328e7982e54956ba11e0f0a2c0bd52b16d7431c730dcd4e8fc2cefdc821f7ba12b0f2cba96248bfa33de7f5fa1cfbb181b4038907bfa4185255b4
+"@faker-js/faker@npm:^6.0.0-alpha.5":
+  version: 6.0.0-alpha.5
+  resolution: "@faker-js/faker@npm:6.0.0-alpha.5"
+  checksum: aa145eaeba624a65fe3237f2abfe4fa4a87fb7283cda983cafad95fd8b88b9e58eae403a36bdc4108f9625b0c64b81e901e68d11b33c04c8f24dae07c31e314f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replace deleted fakerjs library with the new community package. 
https://github.com/faker-js/faker
