### PR TITLE
feat(cart): sample data fashion draft presets

### DIFF
--- a/.changeset/nice-waves-swim.md
+++ b/.changeset/nice-waves-swim.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-test-data/line-item': minor
+'@commercetools-test-data/customer': minor
+'@commercetools-test-data/commons': minor
+'@commercetools-test-data/cart': minor
+---
+
+Add Fashion sample data Cart presets.

--- a/models/cart/package.json
+++ b/models/cart/package.json
@@ -21,6 +21,8 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/commons": "4.11.1",
     "@commercetools-test-data/core": "4.11.1",
+    "@commercetools-test-data/customer": "4.11.1",
+    "@commercetools-test-data/discount-code": "4.11.1",
     "@commercetools-test-data/utils": "4.11.1",
     "@commercetools-test-data/line-item": "4.11.1",
     "@commercetools-test-data/cent-precision-money": "4.11.1",

--- a/models/cart/src/cart-draft/builder.ts
+++ b/models/cart/src/cart-draft/builder.ts
@@ -1,7 +1,7 @@
 import { Builder } from '@commercetools-test-data/core';
+import type { TCreateCartDraftBuilder, TCartDraft } from '../types';
 import generator from './generator';
 import transformers from './transformers';
-import type { TCreateCartDraftBuilder, TCartDraft } from '../types';
 
 const Model: TCreateCartDraftBuilder = () =>
   Builder<TCartDraft>({

--- a/models/cart/src/cart-draft/presets/empty.spec.ts
+++ b/models/cart/src/cart-draft/presets/empty.spec.ts
@@ -1,0 +1,36 @@
+import type { TCartDraft } from '../../types';
+import empty from './empty';
+
+it('should set all specified fields to undefined', () => {
+  const emptyCartDraft = empty().build<TCartDraft>();
+  expect(emptyCartDraft).toMatchObject({
+    key: undefined,
+    customerId: undefined,
+    customerEmail: undefined,
+    customerGroup: undefined,
+    anonymousId: undefined,
+    businessUnit: undefined,
+    store: undefined,
+    lineItems: undefined,
+    customLineItems: undefined,
+    taxMode: undefined,
+    externalTaxRateForShippingMethod: undefined,
+    taxRoundingMode: undefined,
+    taxCalculationMode: undefined,
+    inventoryMode: undefined,
+    billingAddress: undefined,
+    shippingAddress: undefined,
+    shippingMethod: undefined,
+    shippingRateInput: undefined,
+    shippingMode: undefined,
+    customShipping: undefined,
+    shipping: undefined,
+    itemShippingAddresses: undefined,
+    discountCodes: undefined,
+    country: undefined,
+    locale: undefined,
+    origin: undefined,
+    deleteDaysAfterLastModification: undefined,
+    custom: undefined,
+  });
+});

--- a/models/cart/src/cart-draft/presets/empty.ts
+++ b/models/cart/src/cart-draft/presets/empty.ts
@@ -1,0 +1,35 @@
+import type { TCartDraftBuilder } from '../../types';
+import CartDraft from '../builder';
+
+const empty = (): TCartDraftBuilder =>
+  CartDraft()
+    .key(undefined)
+    .customerId(undefined)
+    .customerEmail(undefined)
+    .customerGroup(undefined)
+    .anonymousId(undefined)
+    .businessUnit(undefined)
+    .store(undefined)
+    .lineItems(undefined)
+    .customLineItems(undefined)
+    .taxMode(undefined)
+    .externalTaxRateForShippingMethod(undefined)
+    .taxRoundingMode(undefined)
+    .taxCalculationMode(undefined)
+    .inventoryMode(undefined)
+    .billingAddress(undefined)
+    .shippingAddress(undefined)
+    .shippingMethod(undefined)
+    .shippingRateInput(undefined)
+    .shippingMode(undefined)
+    .customShipping(undefined)
+    .shipping(undefined)
+    .itemShippingAddresses(undefined)
+    .discountCodes(undefined)
+    .country(undefined)
+    .locale(undefined)
+    .origin(undefined)
+    .deleteDaysAfterLastModification(undefined)
+    .custom(undefined);
+
+export default empty;

--- a/models/cart/src/cart-draft/presets/index.ts
+++ b/models/cart/src/cart-draft/presets/index.ts
@@ -1,3 +1,6 @@
-const presets = {};
+import empty from './empty';
+import sampleDataFashion from './sample-data-fashion';
+
+const presets = { sampleDataFashion, empty };
 
 export default presets;

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/index.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/index.ts
@@ -1,0 +1,9 @@
+import jamieDoe01 from './jamie-doe-01';
+import johnDoe01 from './john-doe-01';
+import johnDoe02 from './john-doe-02';
+import marySmith01 from './mary-smith-01';
+import marySmith02 from './mary-smith-02';
+
+const presets = { jamieDoe01, johnDoe01, johnDoe02, marySmith01, marySmith02 };
+
+export default presets;

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/jamie-doe-01.spec.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/jamie-doe-01.spec.ts
@@ -1,0 +1,51 @@
+import { TCartDraft } from '../../../types';
+import jamieDoe01 from './jamie-doe-01';
+
+describe('with the preset cart `jamieDoe01`', () => {
+  it('should return a cart discount draft', () => {
+    const cartDraft = jamieDoe01().build<TCartDraft>();
+
+    expect(cartDraft.key).toMatchInlineSnapshot(`"jamie-01-cart"`);
+    expect(cartDraft.customerEmail).toMatchInlineSnapshot(
+      `"jamie.doe@example.com"`
+    );
+    expect(cartDraft.customerGroup).toMatchInlineSnapshot(`
+      {
+        "key": "vip",
+        "typeId": "customer-group",
+      }
+    `);
+    expect(cartDraft.currency).toMatchInlineSnapshot(`"USD"`);
+    expect(cartDraft.country).toMatchInlineSnapshot(`"US"`);
+    expect(cartDraft.origin).toMatchInlineSnapshot(`"Merchant"`);
+    expect(cartDraft.shippingAddress!.firstName).toMatchInlineSnapshot(
+      `"Jamie"`
+    );
+    expect(cartDraft.lineItems![0].sku).toMatchInlineSnapshot(`"718289"`);
+    expect(cartDraft.lineItems![0].quantity).toMatchInlineSnapshot(`2`);
+  });
+
+  it('should return a cart discount draft when build for GraphQL', () => {
+    const cartDraft = jamieDoe01().buildGraphql<TCartDraft>();
+
+    expect(cartDraft.key).toMatchInlineSnapshot(`"jamie-01-cart"`);
+    expect(cartDraft.customerEmail).toMatchInlineSnapshot(
+      `"jamie.doe@example.com"`
+    );
+    expect(cartDraft.customerGroup).toMatchInlineSnapshot(`
+      {
+        "__typename": "Reference",
+        "key": "vip",
+        "typeId": "customer-group",
+      }
+    `);
+    expect(cartDraft.currency).toMatchInlineSnapshot(`"USD"`);
+    expect(cartDraft.country).toMatchInlineSnapshot(`"US"`);
+    expect(cartDraft.origin).toMatchInlineSnapshot(`"Merchant"`);
+    expect(cartDraft.shippingAddress!.firstName).toMatchInlineSnapshot(
+      `"Jamie"`
+    );
+    expect(cartDraft.lineItems![0].sku).toMatchInlineSnapshot(`"718289"`);
+    expect(cartDraft.lineItems![0].quantity).toMatchInlineSnapshot(`2`);
+  });
+});

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/jamie-doe-01.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/jamie-doe-01.ts
@@ -1,0 +1,33 @@
+import { AddressDraft, KeyReference } from '@commercetools-test-data/commons';
+import { CustomerDraft } from '@commercetools-test-data/customer';
+import type { TCustomerDraft } from '@commercetools-test-data/customer';
+import { LineItemDraft } from '@commercetools-test-data/line-item';
+import * as CartDraft from '../..';
+import { origin } from '../../../constants';
+import type { TCartDraftBuilder } from '../../../types';
+
+const jamieDoe = CustomerDraft.presets.sampleDataFashion
+  .jamieDoe()
+  .build<TCustomerDraft>();
+const address = AddressDraft.presets.sampleDataFashion.jamieDoe();
+
+const jamieDoe01 = (): TCartDraftBuilder =>
+  CartDraft.presets
+    .empty()
+    .key('jamie-01-cart')
+    .customerEmail(jamieDoe.email)
+    .customerGroup(
+      KeyReference.presets.customerGroup().key(jamieDoe.customerGroup!.key!)
+    )
+    .currency('USD')
+    .country('US')
+    .origin(origin.Merchant)
+    .shippingAddress(address)
+    .billingAddress(address)
+    // TODO: replace with product preset SKU
+    .lineItems([
+      LineItemDraft.presets.empty().sku('718289').quantity(2),
+      LineItemDraft.presets.empty().sku('855485').quantity(1),
+    ]);
+
+export default jamieDoe01;

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-01.spec.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-01.spec.ts
@@ -1,0 +1,51 @@
+import { TCartDraft } from '../../../types';
+import johnDoe01 from './john-doe-01';
+
+describe('with the preset cart `johnDoe01`', () => {
+  it('should return a cart discount draft', () => {
+    const cartDraft = johnDoe01().build<TCartDraft>();
+
+    expect(cartDraft.key).toMatchInlineSnapshot(`"john-01-cart"`);
+    expect(cartDraft.customerEmail).toMatchInlineSnapshot(
+      `"john.doe@example.com"`
+    );
+    expect(cartDraft.customerGroup).toMatchInlineSnapshot(`
+      {
+        "key": "employee",
+        "typeId": "customer-group",
+      }
+    `);
+    expect(cartDraft.currency).toMatchInlineSnapshot(`"AUD"`);
+    expect(cartDraft.country).toMatchInlineSnapshot(`"AU"`);
+    expect(cartDraft.origin).toMatchInlineSnapshot(`"Merchant"`);
+    expect(cartDraft.shippingAddress!.firstName).toMatchInlineSnapshot(
+      `"John"`
+    );
+    expect(cartDraft.lineItems![0].sku).toMatchInlineSnapshot(`"148096"`);
+    expect(cartDraft.lineItems![0].quantity).toMatchInlineSnapshot(`1`);
+  });
+
+  it('should return a cart discount draft when build for GraphQL', () => {
+    const cartDraft = johnDoe01().buildGraphql<TCartDraft>();
+
+    expect(cartDraft.key).toMatchInlineSnapshot(`"john-01-cart"`);
+    expect(cartDraft.customerEmail).toMatchInlineSnapshot(
+      `"john.doe@example.com"`
+    );
+    expect(cartDraft.customerGroup).toMatchInlineSnapshot(`
+      {
+        "__typename": "Reference",
+        "key": "employee",
+        "typeId": "customer-group",
+      }
+    `);
+    expect(cartDraft.currency).toMatchInlineSnapshot(`"AUD"`);
+    expect(cartDraft.country).toMatchInlineSnapshot(`"AU"`);
+    expect(cartDraft.origin).toMatchInlineSnapshot(`"Merchant"`);
+    expect(cartDraft.shippingAddress!.firstName).toMatchInlineSnapshot(
+      `"John"`
+    );
+    expect(cartDraft.lineItems![0].sku).toMatchInlineSnapshot(`"148096"`);
+    expect(cartDraft.lineItems![0].quantity).toMatchInlineSnapshot(`1`);
+  });
+});

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-01.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-01.ts
@@ -1,0 +1,30 @@
+import { AddressDraft, KeyReference } from '@commercetools-test-data/commons';
+import { CustomerDraft } from '@commercetools-test-data/customer';
+import type { TCustomerDraft } from '@commercetools-test-data/customer';
+import { LineItemDraft } from '@commercetools-test-data/line-item';
+import * as CartDraft from '../..';
+import { origin } from '../../../constants';
+import type { TCartDraftBuilder } from '../../../types';
+
+const johnDoe = CustomerDraft.presets.sampleDataFashion
+  .johnDoe()
+  .build<TCustomerDraft>();
+const address = AddressDraft.presets.sampleDataFashion.johnDoe();
+
+const johnDoe01 = (): TCartDraftBuilder =>
+  CartDraft.presets
+    .empty()
+    .key('john-01-cart')
+    .customerEmail(johnDoe.email)
+    .customerGroup(
+      KeyReference.presets.customerGroup().key(johnDoe.customerGroup!.key!)
+    )
+    .currency('AUD')
+    .country('AU')
+    .origin(origin.Merchant)
+    .shippingAddress(address)
+    .billingAddress(address)
+    // TODO: replace with product preset SKU
+    .lineItems([LineItemDraft.presets.empty().sku('148096').quantity(1)]);
+
+export default johnDoe01;

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-02.spec.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-02.spec.ts
@@ -1,0 +1,51 @@
+import { TCartDraft } from '../../../types';
+import johnDoe02 from './john-doe-02';
+
+describe('with the preset cart `johnDoe02`', () => {
+  it('should return a cart discount draft', () => {
+    const cartDraft = johnDoe02().build<TCartDraft>();
+
+    expect(cartDraft.key).toMatchInlineSnapshot(`"john-02-cart"`);
+    expect(cartDraft.customerEmail).toMatchInlineSnapshot(
+      `"john.doe@example.com"`
+    );
+    expect(cartDraft.customerGroup).toMatchInlineSnapshot(`
+      {
+        "key": "employee",
+        "typeId": "customer-group",
+      }
+    `);
+    expect(cartDraft.currency).toMatchInlineSnapshot(`"EUR"`);
+    expect(cartDraft.country).toMatchInlineSnapshot(`"DE"`);
+    expect(cartDraft.origin).toMatchInlineSnapshot(`"Merchant"`);
+    expect(cartDraft.shippingAddress!.firstName).toMatchInlineSnapshot(
+      `"John"`
+    );
+    expect(cartDraft.lineItems![0].sku).toMatchInlineSnapshot(`"996024"`);
+    expect(cartDraft.lineItems![0].quantity).toMatchInlineSnapshot(`1`);
+  });
+
+  it('should return a cart discount draft when build for GraphQL', () => {
+    const cartDraft = johnDoe02().buildGraphql<TCartDraft>();
+
+    expect(cartDraft.key).toMatchInlineSnapshot(`"john-02-cart"`);
+    expect(cartDraft.customerEmail).toMatchInlineSnapshot(
+      `"john.doe@example.com"`
+    );
+    expect(cartDraft.customerGroup).toMatchInlineSnapshot(`
+      {
+        "__typename": "Reference",
+        "key": "employee",
+        "typeId": "customer-group",
+      }
+    `);
+    expect(cartDraft.currency).toMatchInlineSnapshot(`"EUR"`);
+    expect(cartDraft.country).toMatchInlineSnapshot(`"DE"`);
+    expect(cartDraft.origin).toMatchInlineSnapshot(`"Merchant"`);
+    expect(cartDraft.shippingAddress!.firstName).toMatchInlineSnapshot(
+      `"John"`
+    );
+    expect(cartDraft.lineItems![0].sku).toMatchInlineSnapshot(`"996024"`);
+    expect(cartDraft.lineItems![0].quantity).toMatchInlineSnapshot(`1`);
+  });
+});

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-02.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-02.ts
@@ -1,0 +1,36 @@
+import { AddressDraft, KeyReference } from '@commercetools-test-data/commons';
+import { CustomerDraft } from '@commercetools-test-data/customer';
+import type { TCustomerDraft } from '@commercetools-test-data/customer';
+import { DiscountCodeDraft } from '@commercetools-test-data/discount-code';
+import type { TDiscountCodeDraft } from '@commercetools-test-data/discount-code';
+import { LineItemDraft } from '@commercetools-test-data/line-item';
+import * as CartDraft from '../..';
+import { origin } from '../../../constants';
+import type { TCartDraftBuilder } from '../../../types';
+
+const johnDoe = CustomerDraft.presets.sampleDataFashion
+  .johnDoe()
+  .build<TCustomerDraft>();
+const address = AddressDraft.presets.sampleDataFashion.johnDoe();
+const employeeSale = DiscountCodeDraft.presets.sampleDataFashion
+  .employeeSale()
+  .build<TDiscountCodeDraft>();
+
+const johnDoe01 = (): TCartDraftBuilder =>
+  CartDraft.presets
+    .empty()
+    .key('john-02-cart')
+    .customerEmail(johnDoe.email)
+    .customerGroup(
+      KeyReference.presets.customerGroup().key(johnDoe.customerGroup!.key!)
+    )
+    .currency('EUR')
+    .country('DE')
+    .origin(origin.Merchant)
+    .shippingAddress(address)
+    .billingAddress(address)
+    // TODO: replace with product preset SKU
+    .lineItems([LineItemDraft.presets.empty().sku('996024').quantity(1)])
+    .discountCodes([employeeSale.code]);
+
+export default johnDoe01;

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-01.spec.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-01.spec.ts
@@ -1,0 +1,38 @@
+import { TCartDraft } from '../../../types';
+import marySmith01 from './mary-smith-01';
+
+describe('with the preset cart `marySmith01`', () => {
+  it('should return a cart discount draft', () => {
+    const cartDraft = marySmith01().build<TCartDraft>();
+
+    expect(cartDraft.key).toMatchInlineSnapshot(`"mary-01-cart"`);
+    expect(cartDraft.customerEmail).toMatchInlineSnapshot(
+      `"mary.smith@example.com"`
+    );
+    expect(cartDraft.currency).toMatchInlineSnapshot(`"EUR"`);
+    expect(cartDraft.country).toMatchInlineSnapshot(`"DE"`);
+    expect(cartDraft.origin).toMatchInlineSnapshot(`"Merchant"`);
+    expect(cartDraft.shippingAddress!.firstName).toMatchInlineSnapshot(
+      `"Mary"`
+    );
+    expect(cartDraft.lineItems![0].sku).toMatchInlineSnapshot(`"752502"`);
+    expect(cartDraft.lineItems![0].quantity).toMatchInlineSnapshot(`1`);
+  });
+
+  it('should return a cart discount draft when build for GraphQL', () => {
+    const cartDraft = marySmith01().buildGraphql<TCartDraft>();
+
+    expect(cartDraft.key).toMatchInlineSnapshot(`"mary-01-cart"`);
+    expect(cartDraft.customerEmail).toMatchInlineSnapshot(
+      `"mary.smith@example.com"`
+    );
+    expect(cartDraft.currency).toMatchInlineSnapshot(`"EUR"`);
+    expect(cartDraft.country).toMatchInlineSnapshot(`"DE"`);
+    expect(cartDraft.origin).toMatchInlineSnapshot(`"Merchant"`);
+    expect(cartDraft.shippingAddress!.firstName).toMatchInlineSnapshot(
+      `"Mary"`
+    );
+    expect(cartDraft.lineItems![0].sku).toMatchInlineSnapshot(`"752502"`);
+    expect(cartDraft.lineItems![0].quantity).toMatchInlineSnapshot(`1`);
+  });
+});

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-01.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-01.ts
@@ -1,0 +1,27 @@
+import { AddressDraft } from '@commercetools-test-data/commons';
+import { CustomerDraft } from '@commercetools-test-data/customer';
+import type { TCustomerDraft } from '@commercetools-test-data/customer';
+import { LineItemDraft } from '@commercetools-test-data/line-item';
+import * as CartDraft from '../..';
+import { origin } from '../../../constants';
+import type { TCartDraftBuilder } from '../../../types';
+
+const marySmith = CustomerDraft.presets.sampleDataFashion
+  .marySmith()
+  .build<TCustomerDraft>();
+const address = AddressDraft.presets.sampleDataFashion.marySmith();
+
+const marySmith01 = (): TCartDraftBuilder =>
+  CartDraft.presets
+    .empty()
+    .key('mary-01-cart')
+    .customerEmail(marySmith.email)
+    .currency('EUR')
+    .country('DE')
+    .origin(origin.Merchant)
+    .shippingAddress(address)
+    .billingAddress(address)
+    // TODO: replace with product preset SKU
+    .lineItems([LineItemDraft.presets.empty().sku('752502').quantity(1)]);
+
+export default marySmith01;

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-02.spec.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-02.spec.ts
@@ -1,0 +1,38 @@
+import { TCartDraft } from '../../../types';
+import marySmith02 from './mary-smith-02';
+
+describe('with the preset cart `marySmith01`', () => {
+  it('should return a cart discount draft', () => {
+    const cartDraft = marySmith02().build<TCartDraft>();
+
+    expect(cartDraft.key).toMatchInlineSnapshot(`"mary-02-cart"`);
+    expect(cartDraft.customerEmail).toMatchInlineSnapshot(
+      `"mary.smith@example.com"`
+    );
+    expect(cartDraft.currency).toMatchInlineSnapshot(`"EUR"`);
+    expect(cartDraft.country).toMatchInlineSnapshot(`"DE"`);
+    expect(cartDraft.origin).toMatchInlineSnapshot(`"Merchant"`);
+    expect(cartDraft.shippingAddress!.firstName).toMatchInlineSnapshot(
+      `"Mary"`
+    );
+    expect(cartDraft.lineItems![0].sku).toMatchInlineSnapshot(`"118718"`);
+    expect(cartDraft.lineItems![0].quantity).toMatchInlineSnapshot(`2`);
+  });
+
+  it('should return a cart discount draft when build for GraphQL', () => {
+    const cartDraft = marySmith02().buildGraphql<TCartDraft>();
+
+    expect(cartDraft.key).toMatchInlineSnapshot(`"mary-02-cart"`);
+    expect(cartDraft.customerEmail).toMatchInlineSnapshot(
+      `"mary.smith@example.com"`
+    );
+    expect(cartDraft.currency).toMatchInlineSnapshot(`"EUR"`);
+    expect(cartDraft.country).toMatchInlineSnapshot(`"DE"`);
+    expect(cartDraft.origin).toMatchInlineSnapshot(`"Merchant"`);
+    expect(cartDraft.shippingAddress!.firstName).toMatchInlineSnapshot(
+      `"Mary"`
+    );
+    expect(cartDraft.lineItems![0].sku).toMatchInlineSnapshot(`"118718"`);
+    expect(cartDraft.lineItems![0].quantity).toMatchInlineSnapshot(`2`);
+  });
+});

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-02.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-02.ts
@@ -1,0 +1,33 @@
+import { AddressDraft } from '@commercetools-test-data/commons';
+import { CustomerDraft } from '@commercetools-test-data/customer';
+import type { TCustomerDraft } from '@commercetools-test-data/customer';
+import { DiscountCodeDraft } from '@commercetools-test-data/discount-code';
+import type { TDiscountCodeDraft } from '@commercetools-test-data/discount-code';
+import { LineItemDraft } from '@commercetools-test-data/line-item';
+import * as CartDraft from '../..';
+import { origin } from '../../../constants';
+import type { TCartDraftBuilder } from '../../../types';
+
+const marySmith = CustomerDraft.presets.sampleDataFashion
+  .marySmith()
+  .build<TCustomerDraft>();
+const address = AddressDraft.presets.sampleDataFashion.marySmith();
+const shirtsBogo = DiscountCodeDraft.presets.sampleDataFashion
+  .shirtsBogo()
+  .build<TDiscountCodeDraft>();
+
+const marySmith02 = (): TCartDraftBuilder =>
+  CartDraft.presets
+    .empty()
+    .key('mary-02-cart')
+    .customerEmail(marySmith.email)
+    .currency('EUR')
+    .country('DE')
+    .origin(origin.Merchant)
+    .shippingAddress(address)
+    .billingAddress(address)
+    // TODO: replace with product preset SKU
+    .lineItems([LineItemDraft.presets.empty().sku('118718').quantity(2)])
+    .discountCodes([shirtsBogo.code]);
+
+export default marySmith02;

--- a/models/commons/src/address/address-draft/presets/index.ts
+++ b/models/commons/src/address/address-draft/presets/index.ts
@@ -1,5 +1,6 @@
 import empty from './empty';
+import sampleDataFashion from './sample-data-fashion';
 
-const presets = { empty };
+const presets = { empty, sampleDataFashion };
 
 export default presets;

--- a/models/commons/src/address/address-draft/presets/sample-data-fashion/index.ts
+++ b/models/commons/src/address/address-draft/presets/sample-data-fashion/index.ts
@@ -1,0 +1,7 @@
+import jamieDoe from './jamie-doe';
+import johnDoe from './john-doe';
+import marySmith from './mary-smith';
+
+const presets = { jamieDoe, johnDoe, marySmith };
+
+export default presets;

--- a/models/commons/src/address/address-draft/presets/sample-data-fashion/jamie-doe.spec.ts
+++ b/models/commons/src/address/address-draft/presets/sample-data-fashion/jamie-doe.spec.ts
@@ -1,0 +1,30 @@
+import { TAddressDraft, TAddressDraftGraphql } from '../../../types';
+import jamieDoe from './jamie-doe';
+
+describe('with the preset `jamieDoe`', () => {
+  it('should return a address draft', () => {
+    const address = jamieDoe().build<TAddressDraft>();
+
+    expect(address.firstName).toMatchInlineSnapshot(`"Jamie"`);
+    expect(address.lastName).toMatchInlineSnapshot(`"Doe"`);
+    expect(address.streetName).toMatchInlineSnapshot(`"Main Street"`);
+    expect(address.streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(address.postalCode).toMatchInlineSnapshot(`"56789"`);
+    expect(address.city).toMatchInlineSnapshot(`"Mainville"`);
+    expect(address.state).toMatchInlineSnapshot(`"New Jersey"`);
+    expect(address.country).toMatchInlineSnapshot(`"US"`);
+  });
+
+  it('should return a address draft when built for GraphQL', () => {
+    const address = jamieDoe().buildGraphql<TAddressDraftGraphql>();
+
+    expect(address.firstName).toMatchInlineSnapshot(`"Jamie"`);
+    expect(address.lastName).toMatchInlineSnapshot(`"Doe"`);
+    expect(address.streetName).toMatchInlineSnapshot(`"Main Street"`);
+    expect(address.streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(address.postalCode).toMatchInlineSnapshot(`"56789"`);
+    expect(address.city).toMatchInlineSnapshot(`"Mainville"`);
+    expect(address.state).toMatchInlineSnapshot(`"New Jersey"`);
+    expect(address.country).toMatchInlineSnapshot(`"US"`);
+  });
+});

--- a/models/commons/src/address/address-draft/presets/sample-data-fashion/jamie-doe.ts
+++ b/models/commons/src/address/address-draft/presets/sample-data-fashion/jamie-doe.ts
@@ -1,0 +1,16 @@
+import * as AddressDraft from '../..';
+import { TAddressDraftBuilder } from '../../../types';
+
+const jamieDoe = (): TAddressDraftBuilder =>
+  AddressDraft.presets
+    .empty()
+    .firstName('Jamie')
+    .lastName('Doe')
+    .streetName('Main Street')
+    .streetNumber('1')
+    .postalCode('56789')
+    .city('Mainville')
+    .state('New Jersey')
+    .country('US');
+
+export default jamieDoe;

--- a/models/commons/src/address/address-draft/presets/sample-data-fashion/john-doe.spec.ts
+++ b/models/commons/src/address/address-draft/presets/sample-data-fashion/john-doe.spec.ts
@@ -1,0 +1,28 @@
+import { TAddressDraft, TAddressDraftGraphql } from '../../../types';
+import johnDoe from './john-doe';
+
+describe('with the preset `johnDoe`', () => {
+  it('should return a address draft', () => {
+    const address = johnDoe().build<TAddressDraft>();
+
+    expect(address.firstName).toMatchInlineSnapshot(`"John"`);
+    expect(address.lastName).toMatchInlineSnapshot(`"Doe"`);
+    expect(address.streetName).toMatchInlineSnapshot(`"Center Road"`);
+    expect(address.streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(address.postalCode).toMatchInlineSnapshot(`"34567"`);
+    expect(address.city).toMatchInlineSnapshot(`"Center Town"`);
+    expect(address.country).toMatchInlineSnapshot(`"DE"`);
+  });
+
+  it('should return a address draft when built for GraphQL', () => {
+    const address = johnDoe().buildGraphql<TAddressDraftGraphql>();
+
+    expect(address.firstName).toMatchInlineSnapshot(`"John"`);
+    expect(address.lastName).toMatchInlineSnapshot(`"Doe"`);
+    expect(address.streetName).toMatchInlineSnapshot(`"Center Road"`);
+    expect(address.streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(address.postalCode).toMatchInlineSnapshot(`"34567"`);
+    expect(address.city).toMatchInlineSnapshot(`"Center Town"`);
+    expect(address.country).toMatchInlineSnapshot(`"DE"`);
+  });
+});

--- a/models/commons/src/address/address-draft/presets/sample-data-fashion/john-doe.ts
+++ b/models/commons/src/address/address-draft/presets/sample-data-fashion/john-doe.ts
@@ -1,0 +1,15 @@
+import * as AddressDraft from '../..';
+import { TAddressDraftBuilder } from '../../../types';
+
+const johnDoe = (): TAddressDraftBuilder =>
+  AddressDraft.presets
+    .empty()
+    .firstName('John')
+    .lastName('Doe')
+    .streetName('Center Road')
+    .streetNumber('1')
+    .postalCode('34567')
+    .city('Center Town')
+    .country('DE');
+
+export default johnDoe;

--- a/models/commons/src/address/address-draft/presets/sample-data-fashion/mary-smith.spec.ts
+++ b/models/commons/src/address/address-draft/presets/sample-data-fashion/mary-smith.spec.ts
@@ -1,0 +1,28 @@
+import { TAddressDraft, TAddressDraftGraphql } from '../../../types';
+import marySmith from './mary-smith';
+
+describe('with the preset `marySmith`', () => {
+  it('should return a address draft', () => {
+    const address = marySmith().build<TAddressDraft>();
+
+    expect(address.firstName).toMatchInlineSnapshot(`"Mary"`);
+    expect(address.lastName).toMatchInlineSnapshot(`"Smith"`);
+    expect(address.streetName).toMatchInlineSnapshot(`"Sample Street"`);
+    expect(address.streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(address.postalCode).toMatchInlineSnapshot(`"12345"`);
+    expect(address.city).toMatchInlineSnapshot(`"Sample Town"`);
+    expect(address.country).toMatchInlineSnapshot(`"DE"`);
+  });
+
+  it('should return a address draft when built for GraphQL', () => {
+    const address = marySmith().buildGraphql<TAddressDraftGraphql>();
+
+    expect(address.firstName).toMatchInlineSnapshot(`"Mary"`);
+    expect(address.lastName).toMatchInlineSnapshot(`"Smith"`);
+    expect(address.streetName).toMatchInlineSnapshot(`"Sample Street"`);
+    expect(address.streetNumber).toMatchInlineSnapshot(`"1"`);
+    expect(address.postalCode).toMatchInlineSnapshot(`"12345"`);
+    expect(address.city).toMatchInlineSnapshot(`"Sample Town"`);
+    expect(address.country).toMatchInlineSnapshot(`"DE"`);
+  });
+});

--- a/models/commons/src/address/address-draft/presets/sample-data-fashion/mary-smith.ts
+++ b/models/commons/src/address/address-draft/presets/sample-data-fashion/mary-smith.ts
@@ -1,0 +1,15 @@
+import * as AddressDraft from '../..';
+import { TAddressDraftBuilder } from '../../../types';
+
+const marySmith = (): TAddressDraftBuilder =>
+  AddressDraft.presets
+    .empty()
+    .firstName('Mary')
+    .lastName('Smith')
+    .streetName('Sample Street')
+    .streetNumber('1')
+    .postalCode('12345')
+    .city('Sample Town')
+    .country('DE');
+
+export default marySmith;

--- a/models/commons/src/key-reference/presets/category-reference.spec.ts
+++ b/models/commons/src/key-reference/presets/category-reference.spec.ts
@@ -1,0 +1,10 @@
+import type { TKeyReference } from '../types';
+import categoryReference from './category-reference';
+
+it('should build category reference', () => {
+  const built = categoryReference().build<TKeyReference>();
+  expect(built).toEqual({
+    key: expect.any(String),
+    typeId: 'category',
+  });
+});

--- a/models/commons/src/key-reference/presets/category-reference.ts
+++ b/models/commons/src/key-reference/presets/category-reference.ts
@@ -1,0 +1,6 @@
+import KeyReference from '../builder';
+import type { TKeyReferenceBuilder } from '../types';
+
+const category = (): TKeyReferenceBuilder => KeyReference().typeId('category');
+
+export default category;

--- a/models/commons/src/key-reference/presets/customer-group-reference.spec.ts
+++ b/models/commons/src/key-reference/presets/customer-group-reference.spec.ts
@@ -1,0 +1,10 @@
+import type { TKeyReference } from '../types';
+import customerGroupReference from './customer-group-reference';
+
+it('should build customer group reference', () => {
+  const built = customerGroupReference().build<TKeyReference>();
+  expect(built).toEqual({
+    key: expect.any(String),
+    typeId: 'customer-group',
+  });
+});

--- a/models/commons/src/key-reference/presets/customer-group-reference.ts
+++ b/models/commons/src/key-reference/presets/customer-group-reference.ts
@@ -1,0 +1,7 @@
+import KeyReference from '../builder';
+import type { TKeyReferenceBuilder } from '../types';
+
+const customerGroup = (): TKeyReferenceBuilder =>
+  KeyReference().typeId('customer-group');
+
+export default customerGroup;

--- a/models/commons/src/key-reference/presets/index.ts
+++ b/models/commons/src/key-reference/presets/index.ts
@@ -1,3 +1,6 @@
-const presets = {};
+import category from './category-reference';
+import customerGroup from './customer-group-reference';
+
+const presets = { category, customerGroup };
 
 export default presets;

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.spec.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.spec.ts
@@ -11,15 +11,6 @@ describe('with the preset `jamieDoe`', () => {
     expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
 
     expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"Jamie"`);
-    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Doe"`);
-    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
-      `"Main Street"`
-    );
-    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
-    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"56789"`);
-    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Mainville"`);
-    expect(customer.addresses![0].state).toMatchInlineSnapshot(`"New Jersey"`);
-    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"US"`);
 
     expect(customer.customerGroup!.key).toMatchInlineSnapshot('"vip"');
     expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);
@@ -34,15 +25,6 @@ describe('with the preset `jamieDoe`', () => {
     expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
 
     expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"Jamie"`);
-    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Doe"`);
-    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
-      `"Main Street"`
-    );
-    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
-    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"56789"`);
-    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Mainville"`);
-    expect(customer.addresses![0].state).toMatchInlineSnapshot(`"New Jersey"`);
-    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"US"`);
 
     expect(customer.customerGroup!.key).toMatchInlineSnapshot('"vip"');
     expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.ts
@@ -1,10 +1,10 @@
 import { AddressDraft, KeyReference } from '@commercetools-test-data/commons';
 import type { TCustomerGroupDraft } from '@commercetools-test-data/customer-group';
-import * as CustomerGroup from '@commercetools-test-data/customer-group';
+import { CustomerGroupDraft } from '@commercetools-test-data/customer-group';
 import * as CustomerDraft from '../../';
 import { TCustomerDraftBuilder } from '../../../types';
 
-const customerGroup = CustomerGroup.draftPresets.sampleDataFashion
+const customerGroup = CustomerGroupDraft.presets.sampleDataFashion
   .vip()
   .build<TCustomerGroupDraft>();
 
@@ -15,21 +15,8 @@ const jamieDoe = (): TCustomerDraftBuilder =>
     .email('jamie.doe@example.com')
     .firstName('Jamie')
     .lastName('Doe')
-    .addresses([
-      AddressDraft.presets
-        .empty()
-        .firstName('Jamie')
-        .lastName('Doe')
-        .streetName('Main Street')
-        .streetNumber('1')
-        .postalCode('56789')
-        .city('Mainville')
-        .state('New Jersey')
-        .country('US'),
-    ])
-    .customerGroup(
-      KeyReference.random().key(customerGroup.key!).typeId('customer-group')
-    )
+    .addresses([AddressDraft.presets.sampleDataFashion.jamieDoe()])
+    .customerGroup(KeyReference.presets.customerGroup().key(customerGroup.key!))
     .isEmailVerified(false);
 
 export default jamieDoe;

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.spec.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.spec.ts
@@ -11,14 +11,6 @@ describe('with the preset `johnDoe`', () => {
     expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
 
     expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"John"`);
-    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Doe"`);
-    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
-      `"Center Road"`
-    );
-    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
-    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"34567"`);
-    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Center Town"`);
-    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"DE"`);
 
     expect(customer.customerGroup!.key).toMatchInlineSnapshot('"employee"');
     expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);
@@ -33,14 +25,6 @@ describe('with the preset `johnDoe`', () => {
     expect(customer.lastName).toMatchInlineSnapshot(`"Doe"`);
 
     expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"John"`);
