### PR TITLE
chore(test-data): create `Attribute` model

### DIFF
--- a/.changeset/four-years-listen.md
+++ b/.changeset/four-years-listen.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/attribute': minor
+---
+
+create Attribute model

--- a/models/attribute/LICENSE
+++ b/models/attribute/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) commercetools GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/models/attribute/README.md
+++ b/models/attribute/README.md
@@ -13,8 +13,13 @@ $ yarn add -D @commercetools-test-data/attribute
 # Usage
 
 ```ts
-import type { TAttribute } from '@commercetools-test-data/attribute';
+import type {
+  TAttribute,
+  TAttributeDraft,
+} from '@commercetools-test-data/attribute';
 import * as Attribute from '@commercetools-test-data/attribute';
 
 const attribute = Attribute.random().build<TAttribute>();
+const attributeDraftGraphql =
+  Attribute.AttributeDraft.random().buildGraphql<TAttributeDraft>();
 ```

--- a/models/attribute/README.md
+++ b/models/attribute/README.md
@@ -1,0 +1,20 @@
+# @commercetools-test-data/attribute
+
+This package provides the data model for the commercetools platform `Attribute` type
+
+https://docs.commercetools.com/api/projects/products#attribute
+
+# Install
+
+```bash
+$ yarn add -D @commercetools-test-data/attribute
+```
+
+# Usage
+
+```ts
+import type { TAttribute } from '@commercetools-test-data/attribute';
+import * as Attribute from '@commercetools-test-data/attribute';
+
+const attribute = Attribute.random().build<TAttribute>();
+```

--- a/models/attribute/package.json
+++ b/models/attribute/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@commercetools-test-data/attribute",
+  "version": "4.9.0",
+  "description": "Data model for commercetools API Attribute",
+  "bugs": "https://github.com/commercetools/test-data/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/test-data.git",
+    "directory": "models/attribute"
+  },
+  "keywords": ["javascript", "typescript", "test-data"],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/commercetools-test-data-attribute.cjs.js",
+  "module": "dist/commercetools-test-data-attribute.esm.js",
+  "files": ["dist", "package.json", "LICENSE", "README.md"],
+  "dependencies": {
+    "@babel/runtime": "^7.17.9",
+    "@babel/runtime-corejs3": "^7.17.9",
+    "@commercetools-test-data/attribute-definition": "4.9.0",
+    "@commercetools-test-data/commons": "4.9.0",
+    "@commercetools-test-data/core": "4.9.0",
+    "@commercetools-test-data/utils": "4.9.0",
+    "@commercetools/platform-sdk": "^4.0.0",
+    "@faker-js/faker": "^7.4.0"
+  }
+}

--- a/models/attribute/src/attribute-draft/builder.spec.ts
+++ b/models/attribute/src/attribute-draft/builder.spec.ts
@@ -38,4 +38,15 @@ describe('builder', () => {
       })
     )
   );
+
+  it(
+    ...createBuilderSpec<TAttributeDraft, TAttributeDraft>(
+      'rest',
+      AttributeDraft.random().value({ foo: 'bar' }),
+      expect.objectContaining({
+        name: expect.any(String),
+        value: { foo: 'bar' },
+      })
+    )
+  );
 });

