### PR TITLE
chore(test-data): create `Order` and `OrderFromCartDraft` models

### DIFF
--- a/.changeset/quick-poets-travel.md
+++ b/.changeset/quick-poets-travel.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/order': minor
+---
+
+create Order and OrderFromCartDraft

--- a/models/order/LICENSE
+++ b/models/order/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) commercetools GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/models/order/README.md
+++ b/models/order/README.md
@@ -1,0 +1,25 @@
+# @commercetools-test-data/order
+
+This package provides the data model for the commercetools platform `Order` type
+
+https://docs.commercetools.com/api/projects/orders#order
+
+# Install
+
+```bash
+$ yarn add -D @commercetools-test-data/order
+```
+
+# Usage
+
+```ts
+import type {
+  TOrder,
+  TOrderFromCartDraft,
+} from '@commercetools-test-data/order';
+import * as Order from '@commercetools-test-data/order';
+
+const order = Order.random().build<TOrder>();
+const orderFromCartDraft =
+  Order.OrderFromCartDraft.random().build<TOrderFromCartDraft>();
+```

--- a/models/order/package.json
+++ b/models/order/package.json
@@ -8,21 +8,30 @@
     "url": "https://github.com/commercetools/test-data.git",
     "directory": "models/order"
   },
-  "keywords": ["javascript", "typescript", "test-data"],
+  "keywords": [
+    "javascript",
+    "typescript",
+    "test-data"
+  ],
   "license": "MIT",
   "publishConfig": {
     "access": "public"
   },
   "main": "dist/commercetools-test-data-order.cjs.js",
   "module": "dist/commercetools-test-data-order.esm.js",
-  "files": ["dist", "package.json", "LICENSE", "README.md"],
+  "files": [
+    "dist",
+    "package.json",
+    "LICENSE",
+    "README.md"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/commons": "4.4.0",
     "@commercetools-test-data/core": "4.4.0",
     "@commercetools-test-data/utils": "4.4.0",
-    "@commercetools/platform-sdk": "^4.0.0",
+    "@commercetools/platform-sdk": "^4.5.0",
     "@faker-js/faker": "^7.4.0"
   }
 }

--- a/models/order/package.json
+++ b/models/order/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/order",
-  "version": "4.4.0",
+  "version": "4.10.0",
   "description": "Data model for commercetools API Order",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -8,29 +8,24 @@
     "url": "https://github.com/commercetools/test-data.git",
     "directory": "models/order"
   },
-  "keywords": [
-    "javascript",
-    "typescript",
-    "test-data"
-  ],
+  "keywords": ["javascript", "typescript", "test-data"],
   "license": "MIT",
   "publishConfig": {
     "access": "public"
   },
   "main": "dist/commercetools-test-data-order.cjs.js",
   "module": "dist/commercetools-test-data-order.esm.js",
-  "files": [
-    "dist",
-    "package.json",
-    "LICENSE",
-    "README.md"
-  ],
+  "files": ["dist", "package.json", "LICENSE", "README.md"],
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "4.4.0",
-    "@commercetools-test-data/core": "4.4.0",
-    "@commercetools-test-data/utils": "4.4.0",
+    "@commercetools-test-data/commons": "4.10.0",
+    "@commercetools-test-data/core": "4.10.0",
+    "@commercetools-test-data/utils": "4.10.0",
+    "@commercetools-test-data/line-item": "4.10.0",
+    "@commercetools-test-data/cent-precision-money": "4.10.0",
+    "@commercetools-test-data/cart": "4.10.0",
+    "@commercetools-test-data/cart-discount": "4.10.0",
     "@commercetools/platform-sdk": "^4.5.0",
     "@faker-js/faker": "^7.4.0"
   }

--- a/models/order/package.json
+++ b/models/order/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@commercetools-test-data/order",
+  "version": "4.4.0",
+  "description": "Data model for commercetools API Order",
+  "bugs": "https://github.com/commercetools/test-data/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/test-data.git",
+    "directory": "models/order"
+  },
+  "keywords": ["javascript", "typescript", "test-data"],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/commercetools-test-data-order.cjs.js",
+  "module": "dist/commercetools-test-data-order.esm.js",
+  "files": ["dist", "package.json", "LICENSE", "README.md"],
+  "dependencies": {
+    "@babel/runtime": "^7.17.9",
+    "@babel/runtime-corejs3": "^7.17.9",
+    "@commercetools-test-data/commons": "4.4.0",
+    "@commercetools-test-data/core": "4.4.0",
+    "@commercetools-test-data/utils": "4.4.0",
+    "@commercetools/platform-sdk": "^4.0.0",
+    "@faker-js/faker": "^7.4.0"
+  }
+}

--- a/models/order/package.json
+++ b/models/order/package.json
@@ -27,7 +27,7 @@
     "@commercetools-test-data/customer-group": "4.10.0",
     "@commercetools-test-data/cart": "4.10.0",
     "@commercetools-test-data/cart-discount": "4.10.0",
-    "@commercetools/platform-sdk": "^4.5.0",
+    "@commercetools/platform-sdk": "^4.0.0",
     "@faker-js/faker": "^7.4.0"
   }
 }

--- a/models/order/package.json
+++ b/models/order/package.json
@@ -24,6 +24,7 @@
     "@commercetools-test-data/utils": "4.10.0",
     "@commercetools-test-data/line-item": "4.10.0",
     "@commercetools-test-data/cent-precision-money": "4.10.0",
+    "@commercetools-test-data/customer-group": "4.10.0",
     "@commercetools-test-data/cart": "4.10.0",
     "@commercetools-test-data/cart-discount": "4.10.0",
     "@commercetools/platform-sdk": "^4.5.0",

