### PR TITLE
feat(test-data): add order-from-cart-draft presets

### DIFF
--- a/.changeset/kind-rabbits-buy.md
+++ b/.changeset/kind-rabbits-buy.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/order': minor
+---
+
+Adds order-from-cart-draft presets.

--- a/models/order/src/order-from-cart-draft/builder.ts
+++ b/models/order/src/order-from-cart-draft/builder.ts
@@ -1,10 +1,10 @@
 import { Builder } from '@commercetools-test-data/core';
-import generator from './generator';
-import transformers from './transformers';
 import type {
   TCreateOrderFromCartDraftBuilder,
   TOrderFromCartDraft,
 } from '../types';
+import generator from './generator';
+import transformers from './transformers';
 
 const Model: TCreateOrderFromCartDraftBuilder = () =>
   Builder<TOrderFromCartDraft>({

--- a/models/order/src/order-from-cart-draft/presets/empty.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/empty.spec.ts
@@ -1,0 +1,17 @@
+import type { TOrderFromCartDraft } from '../../types';
+import empty from './empty';
+
+it(`should set the specified fields to undefined`, () => {
+  const emptyOrderFromCartDraft = empty().build<TOrderFromCartDraft>();
+  expect(emptyOrderFromCartDraft).toEqual({
+    cart: undefined,
+    version: expect.any(Number),
+    orderNumber: undefined,
+    purchaseOrderNumber: undefined,
+    paymentState: undefined,
+    orderState: undefined,
+    state: undefined,
+    shipmentState: undefined,
+    custom: undefined,
+  });
+});

--- a/models/order/src/order-from-cart-draft/presets/empty.ts
+++ b/models/order/src/order-from-cart-draft/presets/empty.ts
@@ -1,0 +1,15 @@
+import type { TOrderFromCartDraftBuilder } from '../../types';
+import OrderFromCartDraft from '../builder';
+
+const empty = (): TOrderFromCartDraftBuilder =>
+  OrderFromCartDraft()
+    .cart(undefined)
+    .orderNumber(undefined)
+    .purchaseOrderNumber(undefined)
+    .paymentState(undefined)
+    .orderState(undefined)
+    .state(undefined)
+    .shipmentState(undefined)
+    .custom(undefined);
+
+export default empty;

--- a/models/order/src/order-from-cart-draft/presets/index.ts
+++ b/models/order/src/order-from-cart-draft/presets/index.ts
@@ -1,3 +1,5 @@
-const presets = {};
+import empty from './empty';
+
+const presets = { empty };
 
 export default presets;

--- a/models/order/src/order-from-cart-draft/presets/index.ts
+++ b/models/order/src/order-from-cart-draft/presets/index.ts
@@ -1,5 +1,6 @@
 import empty from './empty';
+import sampleDataFashion from './sample-data-fashion';
 
-const presets = { empty };
+const presets = { empty, sampleDataFashion };
 
 export default presets;

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/index.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/index.ts
@@ -1,0 +1,15 @@
+import jamieCart01 from './jamie-cart-01';
+import johnCart01 from './john-cart-01';
+import johnCart02 from './john-cart-02';
+import maryCart01 from './mary-cart-01';
+import maryCart02 from './mary-cart-02';
+
+const presets = {
+  jamieCart01,
+  johnCart01,
+  johnCart02,
+  maryCart01,
+  maryCart02,
+};
+
+export default presets;

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.spec.ts
@@ -7,7 +7,7 @@ import jamieCart01 from './jamie-cart-01';
 describe(`with jamieCart01 preset`, () => {
   it(`should create an order draft`, () => {
     const jamieCart01OrderFromCartDraft =
-      jamieCart01(2).build<TOrderFromCartDraft>();
+      jamieCart01(1).build<TOrderFromCartDraft>();
     expect(jamieCart01OrderFromCartDraft).toMatchInlineSnapshot(`
       {
         "cart": {
@@ -21,14 +21,14 @@ describe(`with jamieCart01 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": "Shipped",
         "state": undefined,
-        "version": 2,
+        "version": 1,
       }
     `);
   });
 
   it(`should create an order draft when built for graphql`, () => {
     const jamieCart01OrderFromCartDraftGraphql =
-      jamieCart01(3).buildGraphql<TOrderFromCartDraftGraphql>();
+      jamieCart01(1).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(jamieCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "OrderCartCommand",
@@ -44,7 +44,7 @@ describe(`with jamieCart01 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": "Shipped",
         "state": undefined,
-        "version": 3,
+        "version": 1,
       }
     `);
   });

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.spec.ts
@@ -7,7 +7,7 @@ import jamieCart01 from './jamie-cart-01';
 describe(`with jamieCart01 preset`, () => {
   it(`should create an order draft`, () => {
     const jamieCart01OrderFromCartDraft =
-      jamieCart01().build<TOrderFromCartDraft>();
+      jamieCart01(2).build<TOrderFromCartDraft>();
     expect(jamieCart01OrderFromCartDraft).toMatchInlineSnapshot(`
       {
         "cart": {
@@ -21,14 +21,14 @@ describe(`with jamieCart01 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": "Shipped",
         "state": undefined,
-        "version": null,
+        "version": 2,
       }
     `);
   });
 
   it(`should create an order draft when built for graphql`, () => {
     const jamieCart01OrderFromCartDraftGraphql =
-      jamieCart01().buildGraphql<TOrderFromCartDraftGraphql>();
+      jamieCart01(3).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(jamieCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "OrderCartCommand",
@@ -44,7 +44,7 @@ describe(`with jamieCart01 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": "Shipped",
         "state": undefined,
-        "version": null,
+        "version": 3,
       }
     `);
   });

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.spec.ts
@@ -1,0 +1,51 @@
+import {
+  TOrderFromCartDraft,
+  TOrderFromCartDraftGraphql,
+} from '../../../types';
+import jamieCart01 from './jamie-cart-01';
+
+describe(`with jamieCart01 preset`, () => {
+  it(`should create an order draft`, () => {
+    const jamieCart01OrderFromCartDraft =
+      jamieCart01().build<TOrderFromCartDraft>();
+    expect(jamieCart01OrderFromCartDraft).toMatchInlineSnapshot(`
+      {
+        "cart": {
+          "key": "jamie-01-cart",
+          "typeId": "cart",
+        },
+        "custom": undefined,
+        "orderNumber": undefined,
+        "orderState": "Open",
+        "paymentState": "Paid",
+        "purchaseOrderNumber": undefined,
+        "shipmentState": "Shipped",
+        "state": undefined,
+        "version": null,
+      }
+    `);
+  });
+
+  it(`should create an order draft when built for graphql`, () => {
+    const jamieCart01OrderFromCartDraftGraphql =
+      jamieCart01().buildGraphql<TOrderFromCartDraftGraphql>();
+    expect(jamieCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "OrderCartCommand",
+        "cart": {
+          "__typename": "Reference",
+          "key": "jamie-01-cart",
+          "typeId": "cart",
+        },
+        "custom": undefined,
+        "orderNumber": undefined,
+        "orderState": "Open",
+        "paymentState": "Paid",
+        "purchaseOrderNumber": undefined,
+        "shipmentState": "Shipped",
+        "state": undefined,
+        "version": null,
+      }
+    `);
+  });
+});

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.ts
@@ -9,10 +9,10 @@ const jamieCartDraft01 = CartDraft.presets.sampleDataFashion
   .jamieDoe01()
   .build<TCartDraft>();
 
-const jamieCart01 = (): TOrderFromCartDraftBuilder =>
+const jamieCart01 = (versionNumber: number): TOrderFromCartDraftBuilder =>
   OrderFromCartDraft.presets
     .empty()
-    .version(null!)
+    .version(versionNumber)
     .cart(KeyReference.random().key(jamieCartDraft01.key!).typeId('cart'))
     .orderState(constants.orderState.Open)
     .paymentState(constants.paymentState.Paid)

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.ts
@@ -1,13 +1,19 @@
+import { CartDraft } from '@commercetools-test-data/cart';
+import type { TCartDraft } from '@commercetools-test-data/cart';
 import { KeyReference } from '@commercetools-test-data/commons';
 import * as OrderFromCartDraft from '../../';
 import { constants } from '../../..';
 import { TOrderFromCartDraftBuilder } from '../../../types';
 
+const jamieCartDraft01 = CartDraft.presets.sampleDataFashion
+  .jamieDoe01()
+  .build<TCartDraft>();
+
 const jamieCart01 = (): TOrderFromCartDraftBuilder =>
   OrderFromCartDraft.presets
     .empty()
     .version(null!)
-    .cart(KeyReference.random().key('jamie-01-cart').typeId('cart'))
+    .cart(KeyReference.random().key(jamieCartDraft01.key!).typeId('cart'))
     .orderState(constants.orderState.Open)
     .paymentState(constants.paymentState.Paid)
     .shipmentState(constants.shipmentState.Shipped);

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.ts
@@ -1,0 +1,15 @@
+import { KeyReference } from '@commercetools-test-data/commons';
+import * as OrderFromCartDraft from '../../';
+import { constants } from '../../..';
+import { TOrderFromCartDraftBuilder } from '../../../types';
+
+const jamieCart01 = (): TOrderFromCartDraftBuilder =>
+  OrderFromCartDraft.presets
+    .empty()
+    .version(null!)
+    .cart(KeyReference.random().key('jamie-01-cart').typeId('cart'))
+    .orderState(constants.orderState.Open)
+    .paymentState(constants.paymentState.Paid)
+    .shipmentState(constants.shipmentState.Shipped);
+
+export default jamieCart01;

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.spec.ts
@@ -28,7 +28,7 @@ describe(`with johnCart01 preset`, () => {
 
   it(`should create an order draft when built for graphql`, () => {
     const johnCart01OrderFromCartDraftGraphql =
-      johnCart01(2).buildGraphql<TOrderFromCartDraftGraphql>();
+      johnCart01(1).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(johnCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "OrderCartCommand",
@@ -44,7 +44,7 @@ describe(`with johnCart01 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": "Pending",
         "state": undefined,
-        "version": 2,
+        "version": 1,
       }
     `);
   });

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.spec.ts
@@ -1,0 +1,51 @@
+import {
+  TOrderFromCartDraft,
+  TOrderFromCartDraftGraphql,
+} from '../../../types';
+import johnCart01 from './john-cart-01';
+
+describe(`with johnCart01 preset`, () => {
+  it(`should create an order draft`, () => {
+    const johnCart01OrderFromCartDraft =
+      johnCart01().build<TOrderFromCartDraft>();
+    expect(johnCart01OrderFromCartDraft).toMatchInlineSnapshot(`
+      {
+        "cart": {
+          "key": "john-01-cart",
+          "typeId": "cart",
+        },
+        "custom": undefined,
+        "orderNumber": undefined,
+        "orderState": "Open",
+        "paymentState": "Pending",
+        "purchaseOrderNumber": undefined,
+        "shipmentState": "Pending",
+        "state": undefined,
+        "version": null,
+      }
+    `);
+  });
+
+  it(`should create an order draft when built for graphql`, () => {
+    const johnCart01OrderFromCartDraftGraphql =
+      johnCart01().buildGraphql<TOrderFromCartDraftGraphql>();
+    expect(johnCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "OrderCartCommand",
+        "cart": {
+          "__typename": "Reference",
+          "key": "john-01-cart",
+          "typeId": "cart",
+        },
+        "custom": undefined,
+        "orderNumber": undefined,
+        "orderState": "Open",
+        "paymentState": "Pending",
+        "purchaseOrderNumber": undefined,
+        "shipmentState": "Pending",
+        "state": undefined,
+        "version": null,
+      }
+    `);
+  });
+});

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.spec.ts
@@ -7,7 +7,7 @@ import johnCart01 from './john-cart-01';
 describe(`with johnCart01 preset`, () => {
   it(`should create an order draft`, () => {
     const johnCart01OrderFromCartDraft =
-      johnCart01().build<TOrderFromCartDraft>();
+      johnCart01(1).build<TOrderFromCartDraft>();
     expect(johnCart01OrderFromCartDraft).toMatchInlineSnapshot(`
       {
         "cart": {
@@ -21,14 +21,14 @@ describe(`with johnCart01 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": "Pending",
         "state": undefined,
-        "version": null,
+        "version": 1,
       }
     `);
   });
 
   it(`should create an order draft when built for graphql`, () => {
     const johnCart01OrderFromCartDraftGraphql =
-      johnCart01().buildGraphql<TOrderFromCartDraftGraphql>();
+      johnCart01(2).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(johnCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "OrderCartCommand",
@@ -44,7 +44,7 @@ describe(`with johnCart01 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": "Pending",
         "state": undefined,
-        "version": null,
+        "version": 2,
       }
     `);
   });

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.ts
@@ -1,0 +1,15 @@
+import { KeyReference } from '@commercetools-test-data/commons';
+import * as OrderFromCartDraft from '../../';
+import { constants } from '../../..';
+import { TOrderFromCartDraftBuilder } from '../../../types';
+
+const johnCart01 = (): TOrderFromCartDraftBuilder =>
+  OrderFromCartDraft.presets
+    .empty()
+    .version(null!)
+    .cart(KeyReference.random().key('john-01-cart').typeId('cart'))
+    .orderState(constants.orderState.Open)
+    .paymentState(constants.paymentState.Pending)
+    .shipmentState(constants.shipmentState.Pending);
+
+export default johnCart01;

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.ts
@@ -1,13 +1,19 @@
+import { CartDraft } from '@commercetools-test-data/cart';
+import type { TCartDraft } from '@commercetools-test-data/cart';
 import { KeyReference } from '@commercetools-test-data/commons';
 import * as OrderFromCartDraft from '../../';
 import { constants } from '../../..';
 import { TOrderFromCartDraftBuilder } from '../../../types';
 
+const johnCartDraft01 = CartDraft.presets.sampleDataFashion
+  .johnDoe01()
+  .build<TCartDraft>();
+
 const johnCart01 = (): TOrderFromCartDraftBuilder =>
   OrderFromCartDraft.presets
     .empty()
     .version(null!)
-    .cart(KeyReference.random().key('john-01-cart').typeId('cart'))
+    .cart(KeyReference.random().key(johnCartDraft01.key!).typeId('cart'))
     .orderState(constants.orderState.Open)
     .paymentState(constants.paymentState.Pending)
     .shipmentState(constants.shipmentState.Pending);

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.ts
@@ -9,10 +9,10 @@ const johnCartDraft01 = CartDraft.presets.sampleDataFashion
   .johnDoe01()
   .build<TCartDraft>();
 
-const johnCart01 = (): TOrderFromCartDraftBuilder =>
+const johnCart01 = (versionNumber: number): TOrderFromCartDraftBuilder =>
   OrderFromCartDraft.presets
     .empty()
-    .version(null!)
+    .version(versionNumber)
     .cart(KeyReference.random().key(johnCartDraft01.key!).typeId('cart'))
     .orderState(constants.orderState.Open)
     .paymentState(constants.paymentState.Pending)

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.spec.ts
@@ -7,7 +7,7 @@ import johnCart02 from './john-cart-02';
 describe(`with johnCart02 preset`, () => {
   it(`should create an order draft`, () => {
     const johnCart02OrderFromCartDraft =
-      johnCart02().build<TOrderFromCartDraft>();
+      johnCart02(1).build<TOrderFromCartDraft>();
     expect(johnCart02OrderFromCartDraft).toMatchInlineSnapshot(`
       {
         "cart": {
@@ -21,14 +21,14 @@ describe(`with johnCart02 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": "Delayed",
         "state": undefined,
-        "version": null,
+        "version": 1,
       }
     `);
   });
 
   it(`should create an order draft when built for graphql`, () => {
     const johnCart02OrderFromCartDraftGraphql =
-      johnCart02().buildGraphql<TOrderFromCartDraftGraphql>();
+      johnCart02(0).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(johnCart02OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "OrderCartCommand",
@@ -44,7 +44,7 @@ describe(`with johnCart02 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": "Delayed",
         "state": undefined,
-        "version": null,
+        "version": 0,
       }
     `);
   });

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.spec.ts
@@ -28,7 +28,7 @@ describe(`with johnCart02 preset`, () => {
 
   it(`should create an order draft when built for graphql`, () => {
     const johnCart02OrderFromCartDraftGraphql =
-      johnCart02(0).buildGraphql<TOrderFromCartDraftGraphql>();
+      johnCart02(1).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(johnCart02OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "OrderCartCommand",
@@ -44,7 +44,7 @@ describe(`with johnCart02 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": "Delayed",
         "state": undefined,
-        "version": 0,
+        "version": 1,
       }
     `);
   });

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.spec.ts
@@ -1,0 +1,51 @@
+import {
+  TOrderFromCartDraft,
+  TOrderFromCartDraftGraphql,
+} from '../../../types';
+import johnCart02 from './john-cart-02';
+
+describe(`with johnCart02 preset`, () => {
+  it(`should create an order draft`, () => {
+    const johnCart02OrderFromCartDraft =
+      johnCart02().build<TOrderFromCartDraft>();
+    expect(johnCart02OrderFromCartDraft).toMatchInlineSnapshot(`
+      {
+        "cart": {
+          "key": "john-02-cart",
+          "typeId": "cart",
+        },
+        "custom": undefined,
+        "orderNumber": undefined,
+        "orderState": "Confirmed",
+        "paymentState": "Paid",
+        "purchaseOrderNumber": undefined,
+        "shipmentState": "Delayed",
+        "state": undefined,
+        "version": null,
+      }
+    `);
+  });
+
+  it(`should create an order draft when built for graphql`, () => {
+    const johnCart02OrderFromCartDraftGraphql =
+      johnCart02().buildGraphql<TOrderFromCartDraftGraphql>();
+    expect(johnCart02OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "OrderCartCommand",
+        "cart": {
+          "__typename": "Reference",
+          "key": "john-02-cart",
+          "typeId": "cart",
+        },
+        "custom": undefined,
+        "orderNumber": undefined,
+        "orderState": "Confirmed",
+        "paymentState": "Paid",
+        "purchaseOrderNumber": undefined,
+        "shipmentState": "Delayed",
+        "state": undefined,
+        "version": null,
+      }
+    `);
+  });
+});

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.ts
@@ -1,0 +1,15 @@
+import { KeyReference } from '@commercetools-test-data/commons';
+import * as OrderFromCartDraft from '../../';
+import { constants } from '../../..';
+import { TOrderFromCartDraftBuilder } from '../../../types';
+
+const johnCart02 = (): TOrderFromCartDraftBuilder =>
+  OrderFromCartDraft.presets
+    .empty()
+    .version(null!)
+    .cart(KeyReference.random().key('john-02-cart').typeId('cart'))
+    .orderState(constants.orderState.Confirmed)
+    .paymentState(constants.paymentState.Paid)
+    .shipmentState(constants.shipmentState.Delayed);
+
+export default johnCart02;

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.ts
@@ -1,13 +1,19 @@
+import { CartDraft } from '@commercetools-test-data/cart';
+import type { TCartDraft } from '@commercetools-test-data/cart';
 import { KeyReference } from '@commercetools-test-data/commons';
 import * as OrderFromCartDraft from '../../';
 import { constants } from '../../..';
 import { TOrderFromCartDraftBuilder } from '../../../types';
 
+const johnCartDraft02 = CartDraft.presets.sampleDataFashion
+  .johnDoe02()
+  .build<TCartDraft>();
+
 const johnCart02 = (): TOrderFromCartDraftBuilder =>
   OrderFromCartDraft.presets
     .empty()
     .version(null!)
-    .cart(KeyReference.random().key('john-02-cart').typeId('cart'))
+    .cart(KeyReference.random().key(johnCartDraft02.key!).typeId('cart'))
     .orderState(constants.orderState.Confirmed)
     .paymentState(constants.paymentState.Paid)
     .shipmentState(constants.shipmentState.Delayed);

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.ts
@@ -9,10 +9,10 @@ const johnCartDraft02 = CartDraft.presets.sampleDataFashion
   .johnDoe02()
   .build<TCartDraft>();
 
-const johnCart02 = (): TOrderFromCartDraftBuilder =>
+const johnCart02 = (versionNumber: number): TOrderFromCartDraftBuilder =>
   OrderFromCartDraft.presets
     .empty()
-    .version(null!)
+    .version(versionNumber)
     .cart(KeyReference.random().key(johnCartDraft02.key!).typeId('cart'))
     .orderState(constants.orderState.Confirmed)
     .paymentState(constants.paymentState.Paid)

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.spec.ts
@@ -7,7 +7,7 @@ import maryCart01 from './mary-cart-01';
 describe(`with maryCart01 preset`, () => {
   it(`should create an order draft`, () => {
     const maryCart01OrderFromCartDraft =
-      maryCart01(0).build<TOrderFromCartDraft>();
+      maryCart01(1).build<TOrderFromCartDraft>();
     expect(maryCart01OrderFromCartDraft).toMatchInlineSnapshot(`
       {
         "cart": {
@@ -21,14 +21,14 @@ describe(`with maryCart01 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": undefined,
         "state": undefined,
-        "version": 0,
+        "version": 1,
       }
     `);
   });
 
   it(`should create an order draft when built for graphql`, () => {
     const maryCart01OrderFromCartDraftGraphql =
-      maryCart01(2).buildGraphql<TOrderFromCartDraftGraphql>();
+      maryCart01(1).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(maryCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "OrderCartCommand",
@@ -44,7 +44,7 @@ describe(`with maryCart01 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": undefined,
         "state": undefined,
-        "version": 2,
+        "version": 1,
       }
     `);
   });

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.spec.ts
@@ -7,7 +7,7 @@ import maryCart01 from './mary-cart-01';
 describe(`with maryCart01 preset`, () => {
   it(`should create an order draft`, () => {
     const maryCart01OrderFromCartDraft =
-      maryCart01().build<TOrderFromCartDraft>();
+      maryCart01(0).build<TOrderFromCartDraft>();
     expect(maryCart01OrderFromCartDraft).toMatchInlineSnapshot(`
       {
         "cart": {
@@ -21,14 +21,14 @@ describe(`with maryCart01 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": undefined,
         "state": undefined,
-        "version": null,
+        "version": 0,
       }
     `);
   });
 
   it(`should create an order draft when built for graphql`, () => {
     const maryCart01OrderFromCartDraftGraphql =
-      maryCart01().buildGraphql<TOrderFromCartDraftGraphql>();
+      maryCart01(2).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(maryCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "OrderCartCommand",
@@ -44,7 +44,7 @@ describe(`with maryCart01 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": undefined,
         "state": undefined,
-        "version": null,
+        "version": 2,
       }
     `);
   });

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.spec.ts
@@ -1,0 +1,51 @@
+import {
+  TOrderFromCartDraft,
+  TOrderFromCartDraftGraphql,
+} from '../../../types';
+import maryCart01 from './mary-cart-01';
+
+describe(`with maryCart01 preset`, () => {
+  it(`should create an order draft`, () => {
+    const maryCart01OrderFromCartDraft =
+      maryCart01().build<TOrderFromCartDraft>();
+    expect(maryCart01OrderFromCartDraft).toMatchInlineSnapshot(`
+      {
+        "cart": {
+          "key": "mary-01-cart",
+          "typeId": "cart",
+        },
+        "custom": undefined,
+        "orderNumber": undefined,
+        "orderState": "Cancelled",
+        "paymentState": undefined,
+        "purchaseOrderNumber": undefined,
+        "shipmentState": undefined,
+        "state": undefined,
+        "version": null,
+      }
+    `);
+  });
+
+  it(`should create an order draft when built for graphql`, () => {
+    const maryCart01OrderFromCartDraftGraphql =
+      maryCart01().buildGraphql<TOrderFromCartDraftGraphql>();
+    expect(maryCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "OrderCartCommand",
+        "cart": {
+          "__typename": "Reference",
+          "key": "mary-01-cart",
+          "typeId": "cart",
+        },
+        "custom": undefined,
+        "orderNumber": undefined,
+        "orderState": "Cancelled",
+        "paymentState": undefined,
+        "purchaseOrderNumber": undefined,
+        "shipmentState": undefined,
+        "state": undefined,
+        "version": null,
+      }
+    `);
+  });
+});

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.ts
@@ -9,10 +9,10 @@ const maryCartDraft01 = CartDraft.presets.sampleDataFashion
   .marySmith01()
   .build<TCartDraft>();
 
-const maryCart01 = (): TOrderFromCartDraftBuilder =>
+const maryCart01 = (versionNumber: number): TOrderFromCartDraftBuilder =>
   OrderFromCartDraft.presets
     .empty()
-    .version(null!)
+    .version(versionNumber)
     .cart(KeyReference.random().key(maryCartDraft01.key!).typeId('cart'))
     .orderState(constants.orderState.Cancelled);
 

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.ts
@@ -1,13 +1,19 @@
+import { CartDraft } from '@commercetools-test-data/cart';
+import type { TCartDraft } from '@commercetools-test-data/cart';
 import { KeyReference } from '@commercetools-test-data/commons';
 import * as OrderFromCartDraft from '../../';
 import { constants } from '../../..';
 import { TOrderFromCartDraftBuilder } from '../../../types';
 
+const maryCartDraft01 = CartDraft.presets.sampleDataFashion
+  .marySmith01()
+  .build<TCartDraft>();
+
 const maryCart01 = (): TOrderFromCartDraftBuilder =>
   OrderFromCartDraft.presets
     .empty()
     .version(null!)
-    .cart(KeyReference.random().key('mary-01-cart').typeId('cart'))
+    .cart(KeyReference.random().key(maryCartDraft01.key!).typeId('cart'))
     .orderState(constants.orderState.Cancelled);
 
 export default maryCart01;

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.ts
@@ -1,0 +1,13 @@
+import { KeyReference } from '@commercetools-test-data/commons';
+import * as OrderFromCartDraft from '../../';
+import { constants } from '../../..';
+import { TOrderFromCartDraftBuilder } from '../../../types';
+
+const maryCart01 = (): TOrderFromCartDraftBuilder =>
+  OrderFromCartDraft.presets
+    .empty()
+    .version(null!)
+    .cart(KeyReference.random().key('mary-01-cart').typeId('cart'))
+    .orderState(constants.orderState.Cancelled);
+
+export default maryCart01;

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.spec.ts
@@ -7,7 +7,7 @@ import maryCart02 from './mary-cart-02';
 describe(`with maryCart02 preset`, () => {
   it(`should create an order draft`, () => {
     const maryCart02OrderFromCartDraft =
-      maryCart02(2).build<TOrderFromCartDraft>();
+      maryCart02(1).build<TOrderFromCartDraft>();
     expect(maryCart02OrderFromCartDraft).toMatchInlineSnapshot(`
       {
         "cart": {
@@ -21,14 +21,14 @@ describe(`with maryCart02 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": undefined,
         "state": undefined,
-        "version": 2,
+        "version": 1,
       }
     `);
   });
 
   it(`should create an order draft when built for graphql`, () => {
     const maryCart02OrderFromCartDraftGraphql =
-      maryCart02(0).buildGraphql<TOrderFromCartDraftGraphql>();
+      maryCart02(1).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(maryCart02OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "OrderCartCommand",
@@ -44,7 +44,7 @@ describe(`with maryCart02 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": undefined,
         "state": undefined,
-        "version": 0,
+        "version": 1,
       }
     `);
   });

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.spec.ts
@@ -1,0 +1,51 @@
+import {
+  TOrderFromCartDraft,
+  TOrderFromCartDraftGraphql,
+} from '../../../types';
+import maryCart02 from './mary-cart-02';
+
+describe(`with maryCart02 preset`, () => {
+  it(`should create an order draft`, () => {
+    const maryCart02OrderFromCartDraft =
+      maryCart02().build<TOrderFromCartDraft>();
+    expect(maryCart02OrderFromCartDraft).toMatchInlineSnapshot(`
+      {
+        "cart": {
+          "key": "mary-02-cart",
+          "typeId": "cart",
+        },
+        "custom": undefined,
+        "orderNumber": undefined,
+        "orderState": "Complete",
+        "paymentState": undefined,
+        "purchaseOrderNumber": undefined,
+        "shipmentState": undefined,
+        "state": undefined,
+        "version": null,
+      }
+    `);
+  });
+
+  it(`should create an order draft when built for graphql`, () => {
+    const maryCart02OrderFromCartDraftGraphql =
+      maryCart02().buildGraphql<TOrderFromCartDraftGraphql>();
+    expect(maryCart02OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "OrderCartCommand",
+        "cart": {
+          "__typename": "Reference",
+          "key": "mary-02-cart",
+          "typeId": "cart",
+        },
+        "custom": undefined,
+        "orderNumber": undefined,
+        "orderState": "Complete",
+        "paymentState": undefined,
+        "purchaseOrderNumber": undefined,
+        "shipmentState": undefined,
+        "state": undefined,
+        "version": null,
+      }
+    `);
+  });
+});

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.spec.ts
@@ -7,7 +7,7 @@ import maryCart02 from './mary-cart-02';
 describe(`with maryCart02 preset`, () => {
   it(`should create an order draft`, () => {
     const maryCart02OrderFromCartDraft =
-      maryCart02().build<TOrderFromCartDraft>();
+      maryCart02(2).build<TOrderFromCartDraft>();
     expect(maryCart02OrderFromCartDraft).toMatchInlineSnapshot(`
       {
         "cart": {
@@ -21,14 +21,14 @@ describe(`with maryCart02 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": undefined,
         "state": undefined,
-        "version": null,
+        "version": 2,
       }
     `);
   });
 
   it(`should create an order draft when built for graphql`, () => {
     const maryCart02OrderFromCartDraftGraphql =
-      maryCart02().buildGraphql<TOrderFromCartDraftGraphql>();
+      maryCart02(0).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(maryCart02OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "OrderCartCommand",
@@ -44,7 +44,7 @@ describe(`with maryCart02 preset`, () => {
         "purchaseOrderNumber": undefined,
         "shipmentState": undefined,
         "state": undefined,
-        "version": null,
+        "version": 0,
       }
     `);
   });

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.ts
@@ -7,6 +7,7 @@ const maryCart02 = (): TOrderFromCartDraftBuilder =>
   OrderFromCartDraft.presets
     .empty()
     .version(null!)
+    // TODO: use the key from the cart model presets when available
     .cart(KeyReference.random().key('mary-02-cart').typeId('cart'))
     .orderState(constants.orderState.Complete);
 

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.ts
@@ -1,0 +1,13 @@
+import { KeyReference } from '@commercetools-test-data/commons';
+import * as OrderFromCartDraft from '../../';
+import { constants } from '../../..';
+import { TOrderFromCartDraftBuilder } from '../../../types';
+
+const maryCart02 = (): TOrderFromCartDraftBuilder =>
+  OrderFromCartDraft.presets
+    .empty()
+    .version(null!)
+    .cart(KeyReference.random().key('mary-02-cart').typeId('cart'))
+    .orderState(constants.orderState.Complete);
+
+export default maryCart02;

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.ts
@@ -9,10 +9,10 @@ const maryCartDraft02 = CartDraft.presets.sampleDataFashion
   .marySmith02()
   .build<TCartDraft>();
 
-const maryCart02 = (): TOrderFromCartDraftBuilder =>
+const maryCart02 = (versionNumber: number): TOrderFromCartDraftBuilder =>
   OrderFromCartDraft.presets
     .empty()
-    .version(null!)
+    .version(versionNumber)
     .cart(KeyReference.random().key(maryCartDraft02.key!).typeId('cart'))
     .orderState(constants.orderState.Complete);
 

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.ts
@@ -1,14 +1,19 @@
+import { CartDraft } from '@commercetools-test-data/cart';
+import type { TCartDraft } from '@commercetools-test-data/cart';
 import { KeyReference } from '@commercetools-test-data/commons';
 import * as OrderFromCartDraft from '../../';
 import { constants } from '../../..';
 import { TOrderFromCartDraftBuilder } from '../../../types';
 
+const maryCartDraft02 = CartDraft.presets.sampleDataFashion
+  .marySmith02()
+  .build<TCartDraft>();
+
 const maryCart02 = (): TOrderFromCartDraftBuilder =>
   OrderFromCartDraft.presets
     .empty()
     .version(null!)
-    // TODO: use the key from the cart model presets when available
-    .cart(KeyReference.random().key('mary-02-cart').typeId('cart'))
+    .cart(KeyReference.random().key(maryCartDraft02.key!).typeId('cart'))
     .orderState(constants.orderState.Complete);
 
 export default maryCart02;


### PR DESCRIPTION
This PR adds the [orders presets](https://github.com/commercetools/test-data-research/blob/main/src/entity-drafts/orders.ts) for Fashion Sample Data.