--- a/models/attribute/src/attribute-draft/builder.spec.ts
+++ b/models/attribute/src/attribute-draft/builder.spec.ts
@@ -1,0 +1,41 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TAttributeDraft, TAttributeDraftGraphql } from '../types';
+import * as AttributeDraft from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TAttributeDraft, TAttributeDraft>(
+      'default',
+      AttributeDraft.random(),
+      expect.objectContaining({
+        name: expect.any(String),
+        value: null,
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TAttributeDraft, TAttributeDraft>(
+      'rest',
+      AttributeDraft.random(),
+      expect.objectContaining({
+        name: expect.any(String),
+        value: null,
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TAttributeDraft, TAttributeDraftGraphql>(
+      'graphql',
+      AttributeDraft.random(),
+      expect.objectContaining({
+        name: expect.any(String),
+        value: null,
+        __typename: 'ProductAttributeInput',
+      })
+    )
+  );
+});

--- a/models/attribute/src/attribute-draft/builder.ts
+++ b/models/attribute/src/attribute-draft/builder.ts
@@ -1,10 +1,10 @@
 import { Builder } from '@commercetools-test-data/core';
+import type { TAttributeDraft, TCreateAttributeDraftBuilder } from '../types';
 import generator from './generator';
 import transformers from './transformers';
-import type { TAttribute, TCreateAttributeBuilder } from './types';
 
-const Model: TCreateAttributeBuilder = () =>
-  Builder<TAttribute>({
+const Model: TCreateAttributeDraftBuilder = () =>
+  Builder<TAttributeDraft>({
     generator,
     transformers,
   });

--- a/models/attribute/src/attribute-draft/generator.ts
+++ b/models/attribute/src/attribute-draft/generator.ts
@@ -1,0 +1,18 @@
+import { fake, Generator } from '@commercetools-test-data/core';
+import { TAttributeDraft } from '../types';
+
+/**
+ * This model does not have a corresponding REST entity,
+ * as `AttributeDraft` doesn't exist.
+ *
+ * It's been created specifically for GraphQL transformations
+ * when needing `ProductAttributeInput`.
+ */
+const generator = Generator<TAttributeDraft>({
+  fields: {
+    name: fake((f) => f.lorem.slug(3)),
+    value: null,
+  },
+});
+
+export default generator;

--- a/models/attribute/src/attribute-draft/index.ts
+++ b/models/attribute/src/attribute-draft/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/attribute/src/attribute-draft/presets/index.ts
+++ b/models/attribute/src/attribute-draft/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/attribute/src/attribute-draft/transformers.ts
+++ b/models/attribute/src/attribute-draft/transformers.ts
@@ -1,0 +1,13 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type { TAttributeDraft, TAttributeDraftGraphql } from '../types';
+
+const transformers = {
+  default: Transformer<TAttributeDraft, TAttributeDraft>('default', {}),
+  rest: Transformer<TAttributeDraft, TAttributeDraft>('rest', {}),
+  graphql: Transformer<TAttributeDraft, TAttributeDraftGraphql>('graphql', {
+    buildFields: [],
+    addFields: () => ({ __typename: 'ProductAttributeInput' }),
+  }),
+};
+
+export default transformers;

--- a/models/attribute/src/attribute-draft/transformers.ts
+++ b/models/attribute/src/attribute-draft/transformers.ts
@@ -5,7 +5,6 @@ const transformers = {
   default: Transformer<TAttributeDraft, TAttributeDraft>('default', {}),
   rest: Transformer<TAttributeDraft, TAttributeDraft>('rest', {}),
   graphql: Transformer<TAttributeDraft, TAttributeDraftGraphql>('graphql', {
-    buildFields: [],
     addFields: () => ({ __typename: 'ProductAttributeInput' }),
   }),
 };

--- a/models/attribute/src/builder.spec.ts
+++ b/models/attribute/src/builder.spec.ts
@@ -15,14 +15,8 @@ describe('builder', () => {
         attributeDefinition: expect.objectContaining({
           name: expect.any(String),
         }),
-        referencedResource: expect.objectContaining({
-          id: expect.any(String),
-        }),
-        referencedResourceSet: expect.arrayContaining([
-          expect.objectContaining({
-            id: expect.any(String),
-          }),
-        ]),
+        referencedResource: null,
+        referencedResourceSet: expect.arrayContaining([]),
       })
     )
   );
@@ -49,14 +43,8 @@ describe('builder', () => {
           name: expect.any(String),
           __typename: 'AttributeDefinition',
         }),
-        referencedResource: expect.objectContaining({
-          id: expect.any(String),
-        }),
-        referencedResourceSet: expect.arrayContaining([
-          expect.objectContaining({
-            id: expect.any(String),
-          }),
-        ]),
+        referencedResource: null,
+        referencedResourceSet: expect.arrayContaining([]),
         __typename: 'RawProductAttribute',
       })
     )