-    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Doe"`);
-    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
-      `"Center Road"`
-    );
-    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
-    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"34567"`);
-    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Center Town"`);
-    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"DE"`);
 
     expect(customer.customerGroup!.key).toMatchInlineSnapshot('"employee"');
     expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.ts
@@ -1,10 +1,10 @@
 import { AddressDraft, KeyReference } from '@commercetools-test-data/commons';
-import * as CustomerGroup from '@commercetools-test-data/customer-group';
 import type { TCustomerGroupDraft } from '@commercetools-test-data/customer-group';
+import { CustomerGroupDraft } from '@commercetools-test-data/customer-group';
 import * as CustomerDraft from '../../';
 import { TCustomerDraftBuilder } from '../../../types';
 
-const customerGroup = CustomerGroup.draftPresets.sampleDataFashion
+const customerGroup = CustomerGroupDraft.presets.sampleDataFashion
   .employee()
   .build<TCustomerGroupDraft>();
 
@@ -15,20 +15,8 @@ const johnDoe = (): TCustomerDraftBuilder =>
     .email('john.doe@example.com')
     .firstName('John')
     .lastName('Doe')
-    .addresses([
-      AddressDraft.presets
-        .empty()
-        .firstName('John')
-        .lastName('Doe')
-        .streetName('Center Road')
-        .streetNumber('1')
-        .postalCode('34567')
-        .city('Center Town')
-        .country('DE'),
-    ])
-    .customerGroup(
-      KeyReference.random().key(customerGroup.key!).typeId('customer-group')
-    )
+    .addresses([AddressDraft.presets.sampleDataFashion.johnDoe()])
+    .customerGroup(KeyReference.presets.customerGroup().key(customerGroup.key!))
     .isEmailVerified(false);
 
 export default johnDoe;

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.spec.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.spec.ts
@@ -11,14 +11,6 @@ describe('with the preset `marySmith`', () => {
     expect(customer.lastName).toMatchInlineSnapshot(`"Smith"`);
 
     expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"Mary"`);
