### PR TITLE
chore(test-data): create `CartDiscount` and associated draft

### DIFF
--- a/.changeset/odd-penguins-yell.md
+++ b/.changeset/odd-penguins-yell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart-discount': minor
+---
+
+created CartDiscount package

--- a/models/cart-discount/LICENSE
+++ b/models/cart-discount/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) commercetools GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/models/cart-discount/README.md
+++ b/models/cart-discount/README.md
@@ -1,0 +1,26 @@
+# @commercetools-test-data/cart-discount
+
+This package provides the data model for the commercetools platform `CartDiscount` type
+
+https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscount
+
+# Install
+
+```bash
+$ yarn add -D @commercetools-test-data/cart-discount
+```
+
+# Usage
+
+```ts
+import type {
+  TCartDiscount,
+  TCartDiscountDraft,
+} from '@commercetools-test-data/cart-discount';
+import * as CartDiscount from '@commercetools-test-data/cart-discount';
+
+const cartDiscount =
+  CartDiscount.random().build<TCartDiscount>();
+const cartDiscountDraft =
+  CartDiscount.CartDiscountDraft.random().build<TCartDiscountDraft>();
+```

--- a/models/cart-discount/package.json
+++ b/models/cart-discount/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@commercetools-test-data/cart-discount",
+  "version": "4.6.0",
+  "description": "Data model for commercetools API CartDiscount",
+  "bugs": "https://github.com/commercetools/test-data/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/test-data.git",
+    "directory": "models/cart-discount"
+  },
+  "keywords": ["javascript", "typescript", "test-data"],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/commercetools-test-data-cart-discount.cjs.js",
+  "module": "dist/commercetools-test-data-cart-discount.esm.js",
+  "files": ["dist", "package.json", "LICENSE", "README.md"],
+  "dependencies": {
+    "@babel/runtime": "^7.17.9",
+    "@babel/runtime-corejs3": "^7.17.9",
+    "@commercetools-test-data/commons": "4.6.0",
+    "@commercetools-test-data/core": "4.6.0",
+    "@commercetools-test-data/cart-discount-value-absolute": "4.6.0",
+    "@commercetools-test-data/cart-discount-value-fixed": "4.6.0",
+    "@commercetools-test-data/cart-discount-value-gift-line-item": "4.6.0",
+    "@commercetools-test-data/cart-discount-value-gift-relative": "4.6.0",
+    "@commercetools-test-data/utils": "4.6.0",
+    "@commercetools/platform-sdk": "^4.0.0",
+    "@faker-js/faker": "^7.4.0"
+  }
+}

--- a/models/cart-discount/package.json
+++ b/models/cart-discount/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/cart-discount",
-  "version": "4.6.0",
+  "version": "4.8.0",
   "description": "Data model for commercetools API CartDiscount",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,13 +19,13 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "4.6.0",
-    "@commercetools-test-data/core": "4.6.0",
-    "@commercetools-test-data/cart-discount-value-absolute": "4.6.0",
-    "@commercetools-test-data/cart-discount-value-fixed": "4.6.0",
-    "@commercetools-test-data/cart-discount-value-gift-line-item": "4.6.0",
-    "@commercetools-test-data/cart-discount-value-gift-relative": "4.6.0",
-    "@commercetools-test-data/utils": "4.6.0",
+    "@commercetools-test-data/cart-discount-value-absolute": "4.8.0",
+    "@commercetools-test-data/cart-discount-value-fixed": "4.8.0",
+    "@commercetools-test-data/cart-discount-value-gift-line-item": "4.8.0",
+    "@commercetools-test-data/cart-discount-value-relative": "4.8.0",
+    "@commercetools-test-data/commons": "4.8.0",
+    "@commercetools-test-data/core": "4.8.0",
+    "@commercetools-test-data/utils": "4.8.0",
     "@commercetools/platform-sdk": "^4.0.0",
     "@faker-js/faker": "^7.4.0"
   }

