### PR TITLE
Localized String: return null instead of undefined for empty values

### DIFF
--- a/.changeset/fluffy-taxis-speak.md
+++ b/.changeset/fluffy-taxis-speak.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-test-data/category': patch
+'@commercetools-test-data/channel': patch
+'@commercetools-test-data/commons': patch
+---
+
+fix(localized-string): to-localized-field to return null when no value is received

--- a/models/category/src/builder.spec.ts
+++ b/models/category/src/builder.spec.ts
@@ -81,7 +81,7 @@ describe('builder', () => {
             value: expect.any(String),
           }),
         ]),
-        descriptionAllLocales: undefined,
+        descriptionAllLocales: null,
         createdBy: expect.objectContaining({
           customerRef: expect.objectContaining({ typeId: 'customer' }),
           userRef: expect.objectContaining({ typeId: 'user' }),

--- a/models/category/src/types.ts
+++ b/models/category/src/types.ts
@@ -22,6 +22,6 @@ export type TCategoryGraphql = Omit<
   __typename: 'Category';
   createdBy: TClientLoggingGraphql;
   lastModifiedBy: TClientLoggingGraphql;
-  nameAllLocales: TLocalizedStringGraphql | null;
-  descriptionAllLocales: TLocalizedStringGraphql | null;
+  nameAllLocales?: TLocalizedStringGraphql | null;
+  descriptionAllLocales?: TLocalizedStringGraphql | null;
 };

--- a/models/category/src/types.ts
+++ b/models/category/src/types.ts
@@ -22,6 +22,6 @@ export type TCategoryGraphql = Omit<
   __typename: 'Category';
   createdBy: TClientLoggingGraphql;
   lastModifiedBy: TClientLoggingGraphql;
-  nameAllLocales?: TLocalizedStringGraphql;
-  descriptionAllLocales?: TLocalizedStringGraphql;
+  nameAllLocales: TLocalizedStringGraphql | null;
+  descriptionAllLocales: TLocalizedStringGraphql | null;
 };

--- a/models/channel/src/builder.spec.ts
+++ b/models/channel/src/builder.spec.ts
@@ -96,7 +96,7 @@ describe('builder', () => {
             value: expect.any(String),
           }),
         ]),
-        descriptionAllLocales: undefined,
+        descriptionAllLocales: null,
         createdBy: expect.objectContaining({
           customerRef: expect.objectContaining({ typeId: 'customer' }),
           userRef: expect.objectContaining({ typeId: 'user' }),

--- a/models/channel/src/types.ts
+++ b/models/channel/src/types.ts
@@ -31,8 +31,8 @@ export type TChannelGraphql = Omit<
   __typename: 'Channel';
   createdBy: TClientLoggingGraphql;
   lastModifiedBy: TClientLoggingGraphql;
-  nameAllLocales: TLocalizedStringGraphql | null;
-  descriptionAllLocales: TLocalizedStringGraphql | null;
+  nameAllLocales?: TLocalizedStringGraphql | null;
+  descriptionAllLocales?: TLocalizedStringGraphql | null;
 };
 
 export type TChannelBuilder = TBuilder<Channel>;

--- a/models/channel/src/types.ts
+++ b/models/channel/src/types.ts
@@ -31,8 +31,8 @@ export type TChannelGraphql = Omit<
   __typename: 'Channel';
   createdBy: TClientLoggingGraphql;
   lastModifiedBy: TClientLoggingGraphql;
-  nameAllLocales?: TLocalizedStringGraphql;
-  descriptionAllLocales?: TLocalizedStringGraphql;
+  nameAllLocales: TLocalizedStringGraphql | null;
+  descriptionAllLocales: TLocalizedStringGraphql | null;
 };
 
 export type TChannelBuilder = TBuilder<Channel>;

--- a/models/commons/src/localized-string/helpers.ts
+++ b/models/commons/src/localized-string/helpers.ts
@@ -3,7 +3,7 @@ import { TLocalizedStringGraphql } from './types';
 
 const toLocalizedField = <Model>(value?: Model) => {
   if (!value) {
-    return undefined;
+    return null;
   }
 
   const localizedField = buildField<Model>(


### PR DESCRIPTION
# Localized String: return null instead of undefined for empty values

Our GraphQL queries return `null` when an entity doesn't have a localized value

![Screenshot 2022-08-10 at 12 13 41](https://user-images.githubusercontent.com/29254006/183876837-9ac06bc2-278a-4771-a47a-504b049e8f8c.png)

For consistency we should also return `null` instead of `undefined`

