### PR TITLE
chore(test-data): create `ProductData`

### DIFF
--- a/.changeset/fair-squids-enjoy.md
+++ b/.changeset/fair-squids-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product-data': minor
+---
+
+created ProductData

--- a/models/product-data/LICENSE
+++ b/models/product-data/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) commercetools GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/models/product-data/README.md
+++ b/models/product-data/README.md
@@ -1,0 +1,25 @@
+# @commercetools-test-data/product-data
+
+This package provides the data model for the commercetools platform `ProductData` type
+
+https://docs.commercetools.com/api/types#centprecisionmoney
+
+# Install
+
+```bash
+$ yarn add -D @commercetools-test-data/product-data
+```
+
+# Usage
+
+```ts
+import type {
+  TProductData,
+  TProductDataDraft,
+} from '@commercetools-test-data/product-data';
+import * as ProductData from '@commercetools-test-data/product-data';
+
+const productData = ProductData.random().build<TProductData>();
+const productDataDraft =
+  ProductData.ProductDataDraft.random().build<TProductDataDraft>();
+```

--- a/models/product-data/package.json
+++ b/models/product-data/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@commercetools-test-data/product-data",
+  "version": "4.9.0",
+  "description": "Data model for commercetools API ProductData",
+  "bugs": "https://github.com/commercetools/test-data/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/test-data.git",
+    "directory": "models/product-data"
+  },
+  "keywords": ["javascript", "typescript", "test-data"],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/commercetools-test-data-product-data.cjs.js",
+  "module": "dist/commercetools-test-data-product-data.esm.js",
+  "files": ["dist", "package.json", "LICENSE", "README.md"],
+  "dependencies": {
+    "@babel/runtime": "^7.17.9",
+    "@babel/runtime-corejs3": "^7.17.9",
+    "@commercetools-test-data/category": "4.9.0",
+    "@commercetools-test-data/commons": "4.9.0",
+    "@commercetools-test-data/core": "4.9.0",
+    "@commercetools-test-data/utils": "4.9.0",
+    "@commercetools/platform-sdk": "^4.0.0",
+    "@faker-js/faker": "^7.4.0"
+  }
+}