--- a/models/order/src/builder.spec.ts
+++ b/models/order/src/builder.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import { TOrder, TOrderGraphql } from './types';
+import { TOrder, TOrderGraphql, TOrderRest } from './types';
 import * as Order from '.';
 
 describe('builder', () => {
@@ -9,15 +9,184 @@ describe('builder', () => {
     ...createBuilderSpec<TOrder, TOrder>(
       'default',
       Order.random(),
-      expect.objectContaining({})
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        createdAt: expect.any(String),
+        createdBy: expect.objectContaining({
+          customer: expect.objectContaining({ typeId: 'customer' }),
+        }),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          customer: expect.objectContaining({ typeId: 'customer' }),
+        }),
+        completedAt: null,
+        orderNumber: expect.any(String),
+        customerId: expect.any(String),
+        customerEmail: expect.any(String),
+        anonymousId: expect.any(String),
+        businessUnit: null,
+        store: null,
+        lineItems: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+            quantity: expect.any(Number),
+          }),
+        ]),
+        customLineItems: expect.arrayContaining([]),
+        totalPrice: expect.objectContaining({
+          centAmount: expect.any(Number),
+          currencyCode: expect.any(String),
+        }),
+        taxedPrice: null,
+        taxedShippingPrice: null,
+        shippingAddress: expect.objectContaining({
+          city: expect.any(String),
+          firstName: expect.any(String),
+          lastName: expect.any(String),
+        }),
+        billingAddress: expect.objectContaining({
+          city: expect.any(String),
+          firstName: expect.any(String),
+          lastName: expect.any(String),
+        }),
+        shippingMode: expect.any(String),
+        shipping: expect.arrayContaining([]),
+        taxMode: expect.any(String),
+        taxRoundingMode: expect.any(String),
+        taxCalculationMode: expect.any(String),
+        customerGroup: expect.objectContaining({
+          name: expect.any(String),
+          version: expect.any(Number),
+        }),
+        country: expect.any(String),
+        orderState: expect.any(String),
+        state: null,
+        shipmentState: expect.any(String),
+        paymentState: expect.any(String),
+        shippingInfo: null,
+        syncInfo: null,
+        returnInfo: expect.arrayContaining([]),
+        purchaseOrderNumber: expect.any(String),
+        discountCodes: expect.arrayContaining([]),
+        refusedGifts: expect.arrayContaining([
+          expect.objectContaining({
+            cartPredicate: expect.any(String),
+          }),
+        ]),
+        cart: expect.objectContaining({
+          cartState: expect.any(String),
+        }),
+        quote: null,
+        custom: null,
+        paymentInfo: null,
+        locale: expect.any(String),
+        inventoryMode: expect.any(String),
+        shippingRateInput: null,
+        origin: null,
+        itemShippingAddresses: expect.arrayContaining([
+          expect.objectContaining({
+            title: expect.any(String),
+            state: expect.any(String),
+          }),
+        ]),
+      })
     )
   );
 
   it(
-    ...createBuilderSpec<TOrder, TOrder>(
+    ...createBuilderSpec<TOrder, TOrderRest>(
       'rest',
       Order.random(),
-      expect.objectContaining({})
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        createdAt: expect.any(String),
+        createdBy: expect.objectContaining({
+          customer: expect.objectContaining({ typeId: 'customer' }),
+        }),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          customer: expect.objectContaining({ typeId: 'customer' }),
+        }),
+        completedAt: null,
+        orderNumber: expect.any(String),
+        customerId: expect.any(String),
+        customerEmail: expect.any(String),
+        anonymousId: expect.any(String),
+        businessUnit: expect.objectContaining({
+          typeId: 'business-unit',
+        }),
+        store: expect.objectContaining({
+          typeId: 'store',
+        }),
+        lineItems: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+            quantity: expect.any(Number),
+          }),
+        ]),
+        customLineItems: expect.arrayContaining([]),
+        totalPrice: expect.objectContaining({
+          centAmount: expect.any(Number),
+          currencyCode: expect.any(String),
+        }),
+        taxedPrice: null,
+        taxedShippingPrice: null,
+        shippingAddress: expect.objectContaining({
+          city: expect.any(String),
+          firstName: expect.any(String),
+          lastName: expect.any(String),
+        }),
+        billingAddress: expect.objectContaining({
+          city: expect.any(String),
+          firstName: expect.any(String),
+          lastName: expect.any(String),
+        }),
+        shippingMode: expect.any(String),
+        shipping: expect.arrayContaining([]),
+        taxMode: expect.any(String),
+        taxRoundingMode: expect.any(String),
+        taxCalculationMode: expect.any(String),
+        customerGroup: expect.objectContaining({
+          typeId: 'customer-group',
+        }),
+        country: expect.any(String),
+        orderState: expect.any(String),
+        state: expect.objectContaining({
+          typeId: 'state',
+        }),
+        shipmentState: expect.any(String),
+        paymentState: expect.any(String),
+        shippingInfo: null,
+        syncInfo: null,
+        returnInfo: expect.arrayContaining([]),
+        purchaseOrderNumber: expect.any(String),
+        discountCodes: expect.arrayContaining([]),
+        refusedGifts: expect.arrayContaining([
+          expect.objectContaining({
+            typeId: 'cart-discount',
+          }),
+        ]),
+        cart: expect.objectContaining({
+          typeId: 'cart',
+        }),
+        quote: expect.objectContaining({
+          typeId: 'quote',
+        }),
+        custom: null,
+        paymentInfo: null,
+        locale: expect.any(String),
+        inventoryMode: expect.any(String),
+        shippingRateInput: null,
+        origin: null,
+        itemShippingAddresses: expect.arrayContaining([
+          expect.objectContaining({
+            title: expect.any(String),
+            state: expect.any(String),
+          }),
+        ]),
+      })
     )
   );
 
