### PR TITLE
chore(test-data): create `discountCodeDraft` presets

### DIFF
--- a/.changeset/nice-toys-divide.md
+++ b/.changeset/nice-toys-divide.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/discount-code': patch
+---
+
+create discount code draft presets

--- a/.changeset/nice-toys-divide.md
+++ b/.changeset/nice-toys-divide.md
@@ -1,5 +1,5 @@
 ---
-'@commercetools-test-data/discount-code': patch
+'@commercetools-test-data/discount-code': minor
 ---
 
 create discount code draft presets

--- a/models/discount-code/src/discount-code-draft/presets/empty.spec.ts
+++ b/models/discount-code/src/discount-code-draft/presets/empty.spec.ts
@@ -1,0 +1,19 @@
+import type { TDiscountCodeDraft } from '../../types';
+import empty from './empty';
+
+it('should set all fields except `code` and `cartDiscounts` to undefined', () => {
+  const emptyDiscountCodeDraft = empty().build<TDiscountCodeDraft>();
+  expect(emptyDiscountCodeDraft).toEqual({
+    cartDiscounts: expect.any(Array),
+    code: expect.any(String),
+    cartPredicate: undefined,
+    description: undefined,
+    groups: undefined,
+    isActive: undefined,
+    maxApplications: undefined,
+    maxApplicationsPerCustomer: undefined,
+    name: undefined,
+    validFrom: undefined,
+    validUntil: undefined,
+  });
+});

--- a/models/discount-code/src/discount-code-draft/presets/empty.ts
+++ b/models/discount-code/src/discount-code-draft/presets/empty.ts
@@ -1,0 +1,17 @@
+import type { TDiscountCodeDraftBuilder } from '../../types';
+import DiscountCode from '../builder';
+
+const empty = (): TDiscountCodeDraftBuilder =>
+  DiscountCode()
+    .cartPredicate(undefined)
+    .custom(undefined)
+    .description(undefined)
+    .groups(undefined)
+    .isActive(undefined)
+    .maxApplications(undefined)
+    .maxApplicationsPerCustomer(undefined)
+    .name(undefined)
+    .validFrom(undefined)
+    .validUntil(undefined);
+
+export default empty;

