### PR TITLE
chore: remove unused lodash dep in some models

### DIFF
--- a/core/src/@jackfranklin/test-data-bot/index.ts
+++ b/core/src/@jackfranklin/test-data-bot/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Faker } from '@faker-js/faker';
 import { faker } from '@faker-js/faker';
-import { mapValues } from 'lodash';
+import mapValues from 'lodash/mapValues';
 
 export type SequenceFunction = (counter: number) => unknown;
 

--- a/models/category/package.json
+++ b/models/category/package.json
@@ -23,8 +23,6 @@
     "@commercetools-test-data/core": "4.11.1",
     "@commercetools-test-data/utils": "4.11.1",
     "@commercetools/platform-sdk": "^4.0.0",
-    "@faker-js/faker": "^7.4.0",
-    "@types/lodash": "^4.14.182",
-    "lodash": "^4.17.21"
+    "@faker-js/faker": "^7.4.0"
   }
 }

--- a/models/customer-group/package.json
+++ b/models/customer-group/package.json
@@ -23,7 +23,6 @@
     "@commercetools-test-data/core": "4.11.1",
     "@commercetools-test-data/utils": "4.11.1",
     "@commercetools/platform-sdk": "^4.0.0",
-    "@faker-js/faker": "^7.4.0",
-    "lodash": "^4.17.21"
+    "@faker-js/faker": "^7.4.0"
   }
 }

--- a/models/image/package.json
+++ b/models/image/package.json
@@ -23,7 +23,6 @@
     "@commercetools-test-data/core": "4.11.1",
     "@commercetools-test-data/utils": "4.11.1",
     "@commercetools/platform-sdk": "^4.0.0",
-    "@faker-js/faker": "^7.4.0",
-    "lodash": "^4.17.21"
+    "@faker-js/faker": "^7.4.0"
   }
 }

--- a/models/zone/package.json
+++ b/models/zone/package.json
@@ -23,7 +23,6 @@
     "@commercetools-test-data/core": "4.11.1",
     "@commercetools-test-data/utils": "4.11.1",
     "@commercetools/platform-sdk": "^4.0.0",
-    "@faker-js/faker": "^7.4.0",
-    "lodash": "^4.17.21"
+    "@faker-js/faker": "^7.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,12 +400,6 @@ importers:
       '@faker-js/faker':
         specifier: ^7.4.0
         version: 7.6.0
-      '@types/lodash':
-        specifier: ^4.14.182
-        version: 4.14.186
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
 
   models/cent-precision-money:
     dependencies:
@@ -529,9 +523,6 @@ importers:
       '@faker-js/faker':
         specifier: ^7.4.0
         version: 7.6.0
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
 
   models/discount-code:
     dependencies:
@@ -580,9 +571,6 @@ importers:
       '@faker-js/faker':
         specifier: ^7.4.0
         version: 7.6.0
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
 
   models/line-item:
     dependencies:
@@ -1078,9 +1066,6 @@ importers:
       '@faker-js/faker':
         specifier: ^7.4.0
         version: 7.6.0
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
 
   utils:
     dependencies:


### PR DESCRIPTION
This PR was initially intended to change the imports of lodash to `lodash/utility` to provide consistency with other repos  but then I found some instances where `lodash` was added into models and never used so I removed those as well. I hope that's okay 😅 