@@ -26,6 +195,117 @@ describe('builder', () => {
       'graphql',
       Order.random(),
       expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        createdAt: expect.any(String),
+        createdBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+          userRef: expect.objectContaining({ typeId: 'user' }),
+        }),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+          userRef: expect.objectContaining({ typeId: 'user' }),
+        }),
+        completedAt: null,
+        orderNumber: expect.any(String),
+        customerId: expect.any(String),
+        customerEmail: expect.any(String),
+        anonymousId: expect.any(String),
+        businessUnit: null,
+        businessUnitRef: expect.objectContaining({
+          typeId: 'business-unit',
+          __typename: 'Reference',
+        }),
+        store: null,
+        storeRef: expect.objectContaining({
+          typeId: 'store',
+          __typename: 'Reference',
+        }),
+        lineItems: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+            quantity: expect.any(Number),
+          }),
+        ]),
+        customLineItems: expect.arrayContaining([]),
+        totalPrice: expect.objectContaining({
+          centAmount: expect.any(Number),
+          currencyCode: expect.any(String),
+        }),
+        taxedPrice: null,
+        taxedShippingPrice: null,
+        shippingAddress: expect.objectContaining({
+          city: expect.any(String),
+          firstName: expect.any(String),
+          lastName: expect.any(String),
+        }),
+        billingAddress: expect.objectContaining({
+          city: expect.any(String),
+          firstName: expect.any(String),
+          lastName: expect.any(String),
+        }),
+        shippingMode: expect.any(String),
+        shipping: expect.arrayContaining([]),
+        taxMode: expect.any(String),
+        taxRoundingMode: expect.any(String),
+        taxCalculationMode: expect.any(String),
+        customerGroup: expect.objectContaining({
+          name: expect.any(String),
+          version: expect.any(Number),
+        }),
+        customerGroupRef: expect.objectContaining({
+          typeId: 'customer-group',
+          __typename: 'Reference',
+        }),
+        country: expect.any(String),
+        orderState: expect.any(String),
+        state: null,
+        stateRef: expect.objectContaining({
+          typeId: 'state',
+          __typename: 'Reference',
+        }),
+        shipmentState: expect.any(String),
+        paymentState: expect.any(String),
+        shippingInfo: null,
+        syncInfo: null,
+        returnInfo: expect.arrayContaining([]),
+        purchaseOrderNumber: expect.any(String),
+        discountCodes: expect.arrayContaining([]),
+        refusedGifts: expect.arrayContaining([
+          expect.objectContaining({
+            cartPredicate: expect.any(String),
+          }),
+        ]),
+        refusedGiftsRef: expect.arrayContaining([
+          expect.objectContaining({
+            typeId: 'cart-discount',
+            __typename: 'Reference',
+          }),
+        ]),
+        cart: expect.objectContaining({
+          cartState: expect.any(String),
+        }),
+        cartRef: expect.objectContaining({
+          typeId: 'cart',
+          __typename: 'Reference',
+        }),
+        quoteRef: expect.objectContaining({
+          typeId: 'quote',
+          __typename: 'Reference',
+        }),
+        custom: null,
+        paymentInfo: null,
+        locale: expect.any(String),
+        inventoryMode: expect.any(String),
+        shippingRateInput: null,
+        origin: null,
+        itemShippingAddresses: expect.arrayContaining([
+          expect.objectContaining({
+            title: expect.any(String),
+            state: expect.any(String),
+          }),
+        ]),
         __typename: 'Order',
       })
     )

--- a/models/order/src/builder.spec.ts
+++ b/models/order/src/builder.spec.ts
@@ -1,0 +1,33 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TOrder, TOrderGraphql } from './types';
+import * as Order from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TOrder, TOrder>(
+      'default',
+      Order.random(),
+      expect.objectContaining({})
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TOrder, TOrder>(
+      'rest',
+      Order.random(),
+      expect.objectContaining({})
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TOrder, TOrderGraphql>(
+      'graphql',
+      Order.random(),
+      expect.objectContaining({
+        __typename: 'Order',
+      })
+    )
+  );
+});

--- a/models/order/src/builder.ts
+++ b/models/order/src/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type { TOrder, TCreateOrderBuilder } from './types';
+
+const Model: TCreateOrderBuilder = () =>
+  Builder<TOrder>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/order/src/constants.ts
+++ b/models/order/src/constants.ts
@@ -22,3 +22,32 @@ export const shipmentState = {
   Partial: 'Partial',
   Backorder: 'Backorder',
 } as const;
+
+export const shippingMode = {
+  Single: 'Single',
+  Multiple: 'Multiple',
+} as const;
+
+export const taxMode = {
+  Platform: 'Platform',
+  External: 'External',
+  ExternalAmount: 'ExternalAmount',
+  Disabled: 'Disabled',
+} as const;
+
+export const taxRoundingMode = {
+  HalfEven: 'HalfEven',
+  HalfUp: 'HalfUp',
+  HalfDown: 'HalfDown',
+} as const;
+
+export const taxCalculationMode = {
+  LineItemLevel: 'LineItemLevel',
+  UnitPriceLevel: 'UnitPriceLevel',
+} as const;
+
+export const inventoryMode = {
+  TrackOnly: 'TrackOnly',
+  ReserveOnOrder: 'ReserveOnOrder',
+  None: 'None',
+} as const;

--- a/models/order/src/constants.ts
+++ b/models/order/src/constants.ts
@@ -1,0 +1,24 @@
+export const paymentState = {
+  BalanceDue: 'BalanceDue',
+  Failed: 'Failed',
+  Pending: 'Pending',
+  CreditOwed: 'CreditOwed',
+  Paid: 'Paid',
+} as const;
+
+export const orderState = {
+  Open: 'Open',
+  Confirmed: 'Confirmed',
+  Complete: 'Complete',
+  Cancelled: 'Cancelled',
+} as const;
+
+export const shipmentState = {
+  Shipped: 'Shipped',
+  Delivered: 'Delivered',
+  Ready: 'Ready',
+  Pending: 'Pending',
+  Delayed: 'Delayed',
+  Partial: 'Partial',
+  Backorder: 'Backorder',
+} as const;