--- a/models/discount-code/src/discount-code-draft/presets/index.ts
+++ b/models/discount-code/src/discount-code-draft/presets/index.ts
@@ -1,3 +1,6 @@
-const presets = {};
+import empty from './empty';
+import sampleDataFashion from './sample-data-fashion';
+
+const presets = { empty, sampleDataFashion };
 
 export default presets;

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.spec.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.spec.ts
@@ -1,0 +1,61 @@
+import { TDiscountCodeDraftGraphql, TDiscountCodeDraft } from '../../../types';
+import employeeSale from './employee-sale';
+
+describe('with the preset `employeeSale`', () => {
+  it('should return a discount code draft', () => {
+    const discountCodeDraft = employeeSale().build<TDiscountCodeDraft>();
+
+    expect(discountCodeDraft.code).toMatchInlineSnapshot(`"emp15"`);
+    expect(discountCodeDraft.name).toMatchInlineSnapshot(`
+      {
+        "de": undefined,
+        "en": undefined,
+        "en-US": "Employee Sale",
+        "fr": undefined,
+      }
+    `);
+    expect(discountCodeDraft.description).toMatchInlineSnapshot(`
+      {
+        "de": undefined,
+        "en": undefined,
+        "fr": undefined,
+      }
+    `);
+    expect(discountCodeDraft.cartDiscounts[0].key).toMatchInlineSnapshot(
+      `"EmployeeSale"`
+    );
+    expect(discountCodeDraft.cartDiscounts[0].typeId).toMatchInlineSnapshot(
+      `"cart-discount"`
+    );
+    expect(discountCodeDraft.isActive).toMatchInlineSnapshot(`true`);
+    expect(discountCodeDraft.groups).toMatchInlineSnapshot(`[]`);
+  });
+
+  it('should return a discount code draft when built for GraphQL', () => {
+    const discountCodeDraft =
+      employeeSale().buildGraphql<TDiscountCodeDraftGraphql>();
+
+    expect(discountCodeDraft.code).toMatchInlineSnapshot(`"emp15"`);
+    expect(discountCodeDraft.name).toMatchInlineSnapshot(`
+      [
+        {
+          "__typename": "LocalizedString",
+          "locale": "en-US",
+          "value": "Employee Sale",
+        },
+      ]
+    `);
+    expect(discountCodeDraft.description).toMatchInlineSnapshot(`[]`);
+    expect(discountCodeDraft.cartDiscounts[0].key).toMatchInlineSnapshot(
+      `"EmployeeSale"`
+    );
+    expect(discountCodeDraft.cartDiscounts[0].typeId).toMatchInlineSnapshot(
+      `"cart-discount"`
+    );
+    expect(discountCodeDraft.isActive).toMatchInlineSnapshot(`true`);
+    expect(discountCodeDraft.groups).toMatchInlineSnapshot(`[]`);
+    expect(discountCodeDraft.__typename).toMatchInlineSnapshot(
+      `"DiscountCodeDraft"`
+    );
+  });
+});

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.ts
@@ -1,0 +1,18 @@
+import { LocalizedString, Reference } from '@commercetools-test-data/commons';
+import * as DiscountCodeDraft from '../..';
+import { TDiscountCodeDraftBuilder } from '../../../types';
+
+const employeeSale = (): TDiscountCodeDraftBuilder =>
+  DiscountCodeDraft.presets
+    .empty()
+    .code('emp15')
+    .name(LocalizedString.presets.empty()['en-US']('Employee Sale'))
+    .description(LocalizedString.presets.empty())
+    // TODO: use the cart discount preset key here when available
+    .cartDiscounts([
+      Reference.random().key('EmployeeSale').typeId('cart-discount'),
+    ])
+    .isActive(true)
+    .groups([]);
+
+export default employeeSale;

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/index.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/index.ts
@@ -1,0 +1,9 @@
+import employeeSale from './employee-sale';
+import shirtsBogo from './shirts-bogo';
+
+const presets = {
+  employeeSale,
+  shirtsBogo,
+};
+
+export default presets;

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
@@ -1,0 +1,69 @@
+import { TDiscountCodeDraftGraphql, TDiscountCodeDraft } from '../../../types';
+import shirtsBogo from './shirts-bogo';
+
+describe('with the preset `employeeSale`', () => {
+  it('should return a discount code draft', () => {
+    const discountCodeDraft = shirtsBogo().build<TDiscountCodeDraft>();
+
+    expect(discountCodeDraft.code).toMatchInlineSnapshot(`"BOGO"`);
+    expect(discountCodeDraft.name).toMatchInlineSnapshot(`
+      {
+        "de": undefined,
+        "en": undefined,
+        "en-US": "BOGO",
+        "fr": undefined,
+      }
+    `);
+    expect(discountCodeDraft.description).toMatchInlineSnapshot(`
+      {
+        "de": undefined,
+        "en": undefined,
+        "fr": undefined,
+      }
+    `);
+    expect(discountCodeDraft.cartDiscounts[0].key).toMatchInlineSnapshot(
+      `"ShirtsBOGO"`
+    );
+    expect(discountCodeDraft.cartDiscounts[0].typeId).toMatchInlineSnapshot(
+      `"cart-discount"`
+    );
+    expect(discountCodeDraft.isActive).toMatchInlineSnapshot(`true`);
+    expect(discountCodeDraft.groups).toMatchInlineSnapshot(`[]`);
+    expect(discountCodeDraft.maxApplications).toMatchInlineSnapshot(`1`);
+    expect(discountCodeDraft.maxApplicationsPerCustomer).toMatchInlineSnapshot(
+      `1`
+    );
+  });
+
+  it('should return a discount code draft when built for GraphQL', () => {
+    const discountCodeDraft =
+      shirtsBogo().buildGraphql<TDiscountCodeDraftGraphql>();
+
+    expect(discountCodeDraft.code).toMatchInlineSnapshot(`"BOGO"`);
+    expect(discountCodeDraft.name).toMatchInlineSnapshot(`
+      [
+        {
+          "__typename": "LocalizedString",
+          "locale": "en-US",
+          "value": "BOGO",
+        },
+      ]
+    `);
+    expect(discountCodeDraft.description).toMatchInlineSnapshot(`[]`);
+    expect(discountCodeDraft.cartDiscounts[0].key).toMatchInlineSnapshot(
+      `"ShirtsBOGO"`
+    );
+    expect(discountCodeDraft.cartDiscounts[0].typeId).toMatchInlineSnapshot(
+      `"cart-discount"`
+    );
+    expect(discountCodeDraft.isActive).toMatchInlineSnapshot(`true`);
+    expect(discountCodeDraft.groups).toMatchInlineSnapshot(`[]`);
+    expect(discountCodeDraft.maxApplications).toMatchInlineSnapshot(`1`);
+    expect(discountCodeDraft.maxApplicationsPerCustomer).toMatchInlineSnapshot(
+      `1`
+    );
+    expect(discountCodeDraft.__typename).toMatchInlineSnapshot(
+      `"DiscountCodeDraft"`
+    );
+  });
+});

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.ts
@@ -1,0 +1,20 @@
+import { LocalizedString, Reference } from '@commercetools-test-data/commons';
+import * as DiscountCodeDraft from '../..';
+import { TDiscountCodeDraftBuilder } from '../../../types';
+
+const shirtsBogo = (): TDiscountCodeDraftBuilder =>
+  DiscountCodeDraft.presets
+    .empty()
+    .code('BOGO')
+    .name(LocalizedString.presets.empty()['en-US']('BOGO'))
+    .description(LocalizedString.presets.empty())
+    // TODO: use the cart discount preset key here when available
+    .cartDiscounts([
+      Reference.random().key('ShirtsBOGO').typeId('cart-discount'),
+    ])
+    .isActive(true)
+    .maxApplications(1)
+    .maxApplicationsPerCustomer(1)
+    .groups([]);
+
+export default shirtsBogo;

--- a/models/discount-code/src/discount-code-draft/transformers.ts
+++ b/models/discount-code/src/discount-code-draft/transformers.ts
@@ -3,15 +3,15 @@ import type { TDiscountCodeDraft, TDiscountCodeDraftGraphql } from '../types';
 
 const transformers = {
   default: Transformer<TDiscountCodeDraft, TDiscountCodeDraft>('default', {
-    buildFields: ['name', 'description'],
+    buildFields: ['name', 'description', 'cartDiscounts'],
   }),
   rest: Transformer<TDiscountCodeDraft, TDiscountCodeDraft>('rest', {
-    buildFields: ['name', 'description'],
+    buildFields: ['name', 'description', 'cartDiscounts'],
   }),
   graphql: Transformer<TDiscountCodeDraft, TDiscountCodeDraftGraphql>(
     'graphql',
     {
-      buildFields: ['name', 'description'],
+      buildFields: ['name', 'description', 'cartDiscounts'],
       addFields: () => ({
         __typename: 'DiscountCodeDraft',
       }),


### PR DESCRIPTION
## Summary
This PR creates presets for discount code drafts that conforms to [this data](https://github.com/commercetools/test-data-research/blob/main/src/entity-drafts/discount-codes.ts)

Been a while since being in this repo, so I'd appreciate some eagle eyes here!