--- a/models/product-data/src/builder.spec.ts
+++ b/models/product-data/src/builder.spec.ts
@@ -1,0 +1,152 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TProductData, TProductDataGraphql } from './types';
+import * as ProductData from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TProductData, TProductData>(
+      'default',
+      ProductData.random(),
+      expect.objectContaining({
+        name: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        categories: expect.arrayContaining([
+          expect.objectContaining({
+            typeId: 'category',
+          }),
+        ]),
+        categoryOrderHints: expect.any(Object),
+        description: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        slug: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        metaTitle: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        metaDescription: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        metaKeywords: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        masterVariant: null,
+        variants: [],
+        searchKeywords: null,
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TProductData, TProductData>(
+      'rest',
+      ProductData.random(),
+      expect.objectContaining({
+        name: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        categories: expect.arrayContaining([
+          expect.objectContaining({
+            typeId: 'category',
+          }),
+        ]),
+        categoryOrderHints: expect.any(Object),
+        description: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        slug: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        metaTitle: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        metaDescription: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        metaKeywords: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        masterVariant: null,
+        variants: [],
+        searchKeywords: null,
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TProductData, TProductDataGraphql>(
+      'graphql',
+      ProductData.random(),
+      expect.objectContaining({
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        descriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        slugAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        categoryOrderHint: expect.any(String),
+        categoryOrderHints: expect.any(Object),
+        categoriesRef: expect.arrayContaining([
+          {
+            typeId: 'category',
+            id: expect.any(String),
+            __typename: 'Reference',
+          },
+        ]),
+        categories: expect.arrayContaining([
+          expect.objectContaining({
+            __typename: 'Category',
+          }),
+        ]),
+        searchKeyword: expect.arrayContaining([]),
+        searchKeywords: expect.arrayContaining([]),
+        metaTitleAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        metaKeywordsAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        metaDescriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        masterVariant: null,
+        variants: expect.arrayContaining([]),
+        allVariants: expect.arrayContaining([]),
+        variant: null,
+        skus: expect.arrayContaining([expect.any(String)]),
+        __typename: 'ProductData',
+      })
+    )
+  );
+});

--- a/models/product-data/src/builder.ts
+++ b/models/product-data/src/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type { TProductData, TCreateProductDataBuilder } from './types';
+
+const Model: TCreateProductDataBuilder = () =>
+  Builder<TProductData>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/product-data/src/generator.ts
+++ b/models/product-data/src/generator.ts
@@ -1,0 +1,25 @@
+import { LocalizedString, Reference } from '@commercetools-test-data/commons';
+import { fake, Generator } from '@commercetools-test-data/core';
+import { TProductData } from './types';
+
+// https://docs.commercetools.com/api/projects/products#productdata
+
+const generator = Generator<TProductData>({
+  fields: {
+    name: fake(() => LocalizedString.random()),
+    categories: fake(() => [Reference.presets.category()]),
+    categoryOrderHints: {},
+    description: fake(() => LocalizedString.random()),
+    slug: fake(() => LocalizedString.presets.ofSlugs()),
+    metaTitle: fake(() => LocalizedString.random()),
+    metaDescription: fake(() => LocalizedString.random()),
+    metaKeywords: fake(() => LocalizedString.random()),
+    // TODO: Include random ProductVariant when available
+    masterVariant: null,
+    variants: [],
+    // TODO: Include random SearchKeywords when available
+    searchKeywords: null,
+  },
+});
+
+export default generator;

--- a/models/product-data/src/index.ts
+++ b/models/product-data/src/index.ts
@@ -1,0 +1,3 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+export * from './types';

--- a/models/product-data/src/presets/index.ts
+++ b/models/product-data/src/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/product-data/src/transformers.ts
+++ b/models/product-data/src/transformers.ts
@@ -1,0 +1,102 @@
+import {
+  CategoryReference,
+  ProductVariant,
+  SearchKeyword,
+} from '@commercetools/platform-sdk';
+import * as Category from '@commercetools-test-data/category';
+import { TCategoryGraphql } from '@commercetools-test-data/category';
+import { LocalizedString, Reference } from '@commercetools-test-data/commons';
+import { Transformer } from '@commercetools-test-data/core';
+import { faker } from '@faker-js/faker';
+import type { TProductData, TProductDataGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TProductData, TProductData>('default', {
+    buildFields: [
+      'name',
+      'categories',
+      'description',
+      'slug',
+      'metaTitle',
+      'metaDescription',
+      'metaKeywords',
+    ],
+  }),
+  rest: Transformer<TProductData, TProductData>('rest', {
+    buildFields: [
+      'name',
+      'categories',
+      'description',
+      'slug',
+      'metaTitle',
+      'metaDescription',
+      'metaKeywords',
+    ],
+  }),
+  graphql: Transformer<TProductData, TProductDataGraphql>('graphql', {
+    buildFields: [
+      'name',
+      'categories',
+      'description',
+      'slug',
+      'metaTitle',
+      'metaDescription',
+      'metaKeywords',
+    ],
+    /**
+     * We choose `replaceFields` because the type of the `categories` field differs
+     * between REST and GraphQL, and it must be replaced.
+     */
+    replaceFields: ({ fields }) => {
+      const nameAllLocales = LocalizedString.toLocalizedField(fields.name);
+      const descriptionAllLocales = LocalizedString.toLocalizedField(
+        fields.description
+      );
+      const slugAllLocales = LocalizedString.toLocalizedField(fields.slug);
+      const metaTitleAllLocales = LocalizedString.toLocalizedField(
+        fields.metaTitle
+      );
+      const metaKeywordsAllLocales = LocalizedString.toLocalizedField(
+        fields.metaKeywords
+      );
+      const metaDescriptionAllLocales = LocalizedString.toLocalizedField(
+        fields.metaDescription
+      );
+      const categoryOrderHint = faker.lorem.word();
+      const categoriesRef: Array<CategoryReference> = [
+        Reference.presets.category().buildGraphql(),
+      ];
+      const categories: Array<TCategoryGraphql> = [
+        Category.random().buildGraphql(),
+      ];
+      // TODO: add SearchKeyword when available
+      const searchKeyword: Array<SearchKeyword> = [];
+      // TODO: Add ProductVariants when available
+      const allVariants: Array<ProductVariant> = [];
+      // TODO: Add ProductVariant when available
+      const variant = null;
+      const skus = [faker.random.alphaNumeric(8)];
+
+      return {
+        // Include all preexisting fields as we are performing a full replacement
+        ...fields,
+        nameAllLocales,
+        descriptionAllLocales,
+        slugAllLocales,
+        metaTitleAllLocales,
+        metaKeywordsAllLocales,
+        metaDescriptionAllLocales,
+        categoryOrderHint,
+        categoriesRef,
+        categories,
+        searchKeyword,
+        allVariants,
+        variant,
+        skus,
+        __typename: 'ProductData',
+      };
+    },
+  }),
+};
+
+export default transformers;

--- a/models/product-data/src/types.ts
+++ b/models/product-data/src/types.ts
@@ -1,0 +1,30 @@
+import {
+  CategoryReference,
+  ProductData,
+  ProductVariant,
+  SearchKeyword,
+} from '@commercetools/platform-sdk';
+import { TLocalizedStringGraphql } from '@commercetools-test-data/commons';
+import type { TBuilder } from '@commercetools-test-data/core';
+import { TCategoryGraphql } from '../../category/src';
+
+export type TProductData = ProductData;
+
+export type TProductDataGraphql = Omit<TProductData, 'categories'> & {
+  nameAllLocales?: TLocalizedStringGraphql | null;
+  descriptionAllLocales?: TLocalizedStringGraphql | null;
+  slugAllLocales?: TLocalizedStringGraphql | null;
+  metaTitleAllLocales?: TLocalizedStringGraphql | null;
+  metaKeywordsAllLocales?: TLocalizedStringGraphql | null;
+  metaDescriptionAllLocales?: TLocalizedStringGraphql | null;
+  categoryOrderHint?: String | null;
+  categoriesRef: Array<CategoryReference>;
+  categories: Array<TCategoryGraphql>;
+  searchKeyword?: Array<SearchKeyword> | null;
+  allVariants: Array<ProductVariant>;
+  variant?: ProductVariant | null;
+  __typename: 'ProductData';
+};
+
+export type TProductDataBuilder = TBuilder<TProductData>;
+export type TCreateProductDataBuilder = () => TProductDataBuilder;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,7 +1955,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@commercetools-test-data/category@workspace:models/category":
+"@commercetools-test-data/category@4.9.0, @commercetools-test-data/category@workspace:models/category":
   version: 0.0.0-use.local
   resolution: "@commercetools-test-data/category@workspace:models/category"
   dependencies:
@@ -2120,6 +2120,21 @@ __metadata:
     "@babel/runtime": ^7.17.9
     "@babel/runtime-corejs3": ^7.17.9
     "@commercetools-test-data/cent-precision-money": 4.9.0
+    "@commercetools-test-data/commons": 4.9.0
+    "@commercetools-test-data/core": 4.9.0
+    "@commercetools-test-data/utils": 4.9.0
+    "@commercetools/platform-sdk": ^4.0.0
+    "@faker-js/faker": ^7.4.0
+  languageName: unknown
+  linkType: soft
+
+"@commercetools-test-data/product-data@workspace:models/product-data":
+  version: 0.0.0-use.local
+  resolution: "@commercetools-test-data/product-data@workspace:models/product-data"
+  dependencies:
+    "@babel/runtime": ^7.17.9
+    "@babel/runtime-corejs3": ^7.17.9
+    "@commercetools-test-data/category": 4.9.0
     "@commercetools-test-data/commons": 4.9.0
     "@commercetools-test-data/core": 4.9.0
     "@commercetools-test-data/utils": 4.9.0


### PR DESCRIPTION
## Summary

This PR creates the [ProductData](https://docs.commercetools.com/api/projects/products#productdata) model. 

## Description

The GraphQL entity differed quite substantially from the REST model. Notably, its `categories` field was of a completely different type - so I had to perform a full field replacement in the transformer since I couldn't call both `addFields` and `replaceFields` simultaneously due to type mismatches (reviewers, if you see a better way, let me know!)