### PR TITLE
chore(test-data): create `CustomerDraft` presets

### DIFF
--- a/models/commons/src/address/address-draft/presets/empty.spec.ts
+++ b/models/commons/src/address/address-draft/presets/empty.spec.ts
@@ -1,4 +1,3 @@
-import { fake, oneOf } from '@commercetools-test-data/core';
 import type { TAddressDraft } from '../../types';
 import empty from './empty';
 

--- a/models/commons/src/address/address-draft/presets/empty.spec.ts
+++ b/models/commons/src/address/address-draft/presets/empty.spec.ts
@@ -1,0 +1,35 @@
+import { fake, oneOf } from '@commercetools-test-data/core';
+import type { TAddressDraft } from '../../types';
+import empty from './empty';
+
+it('should set all fields except country to undefined', () => {
+  const emptyAddressDraft = empty().build<TAddressDraft>();
+  expect(emptyAddressDraft).toEqual({
+    id: undefined,
+    key: undefined,
+    title: undefined,
+    salutation: undefined,
+    firstName: undefined,
+    lastName: undefined,
+    streetName: undefined,
+    streetNumber: undefined,
+    additionalStreetInfo: undefined,
+    postalCode: undefined,
+    city: undefined,
+    region: undefined,
+    state: undefined,
+    country: expect.any(String),
+    company: undefined,
+    department: undefined,
+    building: undefined,
+    apartment: undefined,
+    pOBox: undefined,
+    phone: undefined,
+    mobile: undefined,
+    fax: undefined,
+    email: undefined,
+    additionalAddressInfo: undefined,
+    externalId: undefined,
+    custom: undefined,
+  });
+});

--- a/models/commons/src/address/address-draft/presets/empty.ts
+++ b/models/commons/src/address/address-draft/presets/empty.ts
@@ -1,0 +1,32 @@
+import type { TAddressDraftBuilder } from '../../types';
+import AddressDraft from '../builder';
+
+const empty = (): TAddressDraftBuilder =>
+  AddressDraft()
+    .id(undefined)
+    .key(undefined)
+    .title(undefined)
+    .salutation(undefined)
+    .firstName(undefined)
+    .lastName(undefined)
+    .streetName(undefined)
+    .streetNumber(undefined)
+    .additionalStreetInfo(undefined)
+    .postalCode(undefined)
+    .city(undefined)
+    .state(undefined)
+    .region(undefined)
+    .company(undefined)
+    .department(undefined)
+    .building(undefined)
+    .apartment(undefined)
+    .pOBox(undefined)
+    .phone(undefined)
+    .mobile(undefined)
+    .fax(undefined)
+    .email(undefined)
+    .additionalAddressInfo(undefined)
+    .externalId(undefined)
+    .custom(undefined);
+
+export default empty;

--- a/models/commons/src/address/address-draft/presets/index.ts
+++ b/models/commons/src/address/address-draft/presets/index.ts
@@ -1,3 +1,5 @@
-const presets = {};
+import empty from './empty';
+
+const presets = { empty };
 
 export default presets;

--- a/models/customer/package.json
+++ b/models/customer/package.json
@@ -21,6 +21,7 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/commons": "4.10.0",
     "@commercetools-test-data/core": "4.10.0",
+    "@commercetools-test-data/customer-group": "4.10.0",
     "@commercetools-test-data/utils": "4.10.0",
     "@commercetools/platform-sdk": "^4.0.0",
     "@faker-js/faker": "^7.4.0"