--- a/models/order/src/generator.ts
+++ b/models/order/src/generator.ts
@@ -74,7 +74,7 @@ const generator = Generator<TOrder>({
     quote: null,
     custom: null,
     paymentInfo: null,
-    locale: fake((f) => f.random.locale()),
+    locale: oneOf('en-US', 'de-DE', 'es-ES'),
     inventoryMode: oneOf(...Object.values(inventoryMode)),
     shippingRateInput: null,
     origin: null,

--- a/models/order/src/generator.ts
+++ b/models/order/src/generator.ts
@@ -1,0 +1,10 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TOrder } from './types';
+
+// https://docs.commercetools.com/api/projects/orders#order
+
+const generator = Generator<TOrder>({
+  fields: {},
+});
+
+export default generator;

--- a/models/order/src/generator.ts
+++ b/models/order/src/generator.ts
@@ -1,10 +1,85 @@
-import { Generator } from '@commercetools-test-data/core';
+import * as Cart from '@commercetools-test-data/cart';
+import * as CartDiscount from '@commercetools-test-data/cart-discount';
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { ClientLogging, Address } from '@commercetools-test-data/commons';
+import {
+  Generator,
+  fake,
+  oneOf,
+  sequence,
+} from '@commercetools-test-data/core';
+import * as CustomerGroup from '@commercetools-test-data/customer-group';
+import * as LineItem from '@commercetools-test-data/line-item';
+import { createRelatedDates } from '@commercetools-test-data/utils';
+import {
+  inventoryMode,
+  orderState,
+  paymentState,
+  shipmentState,
+  shippingMode,
+  taxCalculationMode,
+  taxMode,
+  taxRoundingMode,
+} from './constants';
 import { TOrder } from './types';
+
+const [getOlderDate, getNewerDate] = createRelatedDates();
 
 // https://docs.commercetools.com/api/projects/orders#order
 
 const generator = Generator<TOrder>({
-  fields: {},
+  fields: {
+    id: fake((f) => f.datatype.uuid()),
+    version: sequence(),
+    createdAt: fake(getOlderDate),
+    createdBy: fake(() => ClientLogging.random()),
+    lastModifiedAt: fake(getNewerDate),
+    lastModifiedBy: fake(() => ClientLogging.random()),
+    completedAt: null,
+    orderNumber: fake((f) => String(f.datatype.number({ min: 100000 }))),
+    customerId: fake((f) => f.datatype.uuid()),
+    customerEmail: fake((f) => f.internet.email()),
+    anonymousId: fake((f) => f.datatype.uuid()),
+    businessUnit: null,
+    store: null,
+    lineItems: fake(() => [LineItem.random()]),
+    customLineItems: [],
+    totalPrice: fake(() => CentPrecisionMoney.random()),
+    taxedPrice: null,
+    taxedShippingPrice: null,
+    shippingAddress: fake(() => Address.random()),
+    billingAddress: fake(() => Address.random()),
+    shippingMode: oneOf(...Object.values(shippingMode)),
+    shipping: [],
+    taxMode: oneOf(...Object.values(taxMode)),
+    taxRoundingMode: oneOf(...Object.values(taxRoundingMode)),
+    taxCalculationMode: oneOf(...Object.values(taxCalculationMode)),
+    customerGroup: fake(() => CustomerGroup.random()),
+    country: fake((f) => f.address.countryCode()),
+    orderState: oneOf(...Object.values(orderState)),
+    state: null,
+    shipmentState: oneOf(...Object.values(shipmentState)),
+    paymentState: oneOf(...Object.values(paymentState)),
+    shippingInfo: null,
+    syncInfo: null,
+    returnInfo: [],
+    purchaseOrderNumber: fake((f) =>
+      String(f.datatype.number({ min: 100000 }))
+    ),
+    discountCodes: [],
+    // TODO: unsupported by SDK types
+    // directDiscounts: [],
+    refusedGifts: fake(() => [CartDiscount.random()]),
+    cart: fake(() => Cart.random()),
+    quote: null,
+    custom: null,
+    paymentInfo: null,
+    locale: fake((f) => f.random.locale()),
+    inventoryMode: oneOf(...Object.values(inventoryMode)),
+    shippingRateInput: null,
+    origin: null,
+    itemShippingAddresses: fake(() => [Address.random()]),
+  },
 });
 
 export default generator;

--- a/models/order/src/index.ts
+++ b/models/order/src/index.ts
@@ -1,0 +1,6 @@
+import * as OrderFromCartDraft from './order-from-cart-draft';
+export { OrderFromCartDraft };
+
+export { default as random } from './builder';
+export { default as presets } from './presets';
+export * from './types';

--- a/models/order/src/index.ts
+++ b/models/order/src/index.ts
@@ -4,3 +4,4 @@ export { OrderFromCartDraft };
 export { default as random } from './builder';
 export { default as presets } from './presets';
 export * from './types';
+export * as constants from './constants';

--- a/models/order/src/order-from-cart-draft/builder.spec.ts
+++ b/models/order/src/order-from-cart-draft/builder.spec.ts
@@ -1,0 +1,33 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TOrderFromCartDraft, TOrderFromCartDraftGraphql } from '../types';
+import * as OrderFromCartDraft from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TOrderFromCartDraft, TOrderFromCartDraft>(
+      'default',
+      OrderFromCartDraft.random(),
+      expect.objectContaining({})
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TOrderFromCartDraft, TOrderFromCartDraft>(
+      'rest',
+      OrderFromCartDraft.random(),
+      expect.objectContaining({})
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TOrderFromCartDraft, TOrderFromCartDraftGraphql>(
+      'graphql',
+      OrderFromCartDraft.random(),
+      expect.objectContaining({
+        __typename: 'OrderFromCartDraft',
+      })
+    )
+  );
+});