--- a/models/attribute/src/builder.spec.ts
+++ b/models/attribute/src/builder.spec.ts
@@ -1,0 +1,64 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TAttribute, TAttributeDefault, TAttributeGraphql } from './types';
+import * as Attribute from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TAttributeDefault, TAttributeDefault>(
+      'default',
+      Attribute.random(),
+      expect.objectContaining({
+        name: expect.any(String),
+        value: null,
+        attributeDefinition: expect.objectContaining({
+          name: expect.any(String),
+        }),
+        referencedResource: expect.objectContaining({
+          id: expect.any(String),
+        }),
+        referencedResourceSet: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+          }),
+        ]),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TAttributeDefault, TAttribute>(
+      'rest',
+      Attribute.random(),
+      expect.objectContaining({
+        name: expect.any(String),
+        value: null,
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TAttributeDefault, TAttributeGraphql>(
+      'graphql',
+      Attribute.random(),
+      expect.objectContaining({
+        name: expect.any(String),
+        value: null,
+        attributeDefinition: expect.objectContaining({
+          name: expect.any(String),
+          __typename: 'AttributeDefinition',
+        }),
+        referencedResource: expect.objectContaining({
+          id: expect.any(String),
+        }),
+        referencedResourceSet: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+          }),
+        ]),
+        __typename: 'RawProductAttribute',
+      })
+    )
+  );
+});