--- a/models/customer/src/customer-draft/builder.spec.ts
+++ b/models/customer/src/customer-draft/builder.spec.ts
@@ -28,7 +28,13 @@ describe('builder', () => {
         vatId: expect.any(String),
         isEmailVerified: expect.any(Boolean),
         customerGroup: null,
-        addresses: null,
+        addresses: expect.arrayContaining([
+          expect.objectContaining({
+            city: expect.any(String),
+            firstName: expect.any(String),
+            lastName: expect.any(String),
+          }),
+        ]),
         defaultBillingAddress: null,
         billingAddresses: null,
         defaultShippingAddress: null,
@@ -62,7 +68,13 @@ describe('builder', () => {
         vatId: expect.any(String),
         isEmailVerified: expect.any(Boolean),
         customerGroup: null,
-        addresses: null,
+        addresses: expect.arrayContaining([
+          expect.objectContaining({
+            city: expect.any(String),
+            firstName: expect.any(String),
+            lastName: expect.any(String),
+          }),
+        ]),
         defaultBillingAddress: null,
         billingAddresses: null,
         defaultShippingAddress: null,
@@ -97,7 +109,14 @@ describe('builder', () => {
         vatId: expect.any(String),
         isEmailVerified: expect.any(Boolean),
         customerGroup: null,
-        addresses: null,
+        addresses: expect.arrayContaining([
+          expect.objectContaining({
+            city: expect.any(String),
+            firstName: expect.any(String),
+            lastName: expect.any(String),
+            __typename: 'AddressDraft',
+          }),
+        ]),
         defaultBillingAddress: null,
         billingAddresses: null,
         defaultShippingAddress: null,

--- a/models/customer/src/customer-draft/generator.ts
+++ b/models/customer/src/customer-draft/generator.ts
@@ -1,3 +1,4 @@
+import { AddressDraft } from '@commercetools-test-data/commons';
 import { fake, Generator, oneOf } from '@commercetools-test-data/core';
 import { TCustomerDraft } from '../types';
 
@@ -24,7 +25,7 @@ const generator = Generator<TCustomerDraft>({
     vatId: fake((f) => f.random.alphaNumeric(12)),
     isEmailVerified: fake((f) => f.datatype.boolean()),
     customerGroup: null,
-    addresses: null,
+    addresses: fake(() => [AddressDraft.random()]),
     defaultBillingAddress: null,
     billingAddresses: null,
     defaultShippingAddress: null,

--- a/models/customer/src/customer-draft/presets/empty.spec.ts
+++ b/models/customer/src/customer-draft/presets/empty.spec.ts
@@ -1,0 +1,33 @@
+import type { TCustomerDraft } from '../../types';
+import empty from './empty';
+
+it('should set all fields except `email` to undefined', () => {
+  const emptyCustomerDraft = empty().build<TCustomerDraft>();
+  expect(emptyCustomerDraft).toEqual({
+    customerNumber: undefined,
+    email: expect.any(String),
+    key: undefined,
+    password: undefined,
+    stores: undefined,
+    firstName: undefined,
+    lastName: undefined,
+    middleName: undefined,
+    title: undefined,
+    salutation: undefined,
+    anonymousCart: undefined,
+    anonymousId: undefined,
+    externalId: undefined,
+    dateOfBirth: undefined,
+    companyName: undefined,
+    vatId: undefined,
+    isEmailVerified: undefined,
+    customerGroup: undefined,
+    addresses: undefined,
+    defaultBillingAddress: undefined,
+    billingAddresses: undefined,
+    defaultShippingAddress: undefined,
+    shippingAddresses: undefined,
+    custom: undefined,
+    locale: undefined,
+  });
+});

--- a/models/customer/src/customer-draft/presets/empty.ts
+++ b/models/customer/src/customer-draft/presets/empty.ts
@@ -1,0 +1,31 @@
+import type { TCustomerDraftBuilder } from '../../types';
+import CustomerDraft from '../builder';
+
+const empty = (): TCustomerDraftBuilder =>
+  CustomerDraft()
+    .customerNumber(undefined)
+    .key(undefined)
+    .password(undefined)
+    .stores(undefined)
+    .firstName(undefined)
+    .lastName(undefined)
+    .middleName(undefined)
+    .title(undefined)
+    .salutation(undefined)
+    .anonymousCart(undefined)
+    .anonymousId(undefined)
+    .externalId(undefined)
+    .dateOfBirth(undefined)
+    .companyName(undefined)
+    .vatId(undefined)
+    .isEmailVerified(undefined)
+    .customerGroup(undefined)
+    .addresses(undefined)
+    .defaultBillingAddress(undefined)
+    .billingAddresses(undefined)
+    .defaultShippingAddress(undefined)
+    .shippingAddresses(undefined)
+    .custom(undefined)
+    .locale(undefined);
+
+export default empty;

--- a/models/customer/src/customer-draft/presets/index.ts
+++ b/models/customer/src/customer-draft/presets/index.ts
@@ -1,5 +1,6 @@
+import empty from './empty';
 import sampleDataFashion from './sample-data-fashion';
 
-const presets = { sampleDataFashion };
+const presets = { sampleDataFashion, empty };
 
 export default presets;

--- a/models/customer/src/customer-draft/presets/index.ts
+++ b/models/customer/src/customer-draft/presets/index.ts
@@ -1,3 +1,5 @@
-const presets = {};
+import sampleDataFashion from './sample-data-fashion';
+
+const presets = { sampleDataFashion };
 
 export default presets;

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/index.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/index.ts
@@ -1,0 +1,11 @@
+import jamieDoe from './jamie-doe';
+import johnDoe from './john-doe';
+import marySmith from './mary-smith';
+
+const presets = {
+  jamieDoe,
+  johnDoe,
+  marySmith,
+};
+
+export default presets;

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.spec.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.spec.ts
@@ -9,19 +9,20 @@ describe('with the preset `jamieDoe`', () => {
     expect(customer.email).toMatchInlineSnapshot(`"jamie.doe@example.com"`);
     expect(customer.firstName).toMatchInlineSnapshot(`"Jamie"`);
     expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
-    //   expect(customer.addresses).toMatchInlineSnapshot(`
-    //     [{
-    //       "firstName": "Jamie",
-    //       "lastName": "Doe",
-    //       "streetName": "Main Street",
-    //       "streetNumber": "1",
-    //       "postalCode": "56789",
-    //       "city": "Mainville",
-    //       "state": "New Jersey",
-    //       "country": "US",
-    //     }]
-    //   `);
+
+    expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"Jamie"`);
+    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Doe"`);
+    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
+      `"Main Street"`
+    );
+    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"56789"`);
+    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Mainville"`);
+    expect(customer.addresses![0].state).toMatchInlineSnapshot(`"New Jersey"`);
+    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"US"`);
+
     expect(customer.customerGroup!.key).toMatchInlineSnapshot('"vip"');
+    expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);
   });
 
   it('should return a customer draft with name `Jamie Doe` when built for GraphQL', () => {
@@ -31,18 +32,19 @@ describe('with the preset `jamieDoe`', () => {
     expect(customer.email).toMatchInlineSnapshot(`"jamie.doe@example.com"`);
     expect(customer.firstName).toMatchInlineSnapshot(`"Jamie"`);
     expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
-    //   expect(customer.addresses).toMatchInlineSnapshot(`
-    //     [{
-    //       "firstName": "Jamie",
-    //       "lastName": "Doe",
-    //       "streetName": "Main Street",
-    //       "streetNumber": "1",
-    //       "postalCode": "56789",
-    //       "city": "Mainville",
-    //       "state": "New Jersey",
-    //       "country": "US",
-    //     }]
-    //   `);
+
+    expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"Jamie"`);
+    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Doe"`);
+    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
+      `"Main Street"`
+    );
+    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"56789"`);
+    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Mainville"`);
+    expect(customer.addresses![0].state).toMatchInlineSnapshot(`"New Jersey"`);
+    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"US"`);
+
     expect(customer.customerGroup!.key).toMatchInlineSnapshot('"vip"');
+    expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);
   });
 });

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.spec.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.spec.ts
@@ -1,0 +1,48 @@
+import { TCustomerDraft, TCustomerDraftGraphql } from '../../../types';
+import jamieDoe from './jamie-doe';
+
+describe('with the preset `jamieDoe`', () => {
+  it('should return a customer draft with name `Jamie Doe`', () => {
+    const customer = jamieDoe().build<TCustomerDraft>();
+
+    expect(customer.key).toMatchInlineSnapshot(`"12345"`);
+    expect(customer.email).toMatchInlineSnapshot(`"jamie.doe@example.com"`);
+    expect(customer.firstName).toMatchInlineSnapshot(`"Jamie"`);
+    expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
+    //   expect(customer.addresses).toMatchInlineSnapshot(`
+    //     [{
+    //       "firstName": "Jamie",
+    //       "lastName": "Doe",
+    //       "streetName": "Main Street",
+    //       "streetNumber": "1",
+    //       "postalCode": "56789",
+    //       "city": "Mainville",
+    //       "state": "New Jersey",
+    //       "country": "US",
+    //     }]
+    //   `);
+    expect(customer.customerGroup!.key).toMatchInlineSnapshot('"vip"');
+  });
+
+  it('should return a customer draft with name `Jamie Doe` when built for GraphQL', () => {
+    const customer = jamieDoe().buildGraphql<TCustomerDraftGraphql>();
+
+    expect(customer.key).toMatchInlineSnapshot(`"12345"`);
+    expect(customer.email).toMatchInlineSnapshot(`"jamie.doe@example.com"`);
+    expect(customer.firstName).toMatchInlineSnapshot(`"Jamie"`);
+    expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
+    //   expect(customer.addresses).toMatchInlineSnapshot(`
+    //     [{
+    //       "firstName": "Jamie",
+    //       "lastName": "Doe",
+    //       "streetName": "Main Street",
+    //       "streetNumber": "1",
+    //       "postalCode": "56789",
+    //       "city": "Mainville",
+    //       "state": "New Jersey",
+    //       "country": "US",
+    //     }]
+    //   `);
+    expect(customer.customerGroup!.key).toMatchInlineSnapshot('"vip"');
+  });
+});

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.ts
@@ -1,15 +1,16 @@
 import { AddressDraft, Reference } from '@commercetools-test-data/commons';
 import type { TCustomerGroupDraft } from '@commercetools-test-data/customer-group';
 import * as CustomerGroup from '@commercetools-test-data/customer-group';
