### PR TITLE
Address draft: fix fake  deprecated field

### DIFF
--- a/.changeset/shaggy-mails-hammer.md
+++ b/.changeset/shaggy-mails-hammer.md
@@ -1,5 +1,5 @@
 ---
-'@commercetools-test-data/commons': minor
+'@commercetools-test-data/commons': patch
 ---
 
 fix(address): replacing depracated fake address function

--- a/.changeset/shaggy-mails-hammer.md
+++ b/.changeset/shaggy-mails-hammer.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/commons': minor
+---
+
+fix(address): replacing depracated fake address function

--- a/models/commons/src/address/address-draft/generator.ts
+++ b/models/commons/src/address/address-draft/generator.ts
@@ -16,7 +16,7 @@ const generator = Generator<TAddressDraft>({
     lastName: fake((f) => f.name.lastName()),
     streetName: fake((f) => f.address.street()),
     streetNumber: fake((f) => String(f.datatype.number())),
-    additionalStreetInfo: fake((f) => f.address.streetSuffix()),
+    additionalStreetInfo: fake((f) => f.address.street()),
     postalCode: fake((f) => f.address.zipCode()),
     city: fake((f) => f.address.city()),
     region: null,


### PR DESCRIPTION
# Address Draft deprecated field fix
The latest version of `@faker-js/faker` is deprecating `address.streetSuffix()` and throwing an error during test runs

![Screenshot 2022-08-09 at 17 58 15](https://user-images.githubusercontent.com/29254006/183700860-202ca3f9-b6e3-4091-9506-88de3155219e.png)
