### PR TITLE
feat(presets/customer-group): draft presets for fashion sample data

### DIFF
--- a/.changeset/tidy-pianos-shave.md
+++ b/.changeset/tidy-pianos-shave.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/customer-group': minor
+---
+
+Add `CustomerGroup` draft presets for sample data fashion

--- a/models/customer-group/src/customer-group-draft/presets/index.ts
+++ b/models/customer-group/src/customer-group-draft/presets/index.ts
@@ -1,3 +1,5 @@
-const presets = {};
+import sampleDataFashion from './sample-data-fashion';
+
+const presets = { sampleDataFashion };
 
 export default presets;

--- a/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/employee.spec.ts
+++ b/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/employee.spec.ts
@@ -1,0 +1,21 @@
+import {
+  TCustomerGroupDraft,
+  TCustomerGroupDraftGraphql,
+} from '../../../types';
+import employee from './employee';
+
+describe('with the preset `employee`', () => {
+  it('should return a customer group draft with name `Employee`', () => {
+    const customerGroup = employee().build<TCustomerGroupDraft>();
+
+    expect(customerGroup.key).toMatchInlineSnapshot(`"employee"`);
+    expect(customerGroup.groupName).toMatchInlineSnapshot(`"Employee"`);
+  });
+
+  it('should return a customer group draft with name `Employee` when built for GraphQL', () => {
+    const customerGroup = employee().buildGraphql<TCustomerGroupDraftGraphql>();
+
+    expect(customerGroup.key).toMatchInlineSnapshot(`"employee"`);
+    expect(customerGroup.groupName).toMatchInlineSnapshot(`"Employee"`);
+  });
+});

--- a/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/employee.ts
+++ b/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/employee.ts
@@ -1,0 +1,6 @@
+import CustomerGroupDraft from '../../builder';
+
+const employee = () =>
+  CustomerGroupDraft().key('employee').groupName('Employee');
+
+export default employee;

--- a/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/index.ts
+++ b/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/index.ts
@@ -1,0 +1,6 @@
+import employee from './employee';
+import luxe from './luxe';
+import vip from './vip';
+
+const presets = { employee, luxe, vip };
+export default presets;

--- a/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/luxe.spec.ts
+++ b/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/luxe.spec.ts
@@ -1,0 +1,21 @@
+import {
+  TCustomerGroupDraft,
+  TCustomerGroupDraftGraphql,
+} from '../../../types';
+import luxe from './luxe';
+
+describe('with the preset `luxe`', () => {
+  it('should return a customer group draft with name `Luxe`', () => {
+    const customerGroup = luxe().build<TCustomerGroupDraft>();
+
+    expect(customerGroup.key).toMatchInlineSnapshot(`"luxe"`);
+    expect(customerGroup.groupName).toMatchInlineSnapshot(`"Luxe"`);
+  });
+
+  it('should return a customer group draft with name `Luxe` when built for GraphQL', () => {
+    const customerGroup = luxe().buildGraphql<TCustomerGroupDraftGraphql>();
+
+    expect(customerGroup.key).toMatchInlineSnapshot(`"luxe"`);
+    expect(customerGroup.groupName).toMatchInlineSnapshot(`"Luxe"`);
+  });
+});

--- a/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/luxe.ts
+++ b/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/luxe.ts
@@ -1,0 +1,5 @@
+import CustomerGroupDraft from '../../builder';
+
+const luxe = () => CustomerGroupDraft().key('luxe').groupName('Luxe');
+
+export default luxe;

--- a/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/vip.spec.ts
+++ b/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/vip.spec.ts
@@ -1,0 +1,21 @@
+import {
+  TCustomerGroupDraft,
+  TCustomerGroupDraftGraphql,
+} from '../../../types';
+import vip from './vip';
+
+describe('with the preset `vip`', () => {
+  it('should return a customer group draft with name `VIP`', () => {
+    const customerGroup = vip().build<TCustomerGroupDraft>();
+
+    expect(customerGroup.key).toMatchInlineSnapshot(`"vip"`);
+    expect(customerGroup.groupName).toMatchInlineSnapshot(`"VIP"`);
+  });
+
+  it('should return a customer group draft with name `VIP` when built for GraphQL', () => {
+    const customerGroup = vip().buildGraphql<TCustomerGroupDraftGraphql>();
+
+    expect(customerGroup.key).toMatchInlineSnapshot(`"vip"`);
+    expect(customerGroup.groupName).toMatchInlineSnapshot(`"VIP"`);
+  });
+});

--- a/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/vip.ts
+++ b/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/vip.ts
@@ -1,0 +1,5 @@
+import CustomerGroupDraft from '../../builder';
+
+const vip = () => CustomerGroupDraft().key('vip').groupName('VIP');
+
+export default vip;

--- a/models/customer-group/src/index.ts
+++ b/models/customer-group/src/index.ts
@@ -3,4 +3,5 @@ export { CustomerGroupDraft };
 
 export { default as random } from './builder';
 export { default as presets } from './presets';
+export { default as draftPresets } from './customer-group-draft/presets';
 export * from './types';

--- a/models/zone/src/zone-draft/presets/index.ts
+++ b/models/zone/src/zone-draft/presets/index.ts
@@ -1,5 +1,5 @@
-import SampleDataFashion from './sample-data-fashion';
+import sampleDataFashion from './sample-data-fashion';
 
-const presets = { SampleDataFashion };
+const presets = { sampleDataFashion };
 
 export default presets;


### PR DESCRIPTION
#### Summary
- Customer group draft [presets](https://github.com/commercetools/test-data-research/blob/main/src/entity-drafts/customer-groups.ts) for fashion sample data
- Fixed zone draft preset export casing for consistency