+import * as CustomerDraft from '../../';
 import { TCustomerDraftBuilder } from '../../../types';
-import CustomerDraft from '../../builder';
 
 const customerGroup = CustomerGroup.draftPresets.sampleDataFashion
   .vip()
   .build<TCustomerGroupDraft>();
 
 const jamieDoe = (): TCustomerDraftBuilder =>
-  CustomerDraft()
+  CustomerDraft.presets
+    .empty()
     .key('12345')
     .email('jamie.doe@example.com')
     .firstName('Jamie')

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.ts
@@ -1,0 +1,33 @@
+import { AddressDraft, Reference } from '@commercetools-test-data/commons';
+import * as CustomerGroup from '@commercetools-test-data/customer-group';
+import type { TCustomerGroupDraft } from '@commercetools-test-data/customer-group';
+import { TCustomerDraftBuilder } from '../../../types';
+import CustomerDraft from '../../builder';
+
+const customerGroup = CustomerGroup.draftPresets.sampleDataFashion
+  .vip()
+  .build<TCustomerGroupDraft>();
+
+const jamieDoe = (): TCustomerDraftBuilder =>
+  CustomerDraft()
+    .key('12345')
+    .email('jamie.doe@example.com')
+    .firstName('Jamie')
+    .lastName('Doe')
+    .addresses([
+      AddressDraft.presets
+        .empty()
+        .firstName('Jamie')
+        .lastName('Doe')
+        .streetName('Main Street')
+        .streetNumber('1')
+        .postalCode('56789')
+        .city('Mainville')
+        .state('New Jersey')
+        .country('US'),
+    ])
+    .customerGroup(
+      Reference.random().key(customerGroup.key!).typeId('customer-group')
+    );
+
+export default jamieDoe;

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.ts
@@ -1,6 +1,6 @@
 import { AddressDraft, Reference } from '@commercetools-test-data/commons';