--- a/models/order/src/order-from-cart-draft/builder.spec.ts
+++ b/models/order/src/order-from-cart-draft/builder.spec.ts
@@ -9,7 +9,21 @@ describe('builder', () => {
     ...createBuilderSpec<TOrderFromCartDraft, TOrderFromCartDraft>(
       'default',
       OrderFromCartDraft.random(),
-      expect.objectContaining({})
+      expect.objectContaining({
+        cart: expect.objectContaining({
+          typeId: 'cart',
+        }),
+        version: expect.any(Number),
+        orderNumber: expect.any(String),
+        purchaseOrderNumber: expect.any(String),
+        paymentState: expect.any(String),
+        orderState: expect.any(String),
+        state: expect.objectContaining({
+          typeId: 'state',
+        }),
+        shipmentState: expect.any(String),
+        custom: null,
+      })
     )
   );
 
@@ -17,7 +31,21 @@ describe('builder', () => {
     ...createBuilderSpec<TOrderFromCartDraft, TOrderFromCartDraft>(
       'rest',
       OrderFromCartDraft.random(),
-      expect.objectContaining({})
+      expect.objectContaining({
+        cart: expect.objectContaining({
+          typeId: 'cart',
+        }),
+        version: expect.any(Number),
+        orderNumber: expect.any(String),
+        purchaseOrderNumber: expect.any(String),
+        paymentState: expect.any(String),
+        orderState: expect.any(String),
+        state: expect.objectContaining({
+          typeId: 'state',
+        }),
+        shipmentState: expect.any(String),
+        custom: null,
+      })
     )
   );
 
@@ -26,7 +54,22 @@ describe('builder', () => {
       'graphql',
       OrderFromCartDraft.random(),
       expect.objectContaining({
-        __typename: 'OrderFromCartDraft',
+        cart: expect.objectContaining({
+          typeId: 'cart',
+          __typename: 'Reference',
+        }),
+        version: expect.any(Number),
+        orderNumber: expect.any(String),
+        purchaseOrderNumber: expect.any(String),
+        paymentState: expect.any(String),
+        orderState: expect.any(String),
+        state: expect.objectContaining({
+          typeId: 'state',
+          __typename: 'Reference',
+        }),
+        shipmentState: expect.any(String),
+        custom: null,
+        __typename: 'OrderCartCommand',
       })
     )
   );

--- a/models/order/src/order-from-cart-draft/builder.ts
+++ b/models/order/src/order-from-cart-draft/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type {
+  TCreateOrderFromCartDraftBuilder,
+  TOrderFromCartDraft,
+} from '../types';
+
+const Model: TCreateOrderFromCartDraftBuilder = () =>
+  Builder<TOrderFromCartDraft>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/order/src/order-from-cart-draft/generator.ts
+++ b/models/order/src/order-from-cart-draft/generator.ts
@@ -1,10 +1,20 @@
-import { fake, Generator, oneOf } from '@commercetools-test-data/core';
+import {
+  fake,
+  Generator,
+  oneOf,
+  sequence,
+} from '@commercetools-test-data/core';
 import { TOrderFromCartDraft } from '../types';
+import { Reference } from '@commercetools-test-data/commons';
 
 // https://docs.commercetools.com/api/projects/orders#orderfromcartdraft
 
 const generator = Generator<TOrderFromCartDraft>({
-  fields: {},
+  fields: {
+    cart: fake(() => Reference.random().typeId('cart')),
+    version: sequence(),
+    orderNumber: fake((f) => String(f.datatype.number({ min: 100000 }))),
+  },
 });
 
 export default generator;

--- a/models/order/src/order-from-cart-draft/generator.ts
+++ b/models/order/src/order-from-cart-draft/generator.ts
@@ -1,0 +1,10 @@
+import { fake, Generator, oneOf } from '@commercetools-test-data/core';
+import { TOrderFromCartDraft } from '../types';
+
+// https://docs.commercetools.com/api/projects/orders#orderfromcartdraft
+
+const generator = Generator<TOrderFromCartDraft>({
+  fields: {},
+});
+
+export default generator;

--- a/models/order/src/order-from-cart-draft/generator.ts
+++ b/models/order/src/order-from-cart-draft/generator.ts
@@ -1,11 +1,12 @@
+import { Reference } from '@commercetools-test-data/commons';
 import {
   fake,
   Generator,
   oneOf,
   sequence,
 } from '@commercetools-test-data/core';
+import { orderState, paymentState, shipmentState } from '../constants';
 import { TOrderFromCartDraft } from '../types';
-import { Reference } from '@commercetools-test-data/commons';
 
 // https://docs.commercetools.com/api/projects/orders#orderfromcartdraft
 
@@ -14,6 +15,14 @@ const generator = Generator<TOrderFromCartDraft>({
     cart: fake(() => Reference.random().typeId('cart')),
     version: sequence(),
     orderNumber: fake((f) => String(f.datatype.number({ min: 100000 }))),
+    purchaseOrderNumber: fake((f) =>
+      String(f.datatype.number({ min: 100000 }))
+    ),
+    paymentState: oneOf(...Object.values(paymentState)),
+    orderState: oneOf(...Object.values(orderState)),
+    state: fake(() => Reference.random().typeId('state')),
+    shipmentState: oneOf(...Object.values(shipmentState)),
+    custom: null,
   },
 });
 

--- a/models/order/src/order-from-cart-draft/index.ts
+++ b/models/order/src/order-from-cart-draft/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/order/src/order-from-cart-draft/presets/index.ts
+++ b/models/order/src/order-from-cart-draft/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/order/src/order-from-cart-draft/transformers.ts
+++ b/models/order/src/order-from-cart-draft/transformers.ts
@@ -1,0 +1,20 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type { TOrderFromCartDraft, TOrderFromCartDraftGraphql } from '../types';
+
+const transformers = {
+  default: Transformer<TOrderFromCartDraft, TOrderFromCartDraft>('default', {
+    buildFields: [],
+  }),
+  rest: Transformer<TOrderFromCartDraft, TOrderFromCartDraft>('rest', {
+    buildFields: [],
+  }),
+  graphql: Transformer<TOrderFromCartDraft, TOrderFromCartDraftGraphql>(
+    'graphql',
+    {
+      buildFields: [],
+      addFields: () => ({ __typename: 'MoneyInput' }),
+    }
+  ),
+};
+
+export default transformers;

--- a/models/order/src/order-from-cart-draft/transformers.ts
+++ b/models/order/src/order-from-cart-draft/transformers.ts
@@ -3,16 +3,16 @@ import type { TOrderFromCartDraft, TOrderFromCartDraftGraphql } from '../types';
 
 const transformers = {
   default: Transformer<TOrderFromCartDraft, TOrderFromCartDraft>('default', {
-    buildFields: [],
+    buildFields: ['cart', 'state'],
   }),
   rest: Transformer<TOrderFromCartDraft, TOrderFromCartDraft>('rest', {
-    buildFields: [],
+    buildFields: ['cart', 'state'],
   }),
   graphql: Transformer<TOrderFromCartDraft, TOrderFromCartDraftGraphql>(
     'graphql',
     {
-      buildFields: [],
-      addFields: () => ({ __typename: 'MoneyInput' }),
+      buildFields: ['cart', 'state'],
+      addFields: () => ({ __typename: 'OrderCartCommand' }),
     }
   ),
 };

--- a/models/order/src/presets/index.ts
+++ b/models/order/src/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/order/src/transformers.ts
+++ b/models/order/src/transformers.ts
@@ -1,16 +1,100 @@
+import { Reference } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
-import type { TOrder, TOrderGraphql } from './types';
+import type { TOrder, TOrderGraphql, TOrderRest } from './types';
 
 const transformers = {
   default: Transformer<TOrder, TOrder>('default', {
-    buildFields: [],
+    buildFields: [
+      'createdBy',
+      'lastModifiedBy',
+      'lineItems',
+      'totalPrice',
+      'shippingAddress',
+      'billingAddress',
+      'customerGroup',
+      'refusedGifts',
+      'cart',
+      'itemShippingAddresses',
+    ],
   }),
-  rest: Transformer<TOrder, TOrder>('rest', {
-    buildFields: [],
+  rest: Transformer<TOrder, TOrderRest>('rest', {
+    buildFields: [
+      'createdBy',
+      'lastModifiedBy',
+      'lineItems',
+      'totalPrice',
+      'shippingAddress',
+      'billingAddress',
+      'customerGroup',
+      'refusedGifts',
+      'cart',
+      'itemShippingAddresses',
+    ],
+    replaceFields: ({ fields }) => {
+      return {
+        ...fields,
+        customerGroup: fields.customerGroup
+          ? Reference.random()
+              .id(fields.customerGroup.id)
+              .typeId('customer-group')
+              .buildRest()
+          : undefined,
+        refusedGifts: (fields.refusedGifts || []).map((discount) =>
+          Reference.random().id(discount.id).typeId('cart-discount').buildRest()
+        ),
+        cart: fields.cart
+          ? Reference.random().id(fields.cart.id).typeId('cart').buildRest()
+          : undefined,
+        // TODO: transform from field when store model is available
+        store: Reference.random().typeId('store').buildRest(),
+        // TODO: transform from field when businessUnit model is available
+        businessUnit: Reference.random().typeId('business-unit').buildRest(),
+        // TODO: transform from field when state model is available
+        state: Reference.random().typeId('state').buildRest(),
+        // TODO: transform from field when quote model is available
+        quote: Reference.random().typeId('quote').buildRest(),
+      };
+    },
   }),
   graphql: Transformer<TOrder, TOrderGraphql>('graphql', {
-    buildFields: [],
-    addFields: () => ({
+    buildFields: [
+      'createdBy',
+      'lastModifiedBy',
+      'lineItems',
+      'totalPrice',
+      'shippingAddress',
+      'billingAddress',
+      'customerGroup',
+      'refusedGifts',
+      'cart',
+      'itemShippingAddresses',
+    ],
+    addFields: ({ fields }) => ({
+      customerGroupRef: fields.customerGroup
+        ? Reference.random()
+            .id(fields.customerGroup.id)
+            .typeId('customer-group')
+            .buildGraphql()
+        : null,
+      refusedGiftsRef: (fields.refusedGifts || []).map((discount) =>
+        Reference.random()
+          .id(discount.id)
+          .typeId('cart-discount')
+          .buildGraphql()
+      ),
+      cartRef: fields.cart
+        ? Reference.random().id(fields.cart.id).typeId('cart').buildGraphql()
+        : null,
+      // TODO: transform from field when store model is available
+      storeRef: Reference.random().typeId('store').buildGraphql(),
+      // TODO: transform from field when businessUnit model is available
+      businessUnitRef: Reference.random()
+        .typeId('business-unit')
+        .buildGraphql(),
+      // TODO: transform from field when state model is available
+      stateRef: Reference.random().typeId('state').buildGraphql(),
+      // TODO: transform from field when quote model is available
+      quoteRef: Reference.random().typeId('quote').buildGraphql(),
       __typename: 'Order',
     }),
   }),

--- a/models/order/src/transformers.ts
+++ b/models/order/src/transformers.ts
@@ -1,0 +1,19 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type { TOrder, TOrderGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TOrder, TOrder>('default', {
+    buildFields: [],
+  }),
+  rest: Transformer<TOrder, TOrder>('rest', {
+    buildFields: [],
+  }),
+  graphql: Transformer<TOrder, TOrderGraphql>('graphql', {
+    buildFields: [],
+    addFields: () => ({
+      __typename: 'Order',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/order/src/types.ts
+++ b/models/order/src/types.ts
@@ -1,0 +1,17 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import { Order, OrderFromCartDraft } from '@commercetools/platform-sdk';
+
+export type TOrder = Order;
+export type TOrderFromCartDraft = OrderFromCartDraft;
+
+export type TOrderGraphql = TOrder & {
+  __typename: 'Order';
+};
+export type TOrderFromCartDraftGraphql = TOrderFromCartDraft & {
+  __typename: 'OrderCartCommand';
+};
+
+export type TOrderBuilder = TBuilder<TOrder>;
+export type TOrderFromCartDraftBuilder = TBuilder<TOrderFromCartDraft>;
+export type TCreateOrderBuilder = () => TOrderBuilder;
+export type TCreateOrderFromCartDraftBuilder = () => TOrderFromCartDraftBuilder;

--- a/models/order/src/types.ts
+++ b/models/order/src/types.ts
@@ -1,12 +1,51 @@
+import { TReferenceGraphql } from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { Order, OrderFromCartDraft } from '@commercetools/platform-sdk';
+import {
+  BusinessUnit,
+  Cart,
+  CartDiscount,
+  CustomerGroup,
+  Order,
+  OrderFromCartDraft,
+  Quote,
+  State,
+  Store,
+} from '@commercetools/platform-sdk';
 
-export type TOrder = Order;
-export type TOrderFromCartDraft = OrderFromCartDraft;
+export type TOrder = Omit<
+  Order,
+  | 'customerGroup'
+  | 'refusedGifts'
+  | 'store'
+  | 'businessUnit'
+  | 'state'
+  | 'cart'
+  | 'quote'
+> & {
+  customerGroup: CustomerGroup;
+  refusedGifts: Array<CartDiscount>;
+  store: Store;
+  businessUnit: BusinessUnit;
+  state: State;
+  cart: Cart;
+  quote: Quote;
+};
+
+export type TOrderRest = Order;
 
 export type TOrderGraphql = TOrder & {
+  customerGroupRef: TReferenceGraphql | null;
+  refusedGiftsRefs: Array<TReferenceGraphql> | null;
+  storeRef: TReferenceGraphql | null;
+  businessUnitRef: TReferenceGraphql | null;
+  stateRef: TReferenceGraphql | null;
+  cartRef: TReferenceGraphql | null;
+  quoteRef: TReferenceGraphql | null;
   __typename: 'Order';
 };
+
+export type TOrderFromCartDraft = OrderFromCartDraft;
+
 export type TOrderFromCartDraftGraphql = TOrderFromCartDraft & {
   __typename: 'OrderCartCommand';
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "Modules to generate test data for commercetools APIs",
   "private": true,
   "preconstruct": {
-    "packages": ["core", "models/*", "utils"]
+    "packages": [
+      "core",
+      "models/*",
+      "utils"
+    ]
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
@@ -30,7 +34,7 @@
     "@commitlint/config-conventional": "17.4.2",
     "@manypkg/cli": "0.19.2",
     "@preconstruct/cli": "2.3.0",
-    "@types/jest": "^29.0.0",
+    "@types/jest": "^29.4.0",
     "@types/node": "18.11.18",
     "babel-jest": "29.3.1",
     "cross-env": "7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,17 +482,25 @@ importers:
     specifiers:
       '@babel/runtime': ^7.17.9
       '@babel/runtime-corejs3': ^7.17.9
-      '@commercetools-test-data/commons': 4.4.0
-      '@commercetools-test-data/core': 4.4.0
-      '@commercetools-test-data/utils': 4.4.0
+      '@commercetools-test-data/cart': 4.10.0
+      '@commercetools-test-data/cart-discount': 4.10.0
+      '@commercetools-test-data/cent-precision-money': 4.10.0
+      '@commercetools-test-data/commons': 4.10.0
+      '@commercetools-test-data/core': 4.10.0
+      '@commercetools-test-data/line-item': 4.10.0
+      '@commercetools-test-data/utils': 4.10.0
       '@commercetools/platform-sdk': ^4.5.0
       '@faker-js/faker': ^7.4.0
     dependencies:
       '@babel/runtime': 7.21.0
       '@babel/runtime-corejs3': 7.21.0
-      '@commercetools-test-data/commons': 4.4.0
-      '@commercetools-test-data/core': 4.4.0
-      '@commercetools-test-data/utils': 4.4.0
+      '@commercetools-test-data/cart': link:../cart
+      '@commercetools-test-data/cart-discount': link:../cart-discount
+      '@commercetools-test-data/cent-precision-money': link:../cent-precision-money
+      '@commercetools-test-data/commons': link:../commons
+      '@commercetools-test-data/core': link:../../core
+      '@commercetools-test-data/line-item': link:../line-item
+      '@commercetools-test-data/utils': link:../../utils
       '@commercetools/platform-sdk': 4.5.0
       '@faker-js/faker': 7.6.0
 
@@ -2432,37 +2440,6 @@ packages:
       - typescript
     dev: false
 
-  /@commercetools-test-data/commons/4.4.0:
-    resolution: {integrity: sha512-C5XWXs/4Ayjf96CCAQGkbnX5TfxTRFTP2BDvfm30007yfeQdRfgvgB+HWqpRDTmHOJFcuncQrsDIUkWsahNkqQ==}
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@babel/runtime-corejs3': 7.21.0
-      '@commercetools-test-data/core': 4.4.0
-      '@commercetools/platform-sdk': 4.5.0
-      '@faker-js/faker': 7.6.0
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /@commercetools-test-data/core/4.4.0:
-    resolution: {integrity: sha512-TivhKE1KO53txHnHp6Hz/wpYVLg9AYUXgzoOX11eytimA3T4BN5sBCAa5cyatidlgUCxIaGlBxOQnETdiRQeXQ==}
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@babel/runtime-corejs3': 7.21.0
-      '@faker-js/faker': 7.6.0
-      '@types/lodash': 4.14.191
-      lodash: 4.17.21
-    dev: false
-
-  /@commercetools-test-data/utils/4.4.0:
-    resolution: {integrity: sha512-o9jafDjtxtRh8VGbBwgfslvmX12CrR3KJaHOMv00KY9kwquoIBk4ppm6srLxe6XkM/HJDU911H4IShjE0KOH4Q==}
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@babel/runtime-corejs3': 7.21.0
-      '@faker-js/faker': 7.6.0
-    dev: false
-
   /@commercetools/platform-sdk/4.5.0:
     resolution: {integrity: sha512-WbvK/FxbYp5FMK7oRdXrMBxX1vGmpZHws9MG/l2g2q7qwGBdqSUxc0hPODJBISNh1LGkzW95MJAcC1ihV0ys7g==}
     engines: {node: '>=14'}
@@ -3457,10 +3434,6 @@ packages:
 
   /@types/lodash/4.14.186:
     resolution: {integrity: sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==}
-    dev: false
-
-  /@types/lodash/4.14.191:
-    resolution: {integrity: sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==}
     dev: false
 
   /@types/minimist/1.2.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,7 +490,7 @@ importers:
       '@commercetools-test-data/customer-group': 4.10.0
       '@commercetools-test-data/line-item': 4.10.0
       '@commercetools-test-data/utils': 4.10.0
-      '@commercetools/platform-sdk': ^4.5.0
+      '@commercetools/platform-sdk': ^4.0.0
       '@faker-js/faker': ^7.4.0
     dependencies:
       '@babel/runtime': 7.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@commitlint/config-conventional': 17.4.2
       '@manypkg/cli': 0.19.2
       '@preconstruct/cli': 2.3.0
-      '@types/jest': ^29.0.0
+      '@types/jest': ^29.4.0
       '@types/node': 18.11.18
       babel-jest: 29.3.1
       cross-env: 7.0.3
@@ -475,6 +475,24 @@ importers:
       '@commercetools-test-data/commons': link:../commons
       '@commercetools-test-data/core': link:../../core
       '@commercetools-test-data/utils': link:../../utils
+      '@commercetools/platform-sdk': 4.5.0
+      '@faker-js/faker': 7.6.0
+
+  models/order:
+    specifiers:
+      '@babel/runtime': ^7.17.9
+      '@babel/runtime-corejs3': ^7.17.9
+      '@commercetools-test-data/commons': 4.4.0
+      '@commercetools-test-data/core': 4.4.0
+      '@commercetools-test-data/utils': 4.4.0
+      '@commercetools/platform-sdk': ^4.5.0
+      '@faker-js/faker': ^7.4.0
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@babel/runtime-corejs3': 7.21.0
+      '@commercetools-test-data/commons': 4.4.0
+      '@commercetools-test-data/core': 4.4.0
+      '@commercetools-test-data/utils': 4.4.0
       '@commercetools/platform-sdk': 4.5.0
       '@faker-js/faker': 7.6.0
 
@@ -2074,6 +2092,14 @@ packages:
       regenerator-runtime: 0.13.11
     dev: false
 
+  /@babel/runtime-corejs3/7.21.0:
+    resolution: {integrity: sha512-TDD4UJzos3JJtM+tHX+w2Uc+KWj7GV+VKKFdMVd2Rx8sdA19hcc3P3AHFYd5LVOw+pYuSd5lICC3gm52B6Rwxw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      core-js-pure: 3.29.0
+      regenerator-runtime: 0.13.11
+    dev: false
+
   /@babel/runtime/7.19.4:
     resolution: {integrity: sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==}
     engines: {node: '>=6.9.0'}
@@ -2359,8 +2385,8 @@ packages:
       '@babel/preset-env': 7.19.4_@babel+core@7.21.0
       '@babel/preset-react': 7.18.6_@babel+core@7.21.0
       '@babel/preset-typescript': 7.18.6_@babel+core@7.21.0
-      '@babel/runtime': 7.19.4
-      '@babel/runtime-corejs3': 7.19.4
+      '@babel/runtime': 7.21.0
+      '@babel/runtime-corejs3': 7.21.0
       '@emotion/babel-plugin': 11.10.2_@babel+core@7.21.0
       '@emotion/babel-preset-css-prop': 11.10.0_@babel+core@7.21.0
       babel-plugin-dev-expression: 0.2.3_@babel+core@7.21.0
@@ -2406,6 +2432,37 @@ packages:
       - typescript
     dev: false
 
+  /@commercetools-test-data/commons/4.4.0:
+    resolution: {integrity: sha512-C5XWXs/4Ayjf96CCAQGkbnX5TfxTRFTP2BDvfm30007yfeQdRfgvgB+HWqpRDTmHOJFcuncQrsDIUkWsahNkqQ==}
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@babel/runtime-corejs3': 7.21.0
+      '@commercetools-test-data/core': 4.4.0
+      '@commercetools/platform-sdk': 4.5.0
+      '@faker-js/faker': 7.6.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@commercetools-test-data/core/4.4.0:
+    resolution: {integrity: sha512-TivhKE1KO53txHnHp6Hz/wpYVLg9AYUXgzoOX11eytimA3T4BN5sBCAa5cyatidlgUCxIaGlBxOQnETdiRQeXQ==}
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@babel/runtime-corejs3': 7.21.0
+      '@faker-js/faker': 7.6.0
+      '@types/lodash': 4.14.191
+      lodash: 4.17.21
+    dev: false
+
+  /@commercetools-test-data/utils/4.4.0:
+    resolution: {integrity: sha512-o9jafDjtxtRh8VGbBwgfslvmX12CrR3KJaHOMv00KY9kwquoIBk4ppm6srLxe6XkM/HJDU911H4IShjE0KOH4Q==}
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@babel/runtime-corejs3': 7.21.0
+      '@faker-js/faker': 7.6.0
+    dev: false
+
   /@commercetools/platform-sdk/4.5.0:
     resolution: {integrity: sha512-WbvK/FxbYp5FMK7oRdXrMBxX1vGmpZHws9MG/l2g2q7qwGBdqSUxc0hPODJBISNh1LGkzW95MJAcC1ihV0ys7g==}
     engines: {node: '>=14'}
@@ -2424,7 +2481,7 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       buffer: 6.0.3
-      node-fetch: 2.6.7
+      node-fetch: 2.6.9
       querystring: 0.2.1
     transitivePeerDependencies:
       - encoding
@@ -2434,7 +2491,7 @@ packages:
     resolution: {integrity: sha512-XLRm+o3Yd0mkVoyzsOA98PUu0U0ajQdBHMhZ8N2XMOtL4OY8zsgT8ap5JneXV8zWZNiwIYYAYoUDwBlLZh2lAQ==}
     engines: {node: '>=14'}
     dependencies:
-      node-fetch: 2.6.7
+      node-fetch: 2.6.9
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -3036,7 +3093,7 @@ packages:
     resolution: {integrity: sha512-DXx/P1lyunNoFWwOj1MWBucUhaIJljoiAGOpO2fE0GKMBCI6EZBZD0Up1+fQZoXBecKXRgV9mGgLvIB2fOQ0KQ==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.19.4
+      '@babel/runtime': 7.21.0
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       detect-indent: 6.1.0
@@ -3402,6 +3459,10 @@ packages:
     resolution: {integrity: sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==}
     dev: false
 
+  /@types/lodash/4.14.191:
+    resolution: {integrity: sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==}
+    dev: false
+
   /@types/minimist/1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
     dev: false
@@ -3722,7 +3783,7 @@ packages:
     engines: {node: '>=6.0'}
     dependencies:
       '@babel/runtime': 7.21.0
-      '@babel/runtime-corejs3': 7.19.4
+      '@babel/runtime-corejs3': 7.21.0
     dev: false
 
   /aria-query/5.0.2:
@@ -4306,6 +4367,11 @@ packages:
 
   /core-js-pure/3.25.5:
     resolution: {integrity: sha512-oml3M22pHM+igfWHDfdLVq2ShWmjM2V4L+dQEBs0DWVIqEm9WHCwGAlZ6BmyBQGy5sFrJmcx+856D9lVKyGWYg==}
+    requiresBuild: true
+    dev: false
+
+  /core-js-pure/3.29.0:
+    resolution: {integrity: sha512-v94gUjN5UTe1n0yN/opTihJ8QBWD2O8i19RfTZR7foONPWArnjB96QA/wk5ozu1mm6ja3udQCzOzwQXTxi3xOQ==}
     requiresBuild: true
     dev: false
 
@@ -6904,6 +6970,18 @@ packages:
 
   /node-fetch/2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
+  /node-fetch/2.6.9:
+    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,6 +487,7 @@ importers:
       '@commercetools-test-data/cent-precision-money': 4.10.0
       '@commercetools-test-data/commons': 4.10.0
       '@commercetools-test-data/core': 4.10.0
+      '@commercetools-test-data/customer-group': 4.10.0
       '@commercetools-test-data/line-item': 4.10.0
       '@commercetools-test-data/utils': 4.10.0
       '@commercetools/platform-sdk': ^4.5.0
@@ -499,6 +500,7 @@ importers:
       '@commercetools-test-data/cent-precision-money': link:../cent-precision-money
       '@commercetools-test-data/commons': link:../commons
       '@commercetools-test-data/core': link:../../core
+      '@commercetools-test-data/customer-group': link:../customer-group
       '@commercetools-test-data/line-item': link:../line-item
       '@commercetools-test-data/utils': link:../../utils
       '@commercetools/platform-sdk': 4.5.0


### PR DESCRIPTION
## Summary
This PR creates the above models. It also updates the order module's SDK package to include the latest, as some of the documented fields were not included in the types we were using.