-    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Smith"`);
-    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
-      `"Sample Street"`
-    );
-    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
-    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"12345"`);
-    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Sample Town"`);
-    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"DE"`);
 
     expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);
   });
@@ -32,14 +24,6 @@ describe('with the preset `marySmith`', () => {
     expect(customer.lastName).toMatchInlineSnapshot(`"Smith"`);
 
     expect(customer.addresses![0].firstName).toMatchInlineSnapshot(`"Mary"`);
-    expect(customer.addresses![0].lastName).toMatchInlineSnapshot(`"Smith"`);
-    expect(customer.addresses![0].streetName).toMatchInlineSnapshot(
-      `"Sample Street"`
-    );
-    expect(customer.addresses![0].streetNumber).toMatchInlineSnapshot(`"1"`);
-    expect(customer.addresses![0].postalCode).toMatchInlineSnapshot(`"12345"`);
-    expect(customer.addresses![0].city).toMatchInlineSnapshot(`"Sample Town"`);
-    expect(customer.addresses![0].country).toMatchInlineSnapshot(`"DE"`);
 
     expect(customer.isEmailVerified).toMatchInlineSnapshot(`false`);
   });

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.ts
@@ -9,17 +9,7 @@ const marySmith = (): TCustomerDraftBuilder =>
     .email('mary.smith@example.com')
     .firstName('Mary')
     .lastName('Smith')
-    .addresses([
-      AddressDraft.presets
-        .empty()
-        .firstName('Mary')
-        .lastName('Smith')
-        .streetName('Sample Street')
-        .streetNumber('1')
-        .postalCode('12345')
-        .city('Sample Town')
-        .country('DE'),
-    ])
+    .addresses([AddressDraft.presets.sampleDataFashion.marySmith()])
     .isEmailVerified(false);
 
 export default marySmith;

--- a/models/line-item/src/line-item-draft/presets/empty.spec.ts
+++ b/models/line-item/src/line-item-draft/presets/empty.spec.ts
@@ -1,0 +1,21 @@
+import type { TLineItemDraft } from '../../types';
+import empty from './empty';
+
+it('should set all specified fields to undefined', () => {
+  const emptyLineItemDraft = empty().build<TLineItemDraft>();
+  expect(emptyLineItemDraft).toMatchObject({
+    productId: undefined,
+    variantId: undefined,
+    sku: undefined,
+    quantity: undefined,
+    addedAt: undefined,
+    distributionChannel: undefined,
+    supplyChannel: undefined,
+    externalPrice: undefined,
+    externalTotalPrice: undefined,
+    externalTaxRate: undefined,
+    inventoryMode: undefined,
+    shippingDetails: undefined,
+    custom: undefined,
+  });
+});

--- a/models/line-item/src/line-item-draft/presets/empty.ts
+++ b/models/line-item/src/line-item-draft/presets/empty.ts
@@ -1,0 +1,20 @@
+import { TLineItemDraftBuilder } from '../../types';
+import LineItemDraft from '../builder';
+
+const empty = (): TLineItemDraftBuilder =>
+  LineItemDraft()
+    .productId(undefined)
+    .variantId(undefined)
+    .sku(undefined)
+    .quantity(undefined)
+    .addedAt(undefined)
+    .distributionChannel(undefined)
+    .supplyChannel(undefined)
+    .externalPrice(undefined)
+    .externalTotalPrice(undefined)
+    .externalTaxRate(undefined)
+    .inventoryMode(undefined)
+    .shippingDetails(undefined)
+    .custom(undefined);
+
+export default empty;

--- a/models/line-item/src/line-item-draft/presets/index.ts
+++ b/models/line-item/src/line-item-draft/presets/index.ts
@@ -1,3 +1,5 @@
-const presets = {};
+import empty from './empty';
+
+const presets = { empty };
 
 export default presets;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,12 @@ importers:
       '@commercetools-test-data/core':
         specifier: 4.11.1
         version: link:../../core
+      '@commercetools-test-data/customer':
+        specifier: 4.11.1
+        version: link:../customer
+      '@commercetools-test-data/discount-code':
+        specifier: 4.11.1
+        version: link:../discount-code
       '@commercetools-test-data/line-item':
         specifier: 4.11.1
         version: link:../line-item


### PR DESCRIPTION
#### Summary
[Cart draft presets](https://github.com/commercetools/test-data-research/blob/main/src/entity-drafts/carts.ts) for Fashion sample data.

In order not to duplicate data, I ended up moving the customer addresses into their own presets that could span both customer and cart presets.

Whoever tackles the product presets will need to update the line item SKUs.