-import * as CustomerGroup from '@commercetools-test-data/customer-group';
 import type { TCustomerGroupDraft } from '@commercetools-test-data/customer-group';
+import * as CustomerGroup from '@commercetools-test-data/customer-group';
 import { TCustomerDraftBuilder } from '../../../types';
 import CustomerDraft from '../../builder';
 
@@ -28,6 +28,7 @@ const jamieDoe = (): TCustomerDraftBuilder =>
     ])
     .customerGroup(
       Reference.random().key(customerGroup.key!).typeId('customer-group')
-    );
+    )
+    .isEmailVerified(false);
 
 export default jamieDoe;

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.spec.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.spec.ts
@@ -5,44 +5,44 @@ describe('with the preset `johnDoe`', () => {
   it('should return a customer draft with name `John Doe`', () => {
     const customer = johnDoe().build<TCustomerDraft>();
 
-    expect(customer.key).toMatchInlineSnapshot(`"12345"`);
-    expect(customer.email).toMatchInlineSnapshot(`"jamie.doe@example.com"`);
-    expect(customer.firstName).toMatchInlineSnapshot(`"Jamie"`);
+    expect(customer.key).toMatchInlineSnapshot(`"1234"`);
+    expect(customer.email).toMatchInlineSnapshot(`"john.doe@example.com"`);
+    expect(customer.firstName).toMatchInlineSnapshot(`"John"`);
     expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
-    //   expect(customer.addresses).toMatchInlineSnapshot(`
-    //     [{
-    //       "firstName": "Jamie",
-    //       "lastName": "Doe",
-    //       "streetName": "Main Street",
-    //       "streetNumber": "1",
-    //       "postalCode": "56789",
-    //       "city": "Mainville",
-    //       "state": "New Jersey",
-    //       "country": "US",
-    //     }]
-    //   `);
-    expect(customer.customerGroup!.key).toMatchInlineSnapshot('"vip"');
+
+    expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"John"`);
+    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Doe"`);
+    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
+      `"Center Road"`
+    );
+    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"34567"`);
+    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Center Town"`);
+    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"DE"`);
+
+    expect(customer.customerGroup!.key).toMatchInlineSnapshot('"employee"');
+    expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);
   });
 
   it('should return a customer draft with name `John Doe` when built for GraphQL', () => {
     const customer = johnDoe().buildGraphql<TCustomerDraftGraphql>();
 
-    expect(customer.key).toMatchInlineSnapshot(`"12345"`);
-    expect(customer.email).toMatchInlineSnapshot(`"jamie.doe@example.com"`);
-    expect(customer.firstName).toMatchInlineSnapshot(`"Jamie"`);
+    expect(customer.key).toMatchInlineSnapshot(`"1234"`);
+    expect(customer.email).toMatchInlineSnapshot(`"john.doe@example.com"`);
+    expect(customer.firstName).toMatchInlineSnapshot(`"John"`);
     expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
-    //   expect(customer.addresses).toMatchInlineSnapshot(`
-    //     [{
-    //       "firstName": "Jamie",
-    //       "lastName": "Doe",
-    //       "streetName": "Main Street",
-    //       "streetNumber": "1",
-    //       "postalCode": "56789",
-    //       "city": "Mainville",
-    //       "state": "New Jersey",
-    //       "country": "US",
-    //     }]
-    //   `);
-    expect(customer.customerGroup!.key).toMatchInlineSnapshot('"vip"');
+
+    expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"John"`);
+    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Doe"`);
+    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
+      `"Center Road"`
+    );
+    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"34567"`);
+    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Center Town"`);
+    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"DE"`);
+
+    expect(customer.customerGroup!.key).toMatchInlineSnapshot('"employee"');
+    expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);
   });
 });

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.spec.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.spec.ts
@@ -1,0 +1,48 @@
+import { TCustomerDraft, TCustomerDraftGraphql } from '../../../types';
+import johnDoe from './john-doe';
+
+describe('with the preset `johnDoe`', () => {
+  it('should return a customer draft with name `John Doe`', () => {
+    const customer = johnDoe().build<TCustomerDraft>();
+
+    expect(customer.key).toMatchInlineSnapshot(`"12345"`);
+    expect(customer.email).toMatchInlineSnapshot(`"jamie.doe@example.com"`);
+    expect(customer.firstName).toMatchInlineSnapshot(`"Jamie"`);
+    expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
+    //   expect(customer.addresses).toMatchInlineSnapshot(`
+    //     [{
+    //       "firstName": "Jamie",
+    //       "lastName": "Doe",
+    //       "streetName": "Main Street",
+    //       "streetNumber": "1",
+    //       "postalCode": "56789",
+    //       "city": "Mainville",
+    //       "state": "New Jersey",
+    //       "country": "US",
+    //     }]
+    //   `);
+    expect(customer.customerGroup!.key).toMatchInlineSnapshot('"vip"');
+  });
+
+  it('should return a customer draft with name `John Doe` when built for GraphQL', () => {
+    const customer = johnDoe().buildGraphql<TCustomerDraftGraphql>();
+
+    expect(customer.key).toMatchInlineSnapshot(`"12345"`);
+    expect(customer.email).toMatchInlineSnapshot(`"jamie.doe@example.com"`);
+    expect(customer.firstName).toMatchInlineSnapshot(`"Jamie"`);
+    expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
+    //   expect(customer.addresses).toMatchInlineSnapshot(`
+    //     [{
+    //       "firstName": "Jamie",
+    //       "lastName": "Doe",
+    //       "streetName": "Main Street",
+    //       "streetNumber": "1",
+    //       "postalCode": "56789",
+    //       "city": "Mainville",
+    //       "state": "New Jersey",
+    //       "country": "US",
+    //     }]
+    //   `);
+    expect(customer.customerGroup!.key).toMatchInlineSnapshot('"vip"');
+  });
+});

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.ts
@@ -1,0 +1,31 @@
+import { AddressDraft, Reference } from '@commercetools-test-data/commons';
+import * as CustomerGroup from '@commercetools-test-data/customer-group';
+import type { TCustomerGroupDraft } from '@commercetools-test-data/customer-group';
+import { TCustomerDraftBuilder } from '../../../types';
+import CustomerDraft from '../../builder';
+
+const customerGroup = CustomerGroup.draftPresets.sampleDataFashion
+  .employee()
+  .build<TCustomerGroupDraft>();
+
+const johnDoe = (): TCustomerDraftBuilder =>
+  CustomerDraft()
+    .key('1234')
+    .email('john.doe@example.com')
+    .firstName('John')
+    .lastName('Doe')
+    .addresses([
+      AddressDraft.random()
+        .firstName('Jamie')
+        .lastName('Doe')
+        .streetName('Center Road')
+        .streetNumber('1')
+        .postalCode('34567')
+        .city('Center Town')
+        .country('DE'),
+    ])
+    .customerGroup(
+      Reference.random().key(customerGroup.key!).typeId('customer-group')
+    );
+
+export default johnDoe;

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.ts
@@ -15,8 +15,9 @@ const johnDoe = (): TCustomerDraftBuilder =>
     .firstName('John')
     .lastName('Doe')
     .addresses([
-      AddressDraft.random()
-        .firstName('Jamie')
+      AddressDraft.presets
+        .empty()
+        .firstName('John')
         .lastName('Doe')
         .streetName('Center Road')
         .streetNumber('1')
@@ -26,6 +27,7 @@ const johnDoe = (): TCustomerDraftBuilder =>
     ])
     .customerGroup(
       Reference.random().key(customerGroup.key!).typeId('customer-group')
-    );
+    )
+    .isEmailVerified(false);
 
 export default johnDoe;

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.ts
@@ -1,15 +1,16 @@
 import { AddressDraft, Reference } from '@commercetools-test-data/commons';
 import * as CustomerGroup from '@commercetools-test-data/customer-group';
 import type { TCustomerGroupDraft } from '@commercetools-test-data/customer-group';