--- a/models/attribute/src/builder.spec.ts
+++ b/models/attribute/src/builder.spec.ts
@@ -1,12 +1,12 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import { TAttribute, TAttributeDefault, TAttributeGraphql } from './types';
+import { TAttribute, TAttributeRest, TAttributeGraphql } from './types';
 import * as Attribute from '.';
 
 describe('builder', () => {
   it(
-    ...createBuilderSpec<TAttributeDefault, TAttributeDefault>(
+    ...createBuilderSpec<TAttribute, TAttribute>(
       'default',
       Attribute.random(),
       expect.objectContaining({
@@ -28,7 +28,7 @@ describe('builder', () => {
   );
 
   it(
-    ...createBuilderSpec<TAttributeDefault, TAttribute>(
+    ...createBuilderSpec<TAttribute, TAttributeRest>(
       'rest',
       Attribute.random(),
       expect.objectContaining({
@@ -39,7 +39,7 @@ describe('builder', () => {
   );
 
   it(
-    ...createBuilderSpec<TAttributeDefault, TAttributeGraphql>(
+    ...createBuilderSpec<TAttribute, TAttributeGraphql>(
       'graphql',
       Attribute.random(),
       expect.objectContaining({

--- a/models/attribute/src/builder.ts
+++ b/models/attribute/src/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type { TAttributeDefault, TCreateAttributeBuilder } from './types';
+
+const Model: TCreateAttributeBuilder = () =>
+  Builder<TAttributeDefault>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/attribute/src/generator.ts
+++ b/models/attribute/src/generator.ts
@@ -10,8 +10,8 @@ const generator = Generator<TAttribute>({
     // `value` is an overloaded field. It might be best to create your own
     value: null,
     attributeDefinition: fake(() => AttributeDefinition.random()),
-    referencedResource: fake((f) => ({ id: f.datatype.uuid() })),
-    referencedResourceSet: fake((f) => [{ id: f.datatype.uuid() }]),
+    referencedResource: null,
+    referencedResourceSet: [],
   },
 });
 

--- a/models/attribute/src/generator.ts
+++ b/models/attribute/src/generator.ts
@@ -1,10 +1,10 @@
 import * as AttributeDefinition from '@commercetools-test-data/attribute-definition';
 import { fake, Generator } from '@commercetools-test-data/core';
-import { TAttributeDefault } from './types';
+import { TAttribute } from './types';
 
 // https://docs.commercetools.com/api/projects/products#attribute
 
-const generator = Generator<TAttributeDefault>({
+const generator = Generator<TAttribute>({
   fields: {
     name: fake((f) => f.lorem.slug(3)),
     // `value` is an overloaded field. It might be best to create your own

--- a/models/attribute/src/generator.ts
+++ b/models/attribute/src/generator.ts
@@ -7,7 +7,7 @@ import { TAttribute } from './types';
 const generator = Generator<TAttribute>({
   fields: {
     name: fake((f) => f.lorem.slug(3)),
-    // `value` is an overloaded field. It might be best to create your own
+    // `value` is an overloaded field. It might be best to create your own.
     value: null,
     attributeDefinition: fake(() => AttributeDefinition.random()),
     referencedResource: null,

--- a/models/attribute/src/generator.ts
+++ b/models/attribute/src/generator.ts
@@ -1,0 +1,18 @@
+import * as AttributeDefinition from '@commercetools-test-data/attribute-definition';
+import { fake, Generator } from '@commercetools-test-data/core';
+import { TAttributeDefault } from './types';
+
+// https://docs.commercetools.com/api/projects/products#attribute
+
+const generator = Generator<TAttributeDefault>({
+  fields: {
+    name: fake((f) => f.lorem.slug(3)),
+    // `value` is an overloaded field. It might be best to create your own
+    value: null,
+    attributeDefinition: fake(() => AttributeDefinition.random()),
+    referencedResource: fake((f) => ({ id: f.datatype.uuid() })),
+    referencedResourceSet: fake((f) => [{ id: f.datatype.uuid() }]),
+  },
+});
+
+export default generator;

--- a/models/attribute/src/index.ts
+++ b/models/attribute/src/index.ts
@@ -1,3 +1,6 @@
+import * as AttributeDraft from './attribute-draft';
+export { AttributeDraft };
+
 export { default as random } from './builder';
 export { default as presets } from './presets';
 export * from './types';

--- a/models/attribute/src/index.ts
+++ b/models/attribute/src/index.ts
@@ -1,0 +1,3 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+export * from './types';

--- a/models/attribute/src/presets/index.ts
+++ b/models/attribute/src/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/attribute/src/transformers.ts
+++ b/models/attribute/src/transformers.ts
@@ -1,0 +1,19 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type { TAttribute, TAttributeDefault, TAttributeGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TAttributeDefault, TAttributeDefault>('default', {
+    buildFields: ['attributeDefinition'],
+  }),
+  rest: Transformer<TAttributeDefault, TAttribute>('rest', {
+    buildFields: [],
+  }),
+  graphql: Transformer<TAttributeDefault, TAttributeGraphql>('graphql', {
+    buildFields: ['attributeDefinition'],
+    addFields: () => ({
+      __typename: 'RawProductAttribute',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/attribute/src/transformers.ts
+++ b/models/attribute/src/transformers.ts
@@ -7,6 +7,10 @@ const transformers = {
   }),
   rest: Transformer<TAttributeDefault, TAttribute>('rest', {
     buildFields: [],
+    replaceFields: ({ fields }) => ({
+      name: fields.name,
+      value: fields.value,
+    }),
   }),
   graphql: Transformer<TAttributeDefault, TAttributeGraphql>('graphql', {
     buildFields: ['attributeDefinition'],

--- a/models/attribute/src/transformers.ts
+++ b/models/attribute/src/transformers.ts
@@ -1,18 +1,18 @@
 import { Transformer } from '@commercetools-test-data/core';
-import type { TAttribute, TAttributeDefault, TAttributeGraphql } from './types';
+import type { TAttribute, TAttributeRest, TAttributeGraphql } from './types';
 
 const transformers = {
-  default: Transformer<TAttributeDefault, TAttributeDefault>('default', {
+  default: Transformer<TAttribute, TAttribute>('default', {
     buildFields: ['attributeDefinition'],
   }),
-  rest: Transformer<TAttributeDefault, TAttribute>('rest', {
+  rest: Transformer<TAttribute, TAttributeRest>('rest', {
     buildFields: [],
     replaceFields: ({ fields }) => ({
       name: fields.name,
       value: fields.value,
     }),
   }),
-  graphql: Transformer<TAttributeDefault, TAttributeGraphql>('graphql', {
+  graphql: Transformer<TAttribute, TAttributeGraphql>('graphql', {
     buildFields: ['attributeDefinition'],
     addFields: () => ({
       __typename: 'RawProductAttribute',

--- a/models/attribute/src/types.ts
+++ b/models/attribute/src/types.ts
@@ -12,6 +12,8 @@ export type TAttribute = TAttributeRest & {
   referencedResourceSet: Array<TReferenceExpandable>;
 };
 
+export type TAttributeDraft = Attribute;
+
 // REST representation
 export type TAttributeRest = Attribute;
 
@@ -20,5 +22,11 @@ export type TAttributeGraphql = TAttribute & {
   __typename: 'RawProductAttribute';
 };
 
+export type TAttributeDraftGraphql = TAttributeDraft & {
+  __typename: 'ProductAttributeInput';
+};
+
 export type TAttributeBuilder = TBuilder<TAttribute>;
+export type TAttributeDraftBuilder = TBuilder<TAttributeDraft>;
 export type TCreateAttributeBuilder = () => TAttributeBuilder;
+export type TCreateAttributeDraftBuilder = () => TAttributeDraftBuilder;

--- a/models/attribute/src/types.ts
+++ b/models/attribute/src/types.ts
@@ -1,23 +1,24 @@
 import { Attribute, AttributeDefinition } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
 
-// This is the REST representation
-export type TAttribute = Attribute;
-
 export type TReferenceExpandable = {
   id: String;
 };
 
-// This is the generator "catchall" representation
-export type TAttributeDefault = TAttribute & {
+// Base representation
+export type TAttribute = TAttributeRest & {
   attributeDefinition: AttributeDefinition;
   referencedResource: TReferenceExpandable;
   referencedResourceSet: Array<TReferenceExpandable>;
 };
 
-export type TAttributeGraphql = TAttributeDefault & {
+// REST representation
+export type TAttributeRest = Attribute;
+
+// Graphql representation
+export type TAttributeGraphql = TAttribute & {
   __typename: 'RawProductAttribute';
 };
 
-export type TAttributeBuilder = TBuilder<TAttributeDefault>;
+export type TAttributeBuilder = TBuilder<TAttribute>;
 export type TCreateAttributeBuilder = () => TAttributeBuilder;

--- a/models/attribute/src/types.ts
+++ b/models/attribute/src/types.ts
@@ -1,0 +1,23 @@
+import { Attribute, AttributeDefinition } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@commercetools-test-data/core';
+
+// This is the REST representation
+export type TAttribute = Attribute;
+
+export type TReferenceExpandable = {
+  id: String;
+};
+
+// This is the generator "catchall" representation
+export type TAttributeDefault = TAttribute & {
+  attributeDefinition: AttributeDefinition;
+  referencedResource: TReferenceExpandable;
+  referencedResourceSet: Array<TReferenceExpandable>;
+};
+
+export type TAttributeGraphql = TAttributeDefault & {
+  __typename: 'RawProductAttribute';
+};
+
+export type TAttributeBuilder = TBuilder<TAttributeDefault>;
+export type TCreateAttributeBuilder = () => TAttributeBuilder;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1834,7 +1834,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@commercetools-test-data/attribute-definition@workspace:models/attribute-definition":
+"@commercetools-test-data/attribute-definition@4.9.0, @commercetools-test-data/attribute-definition@workspace:models/attribute-definition":
   version: 0.0.0-use.local
   resolution: "@commercetools-test-data/attribute-definition@workspace:models/attribute-definition"
   dependencies:
@@ -1869,6 +1869,21 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.17.9
     "@babel/runtime-corejs3": ^7.17.9
+    "@commercetools-test-data/commons": 4.9.0
+    "@commercetools-test-data/core": 4.9.0
+    "@commercetools-test-data/utils": 4.9.0
+    "@commercetools/platform-sdk": ^4.0.0
+    "@faker-js/faker": ^7.4.0
+  languageName: unknown
+  linkType: soft
+
+"@commercetools-test-data/attribute@workspace:models/attribute":
+  version: 0.0.0-use.local
+  resolution: "@commercetools-test-data/attribute@workspace:models/attribute"
+  dependencies:
+    "@babel/runtime": ^7.17.9
+    "@babel/runtime-corejs3": ^7.17.9
+    "@commercetools-test-data/attribute-definition": 4.9.0
     "@commercetools-test-data/commons": 4.9.0
     "@commercetools-test-data/core": 4.9.0
     "@commercetools-test-data/utils": 4.9.0


### PR DESCRIPTION
## Summary

This PR creates the [Attribute](https://docs.commercetools.com/api/projects/products#attribute) model. This relates to FCT-188 as it is a dependent model for `ProductVariant`.

## Description

The patterns I used here deviate from our norm of representing REST models with the generator type, because the REST representation and graphql representation differ (graphql representation pictured below).
![image](https://user-images.githubusercontent.com/15024562/219438191-885cc717-71ee-4d0e-a6f6-01a0d17133cf.png)

I chose to rename the generator type to `TModelDefault`, in line with our tests, and keep the REST type aliased to the SDK type as usual, so that the type API's for these npm modules remain consistent.