### PR TITLE
chore: update changesets/action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@master
+        uses: changesets/action@v1
         with:
           publish: yarn changeset publish
           version: yarn changeset:version-and-format


### PR DESCRIPTION
Address following warning message:


```
Warning: The workflow file using `changesets/action` is currently using `@master` as the version. This branch has been frozen and deprecated. Please update your workflow to either use `@v1` or a specific commit SHA that is tagged.
```
[ref](
https://github.com/commercetools/test-data/runs/4940171642?check_suite_focus=true#step:10:8)