--- a/models/cart-discount/src/builder.spec.ts
+++ b/models/cart-discount/src/builder.spec.ts
@@ -116,13 +116,13 @@ describe('builder', () => {
         createdBy: expect.objectContaining({
           customerRef: expect.objectContaining({ typeId: 'customer' }),
           userRef: expect.objectContaining({ typeId: 'user' }),
-          __typename: expect.any(String),
+          __typename: 'Initiator',
         }),
         lastModifiedAt: expect.any(String),
         lastModifiedBy: expect.objectContaining({
           customerRef: expect.objectContaining({ typeId: 'customer' }),
           userRef: expect.objectContaining({ typeId: 'user' }),
-          __typename: expect.any(String),
+          __typename: 'Initiator',
         }),
         __typename: 'CartDiscount',
       })

--- a/models/cart-discount/src/builder.spec.ts
+++ b/models/cart-discount/src/builder.spec.ts
@@ -1,0 +1,131 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TCartDiscount, TCartDiscountGraphql } from './types';
+import * as CartDiscount from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TCartDiscount, TCartDiscount>(
+      'default',
+      CartDiscount.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        key: expect.any(String),
+        name: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        description: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        value: expect.objectContaining({
+          type: expect.any(String),
+        }),
+        cartPredicate: '1=1',
+        sortOrder: expect.any(String),
+        isActive: expect.any(Boolean),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        requiresDiscountCode: expect.any(Boolean),
+        references: expect.arrayContaining([]),
+        stackingMode: expect.any(String),
+        createdAt: expect.any(String),
+        createdBy: expect.objectContaining({
+          customer: expect.objectContaining({ typeId: 'customer' }),
+        }),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          customer: expect.objectContaining({ typeId: 'customer' }),
+        }),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TCartDiscount, TCartDiscount>(
+      'rest',
+      CartDiscount.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        key: expect.any(String),
+        name: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        description: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        value: expect.objectContaining({
+          type: expect.any(String),
+        }),
+        cartPredicate: '1=1',
+        sortOrder: expect.any(String),
+        isActive: expect.any(Boolean),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        requiresDiscountCode: expect.any(Boolean),
+        references: expect.arrayContaining([]),
+        stackingMode: expect.any(String),
+        createdAt: expect.any(String),
+        createdBy: expect.objectContaining({
+          customer: expect.objectContaining({ typeId: 'customer' }),
+        }),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          customer: expect.objectContaining({ typeId: 'customer' }),
+        }),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TCartDiscount, TCartDiscountGraphql>(
+      'graphql',
+      CartDiscount.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        key: expect.any(String),
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        descriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        value: expect.objectContaining({
+          type: expect.any(String),
+        }),
+        cartPredicate: '1=1',
+        sortOrder: expect.any(String),
+        isActive: expect.any(Boolean),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        requiresDiscountCode: expect.any(Boolean),
+        references: expect.arrayContaining([]),
+        stackingMode: expect.any(String),
+        createdAt: expect.any(String),
+        createdBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+          userRef: expect.objectContaining({ typeId: 'user' }),
+          __typename: expect.any(String),
+        }),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+          userRef: expect.objectContaining({ typeId: 'user' }),
+          __typename: expect.any(String),
+        }),
+        __typename: 'CartDiscount',
+      })
+    )
+  );
+});