+import * as CustomerDraft from '../../';
 import { TCustomerDraftBuilder } from '../../../types';
-import CustomerDraft from '../../builder';
 
 const customerGroup = CustomerGroup.draftPresets.sampleDataFashion
   .employee()
   .build<TCustomerGroupDraft>();
 
 const johnDoe = (): TCustomerDraftBuilder =>
-  CustomerDraft()
+  CustomerDraft.presets
+    .empty()
     .key('1234')
     .email('john.doe@example.com')
     .firstName('John')

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.spec.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.spec.ts
@@ -1,0 +1,46 @@
+import { TCustomerDraft, TCustomerDraftGraphql } from '../../../types';
+import marySmith from './mary-smith';
+
+describe('with the preset `marySmith`', () => {
+  it('should return a customer draft with name `Mary`', () => {
+    const customer = marySmith().build<TCustomerDraft>();
+
+    expect(customer.key).toMatchInlineSnapshot(`"123456"`);
+    expect(customer.email).toMatchInlineSnapshot(`"mary.smith@example.com"`);
+    expect(customer.firstName).toMatchInlineSnapshot(`"Mary"`);
+    expect(customer.lastName).toMatchInlineSnapshot(`"Smith"`);
+
+    expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"Mary"`);
+    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Smith"`);
+    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
+      `"Sample Street"`
+    );
+    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"12345"`);
+    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Sample Town"`);
+    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"DE"`);
+
+    expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);
+  });
+
+  it('should return a customer draft with name `Mary` when built for GraphQL', () => {
+    const customer = marySmith().buildGraphql<TCustomerDraftGraphql>();
+
+    expect(customer.key).toMatchInlineSnapshot(`"123456"`);
+    expect(customer.email).toMatchInlineSnapshot(`"mary.smith@example.com"`);
+    expect(customer.firstName).toMatchInlineSnapshot(`"Mary"`);
+    expect(customer.lastName).toMatchInlineSnapshot(`"Smith"`);
+
+    expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"Mary"`);
+    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Smith"`);
+    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
+      `"Sample Street"`
+    );
+    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"12345"`);
+    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Sample Town"`);
+    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"DE"`);
+
+    expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);
+  });
+});

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.ts
@@ -1,6 +1,4 @@
-import { AddressDraft, Reference } from '@commercetools-test-data/commons';
-import * as CustomerGroup from '@commercetools-test-data/customer-group';
-import type { TCustomerGroupDraft } from '@commercetools-test-data/customer-group';
+import { AddressDraft } from '@commercetools-test-data/commons';
 import { TCustomerDraftBuilder } from '../../../types';
 import CustomerDraft from '../../builder';
 
@@ -11,7 +9,8 @@ const marySmith = (): TCustomerDraftBuilder =>
     .firstName('Mary')
     .lastName('Smith')
     .addresses([
-      AddressDraft.random()
+      AddressDraft.presets
+        .empty()
         .firstName('Mary')
         .lastName('Smith')
         .streetName('Sample Street')
@@ -19,6 +18,7 @@ const marySmith = (): TCustomerDraftBuilder =>
         .postalCode('12345')
         .city('Sample Town')
         .country('DE'),
-    ]);
+    ])
+    .isEmailVerified(false);
 
 export default marySmith;

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.ts
@@ -1,9 +1,10 @@
 import { AddressDraft } from '@commercetools-test-data/commons';
+import * as CustomerDraft from '../../';
 import { TCustomerDraftBuilder } from '../../../types';
-import CustomerDraft from '../../builder';
 
 const marySmith = (): TCustomerDraftBuilder =>
-  CustomerDraft()
+  CustomerDraft.presets
+    .empty()
     .key('123456')
     .email('mary.smith@example.com')
     .firstName('Mary')

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.ts
@@ -1,0 +1,24 @@
+import { AddressDraft, Reference } from '@commercetools-test-data/commons';
+import * as CustomerGroup from '@commercetools-test-data/customer-group';
+import type { TCustomerGroupDraft } from '@commercetools-test-data/customer-group';
+import { TCustomerDraftBuilder } from '../../../types';
+import CustomerDraft from '../../builder';
+
+const marySmith = (): TCustomerDraftBuilder =>
+  CustomerDraft()
+    .key('123456')
+    .email('mary.smith@example.com')
+    .firstName('Mary')
+    .lastName('Smith')
+    .addresses([
+      AddressDraft.random()
+        .firstName('Mary')
+        .lastName('Smith')
+        .streetName('Sample Street')
+        .streetNumber('1')
+        .postalCode('12345')
+        .city('Sample Town')
+        .country('DE'),
+    ]);
+
+export default marySmith;

--- a/models/customer/src/customer-draft/transformers.ts
+++ b/models/customer/src/customer-draft/transformers.ts
@@ -3,13 +3,13 @@ import type { TCustomerDraft, TCustomerDraftGraphql } from '../types';
 
 const transformers = {
   default: Transformer<TCustomerDraft, TCustomerDraft>('default', {
-    buildFields: [],
+    buildFields: ['addresses', 'customerGroup'],
   }),
   rest: Transformer<TCustomerDraft, TCustomerDraft>('rest', {
-    buildFields: [],
+    buildFields: ['addresses', 'customerGroup'],
   }),
   graphql: Transformer<TCustomerDraft, TCustomerDraftGraphql>('graphql', {
-    buildFields: [],
+    buildFields: ['addresses', 'customerGroup'],
     addFields: () => ({
       __typename: 'CustomerDraft',
     }),

--- a/models/customer/src/index.ts
+++ b/models/customer/src/index.ts
@@ -3,4 +3,5 @@ export { CustomerDraft };
 
 export { default as random } from './builder';
 export { default as presets } from './presets';
+export { default as draftPresets } from './customer-draft/presets';
 export * from './types';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,7 @@ importers:
       '@babel/runtime-corejs3': ^7.17.9
       '@commercetools-test-data/commons': 4.10.0
       '@commercetools-test-data/core': 4.10.0
+      '@commercetools-test-data/customer-group': 4.10.0
       '@commercetools-test-data/utils': 4.10.0
       '@commercetools/platform-sdk': ^4.0.0
       '@faker-js/faker': ^7.4.0
@@ -368,6 +369,7 @@ importers:
       '@babel/runtime-corejs3': 7.19.4
       '@commercetools-test-data/commons': link:../commons
       '@commercetools-test-data/core': link:../../core
+      '@commercetools-test-data/customer-group': link:../customer-group
       '@commercetools-test-data/utils': link:../../utils
       '@commercetools/platform-sdk': 4.5.0
       '@faker-js/faker': 7.6.0


### PR DESCRIPTION
## Summary

This PR creates three presets for FCT's test data, for `CustomerDraft` models 🌈 🕺 

## Description

@stephsprinkle had the solid idea to go ahead and create `empty()` preset functionality for each model, that we use to effectively "clear" the data before replacing it with our own. This way, when we use these presets in merchant center services, we don't end up with spoofed fields that will eventually get considered in a graphql request.

It also fixes a failed test that didn't check for newly build fields included in `buildFields`