--- a/models/cart-discount/src/builder.spec.ts
+++ b/models/cart-discount/src/builder.spec.ts
@@ -22,6 +22,7 @@ describe('builder', () => {
         value: expect.objectContaining({
           type: expect.any(String),
         }),
+        target: null,
         cartPredicate: '1=1',
         sortOrder: expect.any(String),
         isActive: expect.any(Boolean),
@@ -30,6 +31,7 @@ describe('builder', () => {
         requiresDiscountCode: expect.any(Boolean),
         references: expect.arrayContaining([]),
         stackingMode: expect.any(String),
+        custom: null,
         createdAt: expect.any(String),
         createdBy: expect.objectContaining({
           customer: expect.objectContaining({ typeId: 'customer' }),

--- a/models/cart-discount/src/builder.ts
+++ b/models/cart-discount/src/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type { TCartDiscount, TCreateCartDiscountBuilder } from './types';
+
+const Model: TCreateCartDiscountBuilder = () =>
+  Builder<TCartDiscount>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/cart-discount/src/cart-discount-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-draft/builder.spec.ts
@@ -1,0 +1,94 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TCartDiscountDraft, TCartDiscountDraftGraphql } from '../types';
+import * as CartDiscountDraft from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TCartDiscountDraft, TCartDiscountDraft>(
+      'default',
+      CartDiscountDraft.random(),
+      expect.objectContaining({
+        key: expect.any(String),
+        name: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        description: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        value: expect.objectContaining({
+          type: expect.any(String),
+        }),
+        cartPredicate: '1=1',
+        sortOrder: expect.any(String),
+        isActive: expect.any(Boolean),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        requiresDiscountCode: expect.any(Boolean),
+        stackingMode: expect.any(String),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TCartDiscountDraft, TCartDiscountDraft>(
+      'rest',
+      CartDiscountDraft.random(),
+      expect.objectContaining({
+        key: expect.any(String),
+        name: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        description: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        value: expect.objectContaining({
+          type: expect.any(String),
+        }),
+        cartPredicate: '1=1',
+        sortOrder: expect.any(String),
+        isActive: expect.any(Boolean),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        requiresDiscountCode: expect.any(Boolean),
+        stackingMode: expect.any(String),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TCartDiscountDraft, TCartDiscountDraftGraphql>(
+      'graphql',
+      CartDiscountDraft.random(),
+      expect.objectContaining({
+        key: expect.any(String),
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        descriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        value: expect.objectContaining({
+          type: expect.any(String),
+        }),
+        cartPredicate: '1=1',
+        sortOrder: expect.any(String),
+        isActive: expect.any(Boolean),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        requiresDiscountCode: expect.any(Boolean),
+        stackingMode: expect.any(String),
+        __typename: 'CartDiscountDraft',
+      })
+    )
+  );
+});

--- a/models/cart-discount/src/cart-discount-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-draft/builder.spec.ts
@@ -21,12 +21,14 @@ describe('builder', () => {
           type: expect.any(String),
         }),
         cartPredicate: '1=1',
+        target: null,
         sortOrder: expect.any(String),
         isActive: expect.any(Boolean),
         validFrom: expect.any(String),
         validUntil: expect.any(String),
         requiresDiscountCode: expect.any(Boolean),
         stackingMode: expect.any(String),
+        custom: null,
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-draft/builder.spec.ts
@@ -63,18 +63,16 @@ describe('builder', () => {
       CartDiscountDraft.random(),
       expect.objectContaining({
         key: expect.any(String),
-        nameAllLocales: expect.arrayContaining([
+        name: expect.arrayContaining([
           expect.objectContaining({
             locale: 'en',
             value: expect.any(String),
-            __typename: 'LocalizedString',
           }),
         ]),
-        descriptionAllLocales: expect.arrayContaining([
+        description: expect.arrayContaining([
           expect.objectContaining({
             locale: 'en',
             value: expect.any(String),
-            __typename: 'LocalizedString',
           }),
         ]),
         value: expect.objectContaining({

--- a/models/cart-discount/src/cart-discount-draft/builder.ts
+++ b/models/cart-discount/src/cart-discount-draft/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import type {
+  TCreateCartDiscountDraftBuilder,
+  TCartDiscountDraft,
+} from '../types';
+import generator from './generator';
+import transformers from './transformers';
+
+const Model: TCreateCartDiscountDraftBuilder = () =>
+  Builder<TCartDiscountDraft>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/cart-discount/src/cart-discount-draft/generator.ts
+++ b/models/cart-discount/src/cart-discount-draft/generator.ts
@@ -5,6 +5,7 @@ import * as CartDiscountValueRelative from '@commercetools-test-data/cart-discou
 import { LocalizedString } from '@commercetools-test-data/commons';
 import { fake, Generator } from '@commercetools-test-data/core';
 import { createRelatedDates } from '@commercetools-test-data/utils';
+import { stackingMode } from '../constants';
 import { TCartDiscountDraft } from '../types';
 
 // https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscountdraft
@@ -36,7 +37,7 @@ const generator = Generator<TCartDiscountDraft>({
     validUntil: fake(getValidUntil),
     requiresDiscountCode: fake((f) => f.datatype.boolean()),
     stackingMode: fake((f) =>
-      f.helpers.arrayElement(['Stacking', 'StopAfterThisDiscount'])
+      f.helpers.arrayElement(Object.values(stackingMode))
     ),
     custom: null,
   },

--- a/models/cart-discount/src/cart-discount-draft/generator.ts
+++ b/models/cart-discount/src/cart-discount-draft/generator.ts
@@ -1,0 +1,42 @@
+import * as CartDiscountValueAbsolute from '@commercetools-test-data/cart-discount-value-absolute';
+import * as CartDiscountValueFixed from '@commercetools-test-data/cart-discount-value-fixed';
+import * as CartDiscountValueGiftLineItem from '@commercetools-test-data/cart-discount-value-gift-line-item';
+import * as CartDiscountValueRelative from '@commercetools-test-data/cart-discount-value-relative';
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { fake, Generator } from '@commercetools-test-data/core';
+import { createRelatedDates } from '@commercetools-test-data/utils';
+import { TCartDiscountDraft } from '../types';
+
+// https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscountdraft
+
+// eslint-disable-next-line
+const [getValidFrom, _, getValidUntil] = createRelatedDates();
+
+const generator = Generator<TCartDiscountDraft>({
+  fields: {
+    key: fake((f) => f.lorem.slug(2)),
+    name: fake(() => LocalizedString.random()),
+    description: fake(() => LocalizedString.random()),
+    value: fake((f) =>
+      f.helpers.arrayElement([
+        CartDiscountValueAbsolute.CartDiscountValueAbsoluteDraft.random(),
+        CartDiscountValueFixed.CartDiscountValueFixedDraft.random(),
+        CartDiscountValueGiftLineItem.CartDiscountValueGiftLineItemDraft.random(),
+        CartDiscountValueRelative.CartDiscountValueRelativeDraft.random(),
+      ])
+    ),
+    cartPredicate: '1=1',
+    target: null,
+    sortOrder: fake((f) => String(Math.random())),
+    isActive: fake((f) => f.datatype.boolean()),
+    validFrom: fake(getValidFrom),
+    validUntil: fake(getValidUntil),
+    requiresDiscountCode: fake((f) => f.datatype.boolean()),
+    stackingMode: fake((f) =>
+      f.helpers.arrayElement(['Stacking', 'StopAfterThisDiscount'])
+    ),
+    custom: null,
+  },
+});
+
+export default generator;

--- a/models/cart-discount/src/cart-discount-draft/generator.ts
+++ b/models/cart-discount/src/cart-discount-draft/generator.ts
@@ -27,7 +27,10 @@ const generator = Generator<TCartDiscountDraft>({
     ),
     cartPredicate: '1=1',
     target: null,
-    sortOrder: fake((f) => String(Math.random())),
+    // Faker `min` and `max` bounds are inclusive, we need between 0 and 1
+    sortOrder: fake((f) =>
+      String(f.datatype.number({ min: 0.00001, max: 0.99999 }))
+    ),
     isActive: fake((f) => f.datatype.boolean()),
     validFrom: fake(getValidFrom),
     validUntil: fake(getValidUntil),

--- a/models/cart-discount/src/cart-discount-draft/index.ts
+++ b/models/cart-discount/src/cart-discount-draft/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/cart-discount/src/cart-discount-draft/presets/index.ts
+++ b/models/cart-discount/src/cart-discount-draft/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/cart-discount/src/cart-discount-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-draft/transformers.ts
@@ -1,0 +1,27 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { Transformer } from '@commercetools-test-data/core';
+import type { TCartDiscountDraft, TCartDiscountDraftGraphql } from '../types';
+
+const transformers = {
+  default: Transformer<TCartDiscountDraft, TCartDiscountDraft>('default', {
+    buildFields: ['value', 'name', 'description'],
+  }),
+  rest: Transformer<TCartDiscountDraft, TCartDiscountDraft>('rest', {
+    buildFields: ['value', 'name', 'description'],
+  }),
+  graphql: Transformer<TCartDiscountDraft, TCartDiscountDraftGraphql>(
+    'graphql',
+    {
+      buildFields: ['value', 'name', 'description'],
+      addFields: ({ fields }) => ({
+        nameAllLocales: LocalizedString.toLocalizedField(fields.name),
+        descriptionAllLocales: LocalizedString.toLocalizedField(
+          fields.description
+        ),
+        __typename: 'CartDiscountDraft',
+      }),
+    }
+  ),
+};
+
+export default transformers;

--- a/models/cart-discount/src/cart-discount-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-draft/transformers.ts
@@ -1,4 +1,3 @@
-import { LocalizedString } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type { TCartDiscountDraft, TCartDiscountDraftGraphql } from '../types';
 
@@ -13,11 +12,7 @@ const transformers = {
     'graphql',
     {
       buildFields: ['value', 'name', 'description'],
-      addFields: ({ fields }) => ({
-        nameAllLocales: LocalizedString.toLocalizedField(fields.name),
-        descriptionAllLocales: LocalizedString.toLocalizedField(
-          fields.description
-        ),
+      addFields: () => ({
         __typename: 'CartDiscountDraft',
       }),
     }

--- a/models/cart-discount/src/constants.ts
+++ b/models/cart-discount/src/constants.ts
@@ -1,0 +1,6 @@
+const stackingMode = {
+  Stacking: 'Stacking',
+  StopAfterThisDiscount: 'StopAfterThisDiscount',
+} as const;
+
+export { stackingMode };

--- a/models/cart-discount/src/generator.ts
+++ b/models/cart-discount/src/generator.ts
@@ -1,0 +1,53 @@
+import * as CartDiscountValueAbsolute from '@commercetools-test-data/cart-discount-value-absolute';
+import * as CartDiscountValueFixed from '@commercetools-test-data/cart-discount-value-fixed';
+import * as CartDiscountValueGiftLineItem from '@commercetools-test-data/cart-discount-value-gift-line-item';
+import * as CartDiscountValueRelative from '@commercetools-test-data/cart-discount-value-relative';
+import {
+  ClientLogging,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { fake, Generator, sequence } from '@commercetools-test-data/core';
+import { createRelatedDates } from '@commercetools-test-data/utils';
+import { TCartDiscount } from './types';
+
+// https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscount
+
+// eslint-disable-next-line
+const [getValidFrom, _, getValidUntil] = createRelatedDates();
+const [getCreatedAt, getLastModifiedAt] = createRelatedDates();
+
+const generator = Generator<TCartDiscount>({
+  fields: {
+    id: fake((f) => f.random.alphaNumeric(8)),
+    version: sequence(),
+    key: fake((f) => f.lorem.slug(2)),
+    name: fake(() => LocalizedString.random()),
+    description: fake(() => LocalizedString.random()),
+    value: fake((f) =>
+      f.helpers.arrayElement([
+        CartDiscountValueAbsolute.CartDiscountValueAbsoluteDraft.random(),
+        CartDiscountValueFixed.CartDiscountValueFixedDraft.random(),
+        CartDiscountValueGiftLineItem.CartDiscountValueGiftLineItemDraft.random(),
+        CartDiscountValueRelative.CartDiscountValueRelativeDraft.random(),
+      ])
+    ),
+    cartPredicate: '1=1',
+    target: null,
+    sortOrder: fake((f) => String(Math.random())),
+    isActive: fake((f) => f.datatype.boolean()),
+    validFrom: fake(getValidFrom),
+    validUntil: fake(getValidUntil),
+    requiresDiscountCode: fake((f) => f.datatype.boolean()),
+    references: [],
+    stackingMode: fake((f) =>
+      f.helpers.arrayElement(['Stacking', 'StopAfterThisDiscount'])
+    ),
+    custom: null,
+    createdAt: fake(getCreatedAt),
+    createdBy: fake(() => ClientLogging.random()),
+    lastModifiedAt: fake(getLastModifiedAt),
+    lastModifiedBy: fake(() => ClientLogging.random()),
+  },
+});
+
+export default generator;

--- a/models/cart-discount/src/generator.ts
+++ b/models/cart-discount/src/generator.ts
@@ -33,7 +33,10 @@ const generator = Generator<TCartDiscount>({
     ),
     cartPredicate: '1=1',
     target: null,
-    sortOrder: fake((f) => String(Math.random())),
+    // Faker `min` and `max` bounds are inclusive, we need between 0 and 1
+    sortOrder: fake((f) =>
+      String(f.datatype.number({ min: 0.00001, max: 0.99999 }))
+    ),
     isActive: fake((f) => f.datatype.boolean()),
     validFrom: fake(getValidFrom),
     validUntil: fake(getValidUntil),

--- a/models/cart-discount/src/generator.ts
+++ b/models/cart-discount/src/generator.ts
@@ -8,6 +8,7 @@ import {
 } from '@commercetools-test-data/commons';
 import { fake, Generator, sequence } from '@commercetools-test-data/core';
 import { createRelatedDates } from '@commercetools-test-data/utils';
+import { stackingMode } from './constants';
 import { TCartDiscount } from './types';
 
 // https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscount
@@ -43,7 +44,7 @@ const generator = Generator<TCartDiscount>({
     requiresDiscountCode: fake((f) => f.datatype.boolean()),
     references: [],
     stackingMode: fake((f) =>
-      f.helpers.arrayElement(['Stacking', 'StopAfterThisDiscount'])
+      f.helpers.arrayElement(Object.values(stackingMode))
     ),
     custom: null,
     createdAt: fake(getCreatedAt),

--- a/models/cart-discount/src/index.ts
+++ b/models/cart-discount/src/index.ts
@@ -1,0 +1,3 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+export * from './types';

--- a/models/cart-discount/src/presets/index.ts
+++ b/models/cart-discount/src/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/cart-discount/src/transformers.ts
+++ b/models/cart-discount/src/transformers.ts
@@ -1,0 +1,42 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { Transformer } from '@commercetools-test-data/core';
+import type { TCartDiscount, TCartDiscountGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TCartDiscount, TCartDiscount>('default', {
+    buildFields: [
+      'value',
+      'name',
+      'description',
+      'createdBy',
+      'lastModifiedBy',
+    ],
+  }),
+  rest: Transformer<TCartDiscount, TCartDiscount>('rest', {
+    buildFields: [
+      'value',
+      'name',
+      'description',
+      'createdBy',
+      'lastModifiedBy',
+    ],
+  }),
+  graphql: Transformer<TCartDiscount, TCartDiscountGraphql>('graphql', {
+    buildFields: [
+      'value',
+      'name',
+      'description',
+      'createdBy',
+      'lastModifiedBy',
+    ],
+    addFields: ({ fields }) => ({
+      nameAllLocales: LocalizedString.toLocalizedField(fields.name),
+      descriptionAllLocales: LocalizedString.toLocalizedField(
+        fields.description
+      ),
+      __typename: 'CartDiscount',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/cart-discount/src/types.ts
+++ b/models/cart-discount/src/types.ts
@@ -17,8 +17,6 @@ export type TCartDiscountGraphql = TCartDiscount & {
 };
 export type TCartDiscountDraftGraphql = TCartDiscountDraft & {
   __typename: 'CartDiscountDraft';
-  nameAllLocales?: TLocalizedStringGraphql | null;
-  descriptionAllLocales?: TLocalizedStringGraphql | null;
 };
 
 export type TCartDiscountBuilder = TBuilder<TCartDiscount>;

--- a/models/cart-discount/src/types.ts
+++ b/models/cart-discount/src/types.ts
@@ -1,0 +1,28 @@
+import { CartDiscount, CartDiscountDraft } from '@commercetools/platform-sdk';
+import {
+  TClientLoggingGraphql,
+  TLocalizedStringGraphql,
+} from '@commercetools-test-data/commons';
+import type { TBuilder } from '@commercetools-test-data/core';
+
+export type TCartDiscount = CartDiscount;
+export type TCartDiscountDraft = CartDiscountDraft;
+
+export type TCartDiscountGraphql = TCartDiscount & {
+  __typename: 'CartDiscount';
+  createdBy: TClientLoggingGraphql;
+  lastModifiedBy: TClientLoggingGraphql;
+  nameAllLocales?: TLocalizedStringGraphql | null;
+  descriptionAllLocales?: TLocalizedStringGraphql | null;
+};
+export type TCartDiscountDraftGraphql = TCartDiscountDraft & {
+  __typename: 'CartDiscountDraft';
+  nameAllLocales?: TLocalizedStringGraphql | null;
+  descriptionAllLocales?: TLocalizedStringGraphql | null;
+};
+
+export type TCartDiscountBuilder = TBuilder<TCartDiscount>;
+export type TCartDiscountDraftBuilder = TBuilder<TCartDiscountDraft>;
+
+export type TCreateCartDiscountBuilder = () => TCartDiscountBuilder;
+export type TCreateCartDiscountDraftBuilder = () => TCartDiscountDraftBuilder;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,7 +1862,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@commercetools-test-data/cart-discount-value-absolute@workspace:models/cart-discount-value-absolute":
+"@commercetools-test-data/cart-discount-value-absolute@4.8.0, @commercetools-test-data/cart-discount-value-absolute@workspace:models/cart-discount-value-absolute":
   version: 0.0.0-use.local
   resolution: "@commercetools-test-data/cart-discount-value-absolute@workspace:models/cart-discount-value-absolute"
   dependencies:
@@ -1878,7 +1878,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@commercetools-test-data/cart-discount-value-fixed@workspace:models/cart-discount-value-fixed":
+"@commercetools-test-data/cart-discount-value-fixed@4.8.0, @commercetools-test-data/cart-discount-value-fixed@workspace:models/cart-discount-value-fixed":
   version: 0.0.0-use.local
   resolution: "@commercetools-test-data/cart-discount-value-fixed@workspace:models/cart-discount-value-fixed"
   dependencies:
@@ -1894,7 +1894,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@commercetools-test-data/cart-discount-value-gift-line-item@workspace:models/cart-discount-value-gift-line-item":
+"@commercetools-test-data/cart-discount-value-gift-line-item@4.8.0, @commercetools-test-data/cart-discount-value-gift-line-item@workspace:models/cart-discount-value-gift-line-item":
   version: 0.0.0-use.local
   resolution: "@commercetools-test-data/cart-discount-value-gift-line-item@workspace:models/cart-discount-value-gift-line-item"
   dependencies:
@@ -1908,12 +1908,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@commercetools-test-data/cart-discount-value-relative@workspace:models/cart-discount-value-relative":
+"@commercetools-test-data/cart-discount-value-relative@4.8.0, @commercetools-test-data/cart-discount-value-relative@workspace:models/cart-discount-value-relative":
   version: 0.0.0-use.local
   resolution: "@commercetools-test-data/cart-discount-value-relative@workspace:models/cart-discount-value-relative"
   dependencies:
     "@babel/runtime": ^7.17.9
     "@babel/runtime-corejs3": ^7.17.9
+    "@commercetools-test-data/commons": 4.8.0
+    "@commercetools-test-data/core": 4.8.0
+    "@commercetools-test-data/utils": 4.8.0
+    "@commercetools/platform-sdk": ^4.0.0
+    "@faker-js/faker": ^7.4.0
+  languageName: unknown
+  linkType: soft
+
+"@commercetools-test-data/cart-discount@workspace:models/cart-discount":
+  version: 0.0.0-use.local
+  resolution: "@commercetools-test-data/cart-discount@workspace:models/cart-discount"
+  dependencies:
+    "@babel/runtime": ^7.17.9
+    "@babel/runtime-corejs3": ^7.17.9
+    "@commercetools-test-data/cart-discount-value-absolute": 4.8.0
+    "@commercetools-test-data/cart-discount-value-fixed": 4.8.0
+    "@commercetools-test-data/cart-discount-value-gift-line-item": 4.8.0
+    "@commercetools-test-data/cart-discount-value-relative": 4.8.0
     "@commercetools-test-data/commons": 4.8.0
     "@commercetools-test-data/core": 4.8.0
     "@commercetools-test-data/utils": 4.8.0


### PR DESCRIPTION
## Summary

This PR creates the [`CartDiscount`](https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscount) model.

## Description

More of the same, pretty standard migration stuff.