### PR TITLE
FCT-196 `Product` presets

### DIFF
--- a/.changeset/hungry-donkeys-thank.md
+++ b/.changeset/hungry-donkeys-thank.md
@@ -1,0 +1,9 @@
+---
+'@commercetools-test-data/product-variant': minor
+'@commercetools-test-data/commons': minor
+'@commercetools-test-data/product': minor
+'@commercetools-test-data/image': minor
+'@commercetools-test-data/price': minor
+---
+
+Adds product draft presets for fashion sample data.

--- a/models/commons/src/key-reference/presets/index.ts
+++ b/models/commons/src/key-reference/presets/index.ts
@@ -1,6 +1,8 @@
 import category from './category-reference';
 import customerGroup from './customer-group-reference';
+import productType from './product-type-reference';
+import taxCategory from './tax-category-reference';
 
-const presets = { category, customerGroup };
+const presets = { category, customerGroup, productType, taxCategory };
 
 export default presets;

--- a/models/commons/src/key-reference/presets/product-type-reference.spec.ts
+++ b/models/commons/src/key-reference/presets/product-type-reference.spec.ts
@@ -1,0 +1,10 @@
+import type { TKeyReference } from '../types';
+import productTypeReference from './product-type-reference';
+
+it('should build category reference', () => {
+  const built = productTypeReference().build<TKeyReference>();
+  expect(built).toEqual({
+    key: expect.any(String),
+    typeId: 'product-type',
+  });
+});

--- a/models/commons/src/key-reference/presets/product-type-reference.ts
+++ b/models/commons/src/key-reference/presets/product-type-reference.ts
@@ -1,0 +1,7 @@
+import KeyReference from '../builder';
+import type { TKeyReferenceBuilder } from '../types';
+
+const productType = (): TKeyReferenceBuilder =>
+  KeyReference().typeId('product-type');
+
+export default productType;

--- a/models/commons/src/key-reference/presets/tax-category-reference.spec.ts
+++ b/models/commons/src/key-reference/presets/tax-category-reference.spec.ts
@@ -1,0 +1,10 @@
+import type { TKeyReference } from '../types';
+import taxCategoryReference from './tax-category-reference';
+
+it('should build category reference', () => {
+  const built = taxCategoryReference().build<TKeyReference>();
+  expect(built).toEqual({
+    key: expect.any(String),
+    typeId: 'tax-category',
+  });
+});

--- a/models/commons/src/key-reference/presets/tax-category-reference.ts
+++ b/models/commons/src/key-reference/presets/tax-category-reference.ts
@@ -1,0 +1,7 @@
+import KeyReference from '../builder';
+import type { TKeyReferenceBuilder } from '../types';
+
+const taxCategory = (): TKeyReferenceBuilder =>
+  KeyReference().typeId('tax-category');
+
+export default taxCategory;

--- a/models/price/src/price-draft/presets/empty.spec.ts
+++ b/models/price/src/price-draft/presets/empty.spec.ts
@@ -1,0 +1,21 @@
+import { TPriceDraft } from '../../types';
+import empty from './empty';
+
+it(`should set all specified fields to undefined`, () => {
+  const emptyPriceDraft = empty().build<TPriceDraft>();
+  expect(emptyPriceDraft.key).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPriceDraft.value).toEqual({
+    centAmount: expect.any(Number),
+    currencyCode: expect.any(String),
+    type: 'centPrecision',
+    fractionDigits: 2,
+  });
+  expect(emptyPriceDraft.country).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPriceDraft.customerGroup).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPriceDraft.channel).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPriceDraft.validFrom).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPriceDraft.validUntil).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPriceDraft.tiers).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPriceDraft.discounted).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPriceDraft.custom).toMatchInlineSnapshot(`undefined`);
+});

--- a/models/price/src/price-draft/presets/empty.ts
+++ b/models/price/src/price-draft/presets/empty.ts
@@ -1,0 +1,16 @@
+import { TPriceDraftBuilder } from '../../types';
+import PriceDraft from '../builder';
+
+const empty = (): TPriceDraftBuilder =>
+  PriceDraft()
+    .key(undefined)
+    .country(undefined)
+    .customerGroup(undefined)
+    .channel(undefined)
+    .validFrom(undefined)
+    .validUntil(undefined)
+    .tiers(undefined)
+    .discounted(undefined)
+    .custom(undefined);
+
+export default empty;

--- a/models/price/src/price-draft/presets/index.ts
+++ b/models/price/src/price-draft/presets/index.ts
@@ -1,6 +1,7 @@
+import empty from './empty';
 import minimal from './minimal';
 import withValue from './with-value';
 
-const presets = { minimal, withValue };
+const presets = { empty, minimal, withValue };
 
 export default presets;

--- a/models/product-variant/package.json
+++ b/models/product-variant/package.json
@@ -20,6 +20,7 @@
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/attribute-definition": "4.11.1",
+    "@commercetools-test-data/cent-precision-money": "4.11.1",
     "@commercetools-test-data/commons": "4.11.1",
     "@commercetools-test-data/core": "4.11.1",
     "@commercetools-test-data/price": "4.11.1",

--- a/models/product-variant/src/image/presets/empty.ts
+++ b/models/product-variant/src/image/presets/empty.ts
@@ -1,0 +1,6 @@
+import Image from '../builder';
+import { TImageBuilder } from '../types';
+
+const empty = (): TImageBuilder => Image().label(undefined);
+
+export default empty;

--- a/models/product-variant/src/image/presets/index.ts
+++ b/models/product-variant/src/image/presets/index.ts
@@ -1,6 +1,7 @@
 import commercetoolsPosAem from './commercetools-api-platform';
 import commercetoolsApiPlatform from './commercetools-pos-aem';
+import empty from './empty';
 
-const presets = { commercetoolsPosAem, commercetoolsApiPlatform };
+const presets = { commercetoolsPosAem, commercetoolsApiPlatform, empty };
 
 export default presets;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/empty.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/empty.spec.ts
@@ -1,0 +1,16 @@
+import { TProductVariantDraft } from '../../types';
+import empty from './empty';
+
+it(`should set all fields to undefined`, () => {
+  const emptyProductVariantDraft = empty().build<TProductVariantDraft>();
+  expect(emptyProductVariantDraft).toMatchInlineSnapshot(`
+    {
+      "assets": undefined,
+      "attributes": undefined,
+      "images": undefined,
+      "key": undefined,
+      "prices": undefined,
+      "sku": undefined,
+    }
+  `);
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/empty.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/empty.ts
@@ -1,0 +1,13 @@
+import { TProductVariantDraftBuilder } from '../../types';
+import ProductVariantDraft from '../builder';
+
+const empty = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft()
+    .key(undefined)
+    .sku(undefined)
+    .prices(undefined)
+    .attributes(undefined)
+    .images(undefined)
+    .assets(undefined);
+
+export default empty;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/index.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/index.ts
@@ -1,7 +1,15 @@
+import empty from './empty';
+import sampleDataFashion from './sample-data-fashion';
 import withOneImage from './with-one-image';
 import withPrices from './with-prices';
 import withTwoImages from './with-two-images';
 
-const presets = { withPrices, withOneImage, withTwoImages };
+const presets = {
+  withPrices,
+  withOneImage,
+  withTwoImages,
+  empty,
+  sampleDataFashion,
+};
 
 export default presets;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-01.spec.ts
@@ -1,0 +1,52 @@
+import { TProductVariantDraft } from '../../../types';
+import anniversaryShirtVariant01 from './anniversary-shirt-variant-01';
+
+describe(`with anniversaryShirtVariant01 preset`, () => {
+  it(`should return a anniversaryShirtVariant01 preset`, () => {
+    const anniversaryShirtVariant01Preset =
+      anniversaryShirtVariant01().build<TProductVariantDraft>();
+    expect(anniversaryShirtVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Small",
+              "label": "Small",
+            },
+          },
+        ],
+        "images": [],
+        "key": undefined,
+        "prices": [],
+        "sku": undefined,
+      }
+    `);
+  });
+
+  it(`should return a anniversaryShirtVariant01 preset when built for graphql`, () => {
+    const anniversaryShirtVariant01PresetGraphql =
+      anniversaryShirtVariant01().buildGraphql<TProductVariantDraft>();
+    expect(anniversaryShirtVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Small",
+              "label": "Small",
+            },
+          },
+        ],
+        "images": [],
+        "key": undefined,
+        "prices": [],
+        "sku": undefined,
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with anniversaryShirtVariant01 preset`, () => {
       anniversaryShirtVariant01().build<TProductVariantDraft>();
     expect(anniversaryShirtVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -17,9 +17,9 @@ describe(`with anniversaryShirtVariant01 preset`, () => {
             },
           },
         ],
-        "images": [],
+        "images": undefined,
         "key": undefined,
-        "prices": [],
+        "prices": undefined,
         "sku": undefined,
       }
     `);
@@ -31,7 +31,7 @@ describe(`with anniversaryShirtVariant01 preset`, () => {
     expect(anniversaryShirtVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",
@@ -42,9 +42,9 @@ describe(`with anniversaryShirtVariant01 preset`, () => {
             },
           },
         ],
-        "images": [],
+        "images": undefined,
         "key": undefined,
-        "prices": [],
+        "prices": undefined,
         "sku": undefined,
       }
     `);

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-01.ts
@@ -1,0 +1,18 @@
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const anniversaryShirtVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .prices([])
+    .images([])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Small',
+        label: 'Small',
+      }),
+    ])
+    .assets([]);
+
+export default anniversaryShirtVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-01.ts
@@ -3,16 +3,11 @@ import { AttributeDraft } from '../../../../attribute/';
 import { TProductVariantDraftBuilder } from '../../../types';
 
 const anniversaryShirtVariant01 = (): TProductVariantDraftBuilder =>
-  ProductVariantDraft.presets
-    .empty()
-    .prices([])
-    .images([])
-    .attributes([
-      AttributeDraft.random().name('size').value({
-        key: 'Small',
-        label: 'Small',
-      }),
-    ])
-    .assets([]);
+  ProductVariantDraft.presets.empty().attributes([
+    AttributeDraft.random().name('size').value({
+      key: 'Small',
+      label: 'Small',
+    }),
+  ]);
 
 export default anniversaryShirtVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-02.spec.ts
@@ -1,0 +1,52 @@
+import { TProductVariantDraft } from '../../../types';
+import anniversaryShirtVariant02 from './anniversary-shirt-variant-02';
+
+describe(`with anniversaryShirtVariant02 preset`, () => {
+  it(`should return a anniversaryShirtVariant02 preset`, () => {
+    const anniversaryShirtVariant02Preset =
+      anniversaryShirtVariant02().build<TProductVariantDraft>();
+    expect(anniversaryShirtVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+        ],
+        "images": [],
+        "key": undefined,
+        "prices": [],
+        "sku": undefined,
+      }
+    `);
+  });
+
+  it(`should return a anniversaryShirtVariant02 preset when built for graphql`, () => {
+    const anniversaryShirtVariant02PresetGraphql =
+      anniversaryShirtVariant02().buildGraphql<TProductVariantDraft>();
+    expect(anniversaryShirtVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+        ],
+        "images": [],
+        "key": undefined,
+        "prices": [],
+        "sku": undefined,
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with anniversaryShirtVariant02 preset`, () => {
       anniversaryShirtVariant02().build<TProductVariantDraft>();
     expect(anniversaryShirtVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -17,9 +17,9 @@ describe(`with anniversaryShirtVariant02 preset`, () => {
             },
           },
         ],
-        "images": [],
+        "images": undefined,
         "key": undefined,
-        "prices": [],
+        "prices": undefined,
         "sku": undefined,
       }
     `);
@@ -31,7 +31,7 @@ describe(`with anniversaryShirtVariant02 preset`, () => {
     expect(anniversaryShirtVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",
@@ -42,9 +42,9 @@ describe(`with anniversaryShirtVariant02 preset`, () => {
             },
           },
         ],
-        "images": [],
+        "images": undefined,
         "key": undefined,
-        "prices": [],
+        "prices": undefined,
         "sku": undefined,
       }
     `);

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-02.ts
@@ -3,16 +3,11 @@ import { AttributeDraft } from '../../../../attribute/';
 import { TProductVariantDraftBuilder } from '../../../types';
 
 const anniversaryShirtVariant02 = (): TProductVariantDraftBuilder =>
-  ProductVariantDraft.presets
-    .empty()
-    .prices([])
-    .images([])
-    .attributes([
-      AttributeDraft.random().name('size').value({
-        key: 'Medium',
-        label: 'Medium',
-      }),
-    ])
-    .assets([]);
+  ProductVariantDraft.presets.empty().attributes([
+    AttributeDraft.random().name('size').value({
+      key: 'Medium',
+      label: 'Medium',
+    }),
+  ]);
 
 export default anniversaryShirtVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-02.ts
@@ -1,0 +1,18 @@
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const anniversaryShirtVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .prices([])
+    .images([])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Medium',
+        label: 'Medium',
+      }),
+    ])
+    .assets([]);
+
+export default anniversaryShirtVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-03.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-03.spec.ts
@@ -7,7 +7,7 @@ describe(`with anniversaryShirtVariant03 preset`, () => {
       anniversaryShirtVariant03().build<TProductVariantDraft>();
     expect(anniversaryShirtVariant03Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -17,9 +17,9 @@ describe(`with anniversaryShirtVariant03 preset`, () => {
             },
           },
         ],
-        "images": [],
+        "images": undefined,
         "key": undefined,
-        "prices": [],
+        "prices": undefined,
         "sku": undefined,
       }
     `);
@@ -31,7 +31,7 @@ describe(`with anniversaryShirtVariant03 preset`, () => {
     expect(anniversaryShirtVariant03PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",
@@ -42,9 +42,9 @@ describe(`with anniversaryShirtVariant03 preset`, () => {
             },
           },
         ],
-        "images": [],
+        "images": undefined,
         "key": undefined,
-        "prices": [],
+        "prices": undefined,
         "sku": undefined,
       }
     `);

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-03.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-03.spec.ts
@@ -1,0 +1,52 @@
+import { TProductVariantDraft } from '../../../types';
+import anniversaryShirtVariant03 from './anniversary-shirt-variant-03';
+
+describe(`with anniversaryShirtVariant03 preset`, () => {
+  it(`should return a anniversaryShirtVariant03 preset`, () => {
+    const anniversaryShirtVariant03Preset =
+      anniversaryShirtVariant03().build<TProductVariantDraft>();
+    expect(anniversaryShirtVariant03Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+        ],
+        "images": [],
+        "key": undefined,
+        "prices": [],
+        "sku": undefined,
+      }
+    `);
+  });
+
+  it(`should return a anniversaryShirtVariant03 preset when built for graphql`, () => {
+    const anniversaryShirtVariant03PresetGraphql =
+      anniversaryShirtVariant03().buildGraphql<TProductVariantDraft>();
+    expect(anniversaryShirtVariant03PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+        ],
+        "images": [],
+        "key": undefined,
+        "prices": [],
+        "sku": undefined,
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-03.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-03.ts
@@ -4,16 +4,11 @@ import { TProductVariantDraftBuilder } from '../../../types';
 
 // rename master variants to variant01, etc...
 const anniversaryShirtVariant03 = (): TProductVariantDraftBuilder =>
-  ProductVariantDraft.presets
-    .empty()
-    .prices([])
-    .images([])
-    .attributes([
-      AttributeDraft.random().name('size').value({
-        key: 'Large',
-        label: 'Large',
-      }),
-    ])
-    .assets([]);
+  ProductVariantDraft.presets.empty().attributes([
+    AttributeDraft.random().name('size').value({
+      key: 'Large',
+      label: 'Large',
+    }),
+  ]);
 
 export default anniversaryShirtVariant03;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-03.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-03.ts
@@ -1,0 +1,19 @@
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+// rename master variants to variant01, etc...
+const anniversaryShirtVariant03 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .prices([])
+    .images([])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Large',
+        label: 'Large',
+      }),
+    ])
+    .assets([]);
+
+export default anniversaryShirtVariant03;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-01.spec.ts
@@ -1,0 +1,154 @@
+import { TProductVariantDraft } from '../../../types';
+import denimJacketVariant01 from './denim-jacket-variant-01';
+
+describe(`with denimJacketVariant01 preset`, () => {
+  it(`should return a denimJacketVariant01 preset`, () => {
+    const denimJacketVariant01Preset =
+      denimJacketVariant01().build<TProductVariantDraft>();
+    expect(denimJacketVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "sleeve_length",
+            "value": {
+              "key": "Normal",
+              "label": "Normal",
+            },
+          },
+          {
+            "name": "cotton",
+            "value": false,
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 225,
+              "w": 225,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/denim-_KAoINSX.jpeg",
+          },
+        ],
+        "key": "996024",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 10000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 10000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "996024",
+      }
+    `);
+  });
+
+  it(`should return a denimJacketVariant01 preset when built for graphql`, () => {
+    const denimJacketVariant01PresetGraphql =
+      denimJacketVariant01().buildGraphql<TProductVariantDraft>();
+    expect(denimJacketVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "sleeve_length",
+            "value": {
+              "key": "Normal",
+              "label": "Normal",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "cotton",
+            "value": false,
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 225,
+              "w": 225,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/denim-_KAoINSX.jpeg",
+          },
+        ],
+        "key": "996024",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 10000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 10000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "996024",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with denimJacketVariant01 preset`, () => {
       denimJacketVariant01().build<TProductVariantDraft>();
     expect(denimJacketVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "sleeve_length",
@@ -79,7 +79,7 @@ describe(`with denimJacketVariant01 preset`, () => {
     expect(denimJacketVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-01.ts
@@ -1,0 +1,48 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const denimJacketVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('996024')
+    .key('996024')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(10000)
+        )
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(10000)
+        )
+        .country('ES'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/denim-_KAoINSX.jpeg'
+        )
+        .dimensions({ w: 225, h: 225 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('sleeve_length').value({
+        key: 'Normal',
+        label: 'Normal',
+      }),
+      AttributeDraft.random().name('cotton').value(false),
+    ])
+    .assets([]);
+
+export default denimJacketVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-01.ts
@@ -42,7 +42,6 @@ const denimJacketVariant01 = (): TProductVariantDraftBuilder =>
         label: 'Normal',
       }),
       AttributeDraft.random().name('cotton').value(false),
-    ])
-    .assets([]);
+    ]);
 
 export default denimJacketVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-02.spec.ts
@@ -1,0 +1,154 @@
+import { TProductVariantDraft } from '../../../types';
+import denimJacketVariant02 from './denim-jacket-variant-02';
+
+describe(`with denimJacketVariant02 preset`, () => {
+  it(`should return a denimJacketVariant02 preset`, () => {
+    const denimJacketVariant02Preset =
+      denimJacketVariant02().build<TProductVariantDraft>();
+    expect(denimJacketVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "sleeve_length",
+            "value": {
+              "key": "Extra Long",
+              "label": "Extra Long",
+            },
+          },
+          {
+            "name": "cotton",
+            "value": false,
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 225,
+              "w": 225,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/denim-pmNAetyM.jpeg",
+          },
+        ],
+        "key": "996025",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 10000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 10000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "996025",
+      }
+    `);
+  });
+
+  it(`should return a denimJacketVariant02 preset when built for graphql`, () => {
+    const denimJacketVariant02PresetGraphql =
+      denimJacketVariant02().buildGraphql<TProductVariantDraft>();
+    expect(denimJacketVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "sleeve_length",
+            "value": {
+              "key": "Extra Long",
+              "label": "Extra Long",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "cotton",
+            "value": false,
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 225,
+              "w": 225,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/denim-pmNAetyM.jpeg",
+          },
+        ],
+        "key": "996025",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 10000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 10000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "996025",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with denimJacketVariant02 preset`, () => {
       denimJacketVariant02().build<TProductVariantDraft>();
     expect(denimJacketVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "sleeve_length",
@@ -79,7 +79,7 @@ describe(`with denimJacketVariant02 preset`, () => {
     expect(denimJacketVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-02.ts
@@ -42,7 +42,6 @@ const denimJacketVariant02 = (): TProductVariantDraftBuilder =>
         label: 'Extra Long',
       }),
       AttributeDraft.random().name('cotton').value(false),
-    ])
-    .assets([]);
+    ]);
 
 export default denimJacketVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-02.ts
@@ -1,0 +1,48 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const denimJacketVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('996025')
+    .key('996025')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(10000)
+        )
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(10000)
+        )
+        .country('ES'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/denim-pmNAetyM.jpeg'
+        )
+        .dimensions({ w: 225, h: 225 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('sleeve_length').value({
+        key: 'Extra Long',
+        label: 'Extra Long',
+      }),
+      AttributeDraft.random().name('cotton').value(false),
+    ])
+    .assets([]);
+
+export default denimJacketVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with flairJeansVariant01 preset`, () => {
       flairJeansVariant01().build<TProductVariantDraft>();
     expect(flairJeansVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -38,9 +38,9 @@ describe(`with flairJeansVariant01 preset`, () => {
             },
           },
         ],
-        "images": [],
+        "images": undefined,
         "key": undefined,
-        "prices": [],
+        "prices": undefined,
         "sku": undefined,
       }
     `);
@@ -52,7 +52,7 @@ describe(`with flairJeansVariant01 preset`, () => {
     expect(flairJeansVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",
@@ -87,9 +87,9 @@ describe(`with flairJeansVariant01 preset`, () => {
             },
           },
         ],
-        "images": [],
+        "images": undefined,
         "key": undefined,
-        "prices": [],
+        "prices": undefined,
         "sku": undefined,
       }
     `);

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-01.spec.ts
@@ -1,0 +1,97 @@
+import { TProductVariantDraft } from '../../../types';
+import flairJeansVariant01 from './flair-jeans-variant-01';
+
+describe(`with flairJeansVariant01 preset`, () => {
+  it(`should return a flairJeansVariant01 preset`, () => {
+    const flairJeansVariant01Preset =
+      flairJeansVariant01().build<TProductVariantDraft>();
+    expect(flairJeansVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+          {
+            "name": "fit",
+            "value": {
+              "key": "Flair",
+              "label": "Flair",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "key": "Blue",
+              "label": "Blue",
+            },
+          },
+          {
+            "name": "length",
+            "value": {
+              "key": "Crop",
+              "label": "Crop",
+            },
+          },
+        ],
+        "images": [],
+        "key": undefined,
+        "prices": [],
+        "sku": undefined,
+      }
+    `);
+  });
+
+  it(`should return a flairJeansVariant01 preset when built for graphql`, () => {
+    const flairJeansVariant01PresetGraphql =
+      flairJeansVariant01().buildGraphql<TProductVariantDraft>();
+    expect(flairJeansVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "fit",
+            "value": {
+              "key": "Flair",
+              "label": "Flair",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "Blue",
+              "label": "Blue",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "length",
+            "value": {
+              "key": "Crop",
+              "label": "Crop",
+            },
+          },
+        ],
+        "images": [],
+        "key": undefined,
+        "prices": [],
+        "sku": undefined,
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-01.ts
@@ -1,0 +1,30 @@
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const flairJeansVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .prices([])
+    .images([])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Large',
+        label: 'Large',
+      }),
+      AttributeDraft.random().name('fit').value({
+        key: 'Flair',
+        label: 'Flair',
+      }),
+      AttributeDraft.random().name('color').value({
+        key: 'Blue',
+        label: 'Blue',
+      }),
+      AttributeDraft.random().name('length').value({
+        key: 'Crop',
+        label: 'Crop',
+      }),
+    ])
+    .assets([]);
+
+export default flairJeansVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-01.ts
@@ -3,28 +3,23 @@ import { AttributeDraft } from '../../../../attribute/';
 import { TProductVariantDraftBuilder } from '../../../types';
 
 const flairJeansVariant01 = (): TProductVariantDraftBuilder =>
-  ProductVariantDraft.presets
-    .empty()
-    .prices([])
-    .images([])
-    .attributes([
-      AttributeDraft.random().name('size').value({
-        key: 'Large',
-        label: 'Large',
-      }),
-      AttributeDraft.random().name('fit').value({
-        key: 'Flair',
-        label: 'Flair',
-      }),
-      AttributeDraft.random().name('color').value({
-        key: 'Blue',
-        label: 'Blue',
-      }),
-      AttributeDraft.random().name('length').value({
-        key: 'Crop',
-        label: 'Crop',
-      }),
-    ])
-    .assets([]);
+  ProductVariantDraft.presets.empty().attributes([
+    AttributeDraft.random().name('size').value({
+      key: 'Large',
+      label: 'Large',
+    }),
+    AttributeDraft.random().name('fit').value({
+      key: 'Flair',
+      label: 'Flair',
+    }),
+    AttributeDraft.random().name('color').value({
+      key: 'Blue',
+      label: 'Blue',
+    }),
+    AttributeDraft.random().name('length').value({
+      key: 'Crop',
+      label: 'Crop',
+    }),
+  ]);
 
 export default flairJeansVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with flairJeansVariant02 preset`, () => {
       flairJeansVariant02().build<TProductVariantDraft>();
     expect(flairJeansVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -38,9 +38,9 @@ describe(`with flairJeansVariant02 preset`, () => {
             },
           },
         ],
-        "images": [],
+        "images": undefined,
         "key": undefined,
-        "prices": [],
+        "prices": undefined,
         "sku": undefined,
       }
     `);
@@ -52,7 +52,7 @@ describe(`with flairJeansVariant02 preset`, () => {
     expect(flairJeansVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",
@@ -87,9 +87,9 @@ describe(`with flairJeansVariant02 preset`, () => {
             },
           },
         ],
-        "images": [],
+        "images": undefined,
         "key": undefined,
-        "prices": [],
+        "prices": undefined,
         "sku": undefined,
       }
     `);

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-02.spec.ts
@@ -1,0 +1,97 @@
+import { TProductVariantDraft } from '../../../types';
+import flairJeansVariant02 from './flair-jeans-variant-02';
+
+describe(`with flairJeansVariant02 preset`, () => {
+  it(`should return a flairJeansVariant02 preset`, () => {
+    const flairJeansVariant02Preset =
+      flairJeansVariant02().build<TProductVariantDraft>();
+    expect(flairJeansVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+          {
+            "name": "fit",
+            "value": {
+              "key": "Flair",
+              "label": "Flair",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "key": "Black",
+              "label": "Black",
+            },
+          },
+          {
+            "name": "length",
+            "value": {
+              "key": "Extra Long",
+              "label": "Extra Long",
+            },
+          },
+        ],
+        "images": [],
+        "key": undefined,
+        "prices": [],
+        "sku": undefined,
+      }
+    `);
+  });
+
+  it(`should return a flairJeansVariant02 preset when built for graphql`, () => {
+    const flairJeansVariant02PresetGraphql =
+      flairJeansVariant02().buildGraphql<TProductVariantDraft>();
+    expect(flairJeansVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "fit",
+            "value": {
+              "key": "Flair",
+              "label": "Flair",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "Black",
+              "label": "Black",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "length",
+            "value": {
+              "key": "Extra Long",
+              "label": "Extra Long",
+            },
+          },
+        ],
+        "images": [],
+        "key": undefined,
+        "prices": [],
+        "sku": undefined,
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-02.ts
@@ -1,0 +1,30 @@
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const flairJeansVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .prices([])
+    .images([])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Medium',
+        label: 'Medium',
+      }),
+      AttributeDraft.random().name('fit').value({
+        key: 'Flair',
+        label: 'Flair',
+      }),
+      AttributeDraft.random().name('color').value({
+        key: 'Black',
+        label: 'Black',
+      }),
+      AttributeDraft.random().name('length').value({
+        key: 'Extra Long',
+        label: 'Extra Long',
+      }),
+    ])
+    .assets([]);
+
+export default flairJeansVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-02.ts
@@ -3,28 +3,23 @@ import { AttributeDraft } from '../../../../attribute/';
 import { TProductVariantDraftBuilder } from '../../../types';
 
 const flairJeansVariant02 = (): TProductVariantDraftBuilder =>
-  ProductVariantDraft.presets
-    .empty()
-    .prices([])
-    .images([])
-    .attributes([
-      AttributeDraft.random().name('size').value({
-        key: 'Medium',
-        label: 'Medium',
-      }),
-      AttributeDraft.random().name('fit').value({
-        key: 'Flair',
-        label: 'Flair',
-      }),
-      AttributeDraft.random().name('color').value({
-        key: 'Black',
-        label: 'Black',
-      }),
-      AttributeDraft.random().name('length').value({
-        key: 'Extra Long',
-        label: 'Extra Long',
-      }),
-    ])
-    .assets([]);
+  ProductVariantDraft.presets.empty().attributes([
+    AttributeDraft.random().name('size').value({
+      key: 'Medium',
+      label: 'Medium',
+    }),
+    AttributeDraft.random().name('fit').value({
+      key: 'Flair',
+      label: 'Flair',
+    }),
+    AttributeDraft.random().name('color').value({
+      key: 'Black',
+      label: 'Black',
+    }),
+    AttributeDraft.random().name('length').value({
+      key: 'Extra Long',
+      label: 'Extra Long',
+    }),
+  ]);
 
 export default flairJeansVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-01.spec.ts
@@ -1,0 +1,196 @@
+import { TProductVariantDraft } from '../../../types';
+import halloweenTopVariant01 from './halloween-top-variant-01';
+
+describe(`with halloweenTopVariant01 preset`, () => {
+  it(`should return a halloweenTopVariant01 preset`, () => {
+    const halloweenTopVariant01Preset =
+      halloweenTopVariant01().build<TProductVariantDraft>();
+    expect(halloweenTopVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "key": "Purple",
+              "label": "Purple",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 235,
+              "w": 215,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/purple-5xg50uIz.png",
+          },
+        ],
+        "key": "888035",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 2500,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 2500,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 2500,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "888035",
+      }
+    `);
+  });
+
+  it(`should return a halloweenTopVariant01 preset when built for graphql`, () => {
+    const halloweenTopVariant01PresetGraphql =
+      halloweenTopVariant01().buildGraphql<TProductVariantDraft>();
+    expect(halloweenTopVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "Purple",
+              "label": "Purple",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 235,
+              "w": 215,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/purple-5xg50uIz.png",
+          },
+        ],
+        "key": "888035",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 2500,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 2500,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 2500,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "888035",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with halloweenTopVariant01 preset`, () => {
       halloweenTopVariant01().build<TProductVariantDraft>();
     expect(halloweenTopVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -99,7 +99,7 @@ describe(`with halloweenTopVariant01 preset`, () => {
     expect(halloweenTopVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-01.ts
@@ -53,7 +53,6 @@ const halloweenTopVariant01 = (): TProductVariantDraftBuilder =>
         key: 'Purple',
         label: 'Purple',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default halloweenTopVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-01.ts
@@ -1,0 +1,59 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const halloweenTopVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('888035')
+    .key('888035')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(2500)
+        )
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(2500)
+        )
+        .country('US'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(2500)
+        )
+        .country('ES'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/purple-5xg50uIz.png'
+        )
+        .dimensions({ w: 215, h: 235 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Medium',
+        label: 'Medium',
+      }),
+      AttributeDraft.random().name('color').value({
+        key: 'Purple',
+        label: 'Purple',
+      }),
+    ])
+    .assets([]);
+
+export default halloweenTopVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-02.spec.ts
@@ -1,0 +1,196 @@
+import { TProductVariantDraft } from '../../../types';
+import halloweenTopVariant02 from './halloween-top-variant-02';
+
+describe(`with halloweenTopVariant02 preset`, () => {
+  it(`should return a halloweenTopVariant02 preset`, () => {
+    const halloweenTopVariant02Preset =
+      halloweenTopVariant02().build<TProductVariantDraft>();
+    expect(halloweenTopVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "key": "Multi-Color",
+              "label": "Multi-Color",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 700,
+              "w": 900,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/multi-TjZTRFuz.jpeg",
+          },
+        ],
+        "key": "828329",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 3000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 3000,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 3300,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "828329",
+      }
+    `);
+  });
+
+  it(`should return a halloweenTopVariant02 preset when built for graphql`, () => {
+    const halloweenTopVariant02PresetGraphql =
+      halloweenTopVariant02().buildGraphql<TProductVariantDraft>();
+    expect(halloweenTopVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "Multi-Color",
+              "label": "Multi-Color",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 700,
+              "w": 900,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/multi-TjZTRFuz.jpeg",
+          },
+        ],
+        "key": "828329",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 3000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 3000,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 3300,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "828329",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with halloweenTopVariant02 preset`, () => {
       halloweenTopVariant02().build<TProductVariantDraft>();
     expect(halloweenTopVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -99,7 +99,7 @@ describe(`with halloweenTopVariant02 preset`, () => {
     expect(halloweenTopVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-02.ts
@@ -1,0 +1,59 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const halloweenTopVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('828329')
+    .key('828329')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(3000)
+        )
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(3000)
+        )
+        .country('US'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(3300)
+        )
+        .country('ES'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/multi-TjZTRFuz.jpeg'
+        )
+        .dimensions({ w: 900, h: 700 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Large',
+        label: 'Large',
+      }),
+      AttributeDraft.random().name('color').value({
+        key: 'Multi-Color',
+        label: 'Multi-Color',
+      }),
+    ])
+    .assets([]);
+
+export default halloweenTopVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-02.ts
@@ -53,7 +53,6 @@ const halloweenTopVariant02 = (): TProductVariantDraftBuilder =>
         key: 'Multi-Color',
         label: 'Multi-Color',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default halloweenTopVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/index.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/index.ts
@@ -1,0 +1,63 @@
+import anniversaryShirtVariant01 from './anniversary-shirt-variant-01';
+import anniversaryShirtVariant02 from './anniversary-shirt-variant-02';
+import anniversaryShirtVariant03 from './anniversary-shirt-variant-03';
+import denimJacketVariant01 from './denim-jacket-variant-01';
+import denimJacketVariant02 from './denim-jacket-variant-02';
+import flairJeansVariant01 from './flair-jeans-variant-01';
+import flairJeansVariant02 from './flair-jeans-variant-02';
+import halloweenTopVariant01 from './halloween-top-variant-01';
+import halloweenTopVariant02 from './halloween-top-variant-02';
+import maternityTopVariant01 from './maternity-top-variant-01';
+import maternityTopVariant02 from './maternity-top-variant-02';
+import maternityTopVariant03 from './maternity-top-variant-03';
+import necklaceVariant01 from './necklace-variant-01';
+import necklaceVariant02 from './necklace-variant-02';
+import promDressVariant01 from './prom-dress-variant-01';
+import promDressVariant02 from './prom-dress-variant-02';
+import sandalsVariant01 from './sandals-variant-01';
+import sandalsVariant02 from './sandals-variant-02';
+import skinnyJeansVariant01 from './skinny-jeans-variant-01';
+import skinnyJeansVariant02 from './skinny-jeans-variant-02';
+import sportCoatVariant01 from './sport-coat-variant-01';
+import sportCoatVariant02 from './sport-coat-variant-02';
+import summerDressVariant01 from './summer-dress-variant-01';
+import summerDressVariant02 from './summer-dress-variant-02';
+import toddlerTrousersVariant01 from './toddler-trousers-variant-01';
+import toddlerTrousersVariant02 from './toddler-trousers-variant-02';
+import toddlerTrousersVariant03 from './toddler-trousers-variant-03';
+import toteBagVariant01 from './tote-bag-variant-01';
+import toteBagVariant02 from './tote-bag-variant-02';
+
+const presets = {
+  anniversaryShirtVariant01,
+  anniversaryShirtVariant02,
+  anniversaryShirtVariant03,
+  denimJacketVariant01,
+  denimJacketVariant02,
+  flairJeansVariant01,
+  flairJeansVariant02,
+  halloweenTopVariant01,
+  halloweenTopVariant02,
+  maternityTopVariant01,
+  maternityTopVariant02,
+  maternityTopVariant03,
+  necklaceVariant01,
+  necklaceVariant02,
+  promDressVariant01,
+  promDressVariant02,
+  sandalsVariant01,
+  sandalsVariant02,
+  skinnyJeansVariant01,
+  skinnyJeansVariant02,
+  sportCoatVariant01,
+  sportCoatVariant02,
+  summerDressVariant01,
+  summerDressVariant02,
+  toddlerTrousersVariant01,
+  toddlerTrousersVariant02,
+  toddlerTrousersVariant03,
+  toteBagVariant01,
+  toteBagVariant02,
+};
+
+export default presets;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with maternityTopVariant01 preset`, () => {
       maternityTopVariant01().build<TProductVariantDraft>();
     expect(maternityTopVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -65,7 +65,7 @@ describe(`with maternityTopVariant01 preset`, () => {
     expect(maternityTopVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-01.spec.ts
@@ -1,0 +1,124 @@
+import { TProductVariantDraft } from '../../../types';
+import maternityTopVariant01 from './maternity-top-variant-01';
+
+describe(`with maternityTopVariant01 preset`, () => {
+  it(`should return a maternityTopVariant01 preset`, () => {
+    const maternityTopVariant01Preset =
+      maternityTopVariant01().build<TProductVariantDraft>();
+    expect(maternityTopVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Small",
+              "label": "Small",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "key": "Green",
+              "label": "Green",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 300,
+              "w": 262,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-__gg4rwo.png",
+          },
+        ],
+        "key": "118716",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 2695,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "118716",
+      }
+    `);
+  });
+
+  it(`should return a maternityTopVariant01 preset when built for graphql`, () => {
+    const maternityTopVariant01PresetGraphql =
+      maternityTopVariant01().buildGraphql<TProductVariantDraft>();
+    expect(maternityTopVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Small",
+              "label": "Small",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "Green",
+              "label": "Green",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 300,
+              "w": 262,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-__gg4rwo.png",
+          },
+        ],
+        "key": "118716",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 2695,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "118716",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-01.ts
@@ -1,0 +1,43 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const maternityTopVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('118716')
+    .key('118716')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(2695)
+        )
+        .country('DE'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-__gg4rwo.png'
+        )
+        .dimensions({ w: 262, h: 300 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Small',
+        label: 'Small',
+      }),
+      AttributeDraft.random().name('color').value({
+        key: 'Green',
+        label: 'Green',
+      }),
+    ])
+    .assets([]);
+
+export default maternityTopVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-01.ts
@@ -37,7 +37,6 @@ const maternityTopVariant01 = (): TProductVariantDraftBuilder =>
         key: 'Green',
         label: 'Green',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default maternityTopVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with maternityTopVariant02 preset`, () => {
       maternityTopVariant02().build<TProductVariantDraft>();
     expect(maternityTopVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -65,7 +65,7 @@ describe(`with maternityTopVariant02 preset`, () => {
     expect(maternityTopVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-02.spec.ts
@@ -1,0 +1,124 @@
+import { TProductVariantDraft } from '../../../types';
+import maternityTopVariant02 from './maternity-top-variant-02';
+
+describe(`with maternityTopVariant02 preset`, () => {
+  it(`should return a maternityTopVariant02 preset`, () => {
+    const maternityTopVariant02Preset =
+      maternityTopVariant02().build<TProductVariantDraft>();
+    expect(maternityTopVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "key": "Green",
+              "label": "Green",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 300,
+              "w": 262,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-7_8SGLVB.png",
+          },
+        ],
+        "key": "118717",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 2695,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "118717",
+      }
+    `);
+  });
+
+  it(`should return a maternityTopVariant02 preset when built for graphql`, () => {
+    const maternityTopVariant02PresetGraphql =
+      maternityTopVariant02().buildGraphql<TProductVariantDraft>();
+    expect(maternityTopVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "Green",
+              "label": "Green",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 300,
+              "w": 262,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-7_8SGLVB.png",
+          },
+        ],
+        "key": "118717",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 2695,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "118717",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-02.ts
@@ -1,0 +1,43 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const maternityTopVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('118717')
+    .key('118717')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(2695)
+        )
+        .country('DE'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-7_8SGLVB.png'
+        )
+        .dimensions({ w: 262, h: 300 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Medium',
+        label: 'Medium',
+      }),
+      AttributeDraft.random().name('color').value({
+        key: 'Green',
+        label: 'Green',
+      }),
+    ])
+    .assets([]);
+
+export default maternityTopVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-02.ts
@@ -37,7 +37,6 @@ const maternityTopVariant02 = (): TProductVariantDraftBuilder =>
         key: 'Green',
         label: 'Green',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default maternityTopVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-03.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-03.spec.ts
@@ -1,0 +1,124 @@
+import { TProductVariantDraft } from '../../../types';
+import maternityTopVariant03 from './maternity-top-variant-03';
+
+describe(`with maternityTopVariant03 preset`, () => {
+  it(`should return a maternityTopVariant03 preset`, () => {
+    const maternityTopVariant03Preset =
+      maternityTopVariant03().build<TProductVariantDraft>();
+    expect(maternityTopVariant03Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "key": "Green",
+              "label": "Green",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 300,
+              "w": 262,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-lOB-DcqK.png",
+          },
+        ],
+        "key": "118717",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 2695,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "118717",
+      }
+    `);
+  });
+
+  it(`should return a maternityTopVariant03 preset when built for graphql`, () => {
+    const maternityTopVariant03PresetGraphql =
+      maternityTopVariant03().buildGraphql<TProductVariantDraft>();
+    expect(maternityTopVariant03PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "Green",
+              "label": "Green",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 300,
+              "w": 262,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-lOB-DcqK.png",
+          },
+        ],
+        "key": "118717",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 2695,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "118717",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-03.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-03.spec.ts
@@ -7,7 +7,7 @@ describe(`with maternityTopVariant03 preset`, () => {
       maternityTopVariant03().build<TProductVariantDraft>();
     expect(maternityTopVariant03Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -34,7 +34,7 @@ describe(`with maternityTopVariant03 preset`, () => {
             "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-lOB-DcqK.png",
           },
         ],
-        "key": "118717",
+        "key": "118718",
         "prices": [
           {
             "channel": undefined,
@@ -54,7 +54,7 @@ describe(`with maternityTopVariant03 preset`, () => {
             },
           },
         ],
-        "sku": "118717",
+        "sku": "118718",
       }
     `);
   });
@@ -65,7 +65,7 @@ describe(`with maternityTopVariant03 preset`, () => {
     expect(maternityTopVariant03PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",
@@ -95,7 +95,7 @@ describe(`with maternityTopVariant03 preset`, () => {
             "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-lOB-DcqK.png",
           },
         ],
-        "key": "118717",
+        "key": "118718",
         "prices": [
           {
             "__typename": "ProductPriceDataInput",
@@ -117,7 +117,7 @@ describe(`with maternityTopVariant03 preset`, () => {
             },
           },
         ],
-        "sku": "118717",
+        "sku": "118718",
       }
     `);
   });

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-03.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-03.ts
@@ -8,8 +8,8 @@ import { TProductVariantDraftBuilder } from '../../../types';
 const maternityTopVariant03 = (): TProductVariantDraftBuilder =>
   ProductVariantDraft.presets
     .empty()
-    .sku('118717')
-    .key('118717')
+    .sku('118718')
+    .key('118718')
     .prices([
       PriceDraft.presets
         .empty()
@@ -37,7 +37,6 @@ const maternityTopVariant03 = (): TProductVariantDraftBuilder =>
         key: 'Green',
         label: 'Green',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default maternityTopVariant03;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-03.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-03.ts
@@ -1,0 +1,43 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const maternityTopVariant03 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('118717')
+    .key('118717')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(2695)
+        )
+        .country('DE'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-lOB-DcqK.png'
+        )
+        .dimensions({ w: 262, h: 300 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Large',
+        label: 'Large',
+      }),
+      AttributeDraft.random().name('color').value({
+        key: 'Green',
+        label: 'Green',
+      }),
+    ])
+    .assets([]);
+
+export default maternityTopVariant03;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-01.spec.ts
@@ -1,0 +1,190 @@
+import { TProductVariantDraft } from '../../../types';
+import necklaceVariant01 from './necklace-variant-01';
+
+describe(`with necklace variant preset`, () => {
+  it(`should return a necklace preset`, () => {
+    const necklaceVariant01Preset =
+      necklaceVariant01().build<TProductVariantDraft>();
+    expect(necklaceVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "type",
+            "value": {
+              "key": "Jewelry",
+              "label": "Jewelry",
+            },
+          },
+          {
+            "name": "engraving",
+            "value": "Happy Anniversary",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 122,
+              "w": 103,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/necklace-TRlWhVSq.png",
+          },
+        ],
+        "key": "752502",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 5000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 5000,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 5000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "752502",
+      }
+    `);
+  });
+
+  it(`should return a necklace preset when built for graphql`, () => {
+    const necklaceVariant01PresetGraphql =
+      necklaceVariant01().buildGraphql<TProductVariantDraft>();
+    expect(necklaceVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "type",
+            "value": {
+              "key": "Jewelry",
+              "label": "Jewelry",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "engraving",
+            "value": "Happy Anniversary",
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 122,
+              "w": 103,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/necklace-TRlWhVSq.png",
+          },
+        ],
+        "key": "752502",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 5000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 5000,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 5000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "752502",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with necklace variant preset`, () => {
       necklaceVariant01().build<TProductVariantDraft>();
     expect(necklaceVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "type",
@@ -96,7 +96,7 @@ describe(`with necklace variant preset`, () => {
     expect(necklaceVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-01.ts
@@ -50,7 +50,6 @@ const necklaceVariant01 = (): TProductVariantDraftBuilder =>
         label: 'Jewelry',
       }),
       AttributeDraft.random().name('engraving').value('Happy Anniversary'),
-    ])
-    .assets([]);
+    ]);
 
 export default necklaceVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-01.ts
@@ -1,0 +1,56 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const necklaceVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('752502')
+    .key('752502')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(5000)
+        )
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(5000)
+        )
+        .country('US'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(5000)
+        )
+        .country('ES'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/necklace-TRlWhVSq.png'
+        )
+        .dimensions({ w: 103, h: 122 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('type').value({
+        key: 'Jewelry',
+        label: 'Jewelry',
+      }),
+      AttributeDraft.random().name('engraving').value('Happy Anniversary'),
+    ])
+    .assets([]);
+
+export default necklaceVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with necklace variant preset`, () => {
       necklaceVariant02().build<TProductVariantDraft>();
     expect(necklaceVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "type",
@@ -58,7 +58,7 @@ describe(`with necklace variant preset`, () => {
     expect(necklaceVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-02.spec.ts
@@ -1,0 +1,109 @@
+import { TProductVariantDraft } from '../../../types';
+import necklaceVariant02 from './necklace-variant-02';
+
+describe(`with necklace variant preset`, () => {
+  it(`should return a necklace preset`, () => {
+    const necklaceVariant02Preset =
+      necklaceVariant02().build<TProductVariantDraft>();
+    expect(necklaceVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "type",
+            "value": {
+              "key": "Jewelry",
+              "label": "Jewelry",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 241,
+              "w": 209,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/necklace-KmP7rQDP.png",
+          },
+        ],
+        "key": "42610",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1575,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "42610",
+      }
+    `);
+  });
+
+  it(`should return a necklace preset when built for graphql`, () => {
+    const necklaceVariant02PresetGraphql =
+      necklaceVariant02().buildGraphql<TProductVariantDraft>();
+    expect(necklaceVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "type",
+            "value": {
+              "key": "Jewelry",
+              "label": "Jewelry",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 241,
+              "w": 209,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/necklace-KmP7rQDP.png",
+          },
+        ],
+        "key": "42610",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 1575,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "42610",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-02.ts
@@ -1,0 +1,39 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const necklaceVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('42610')
+    .key('42610')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('AUD')
+            .centAmount(1575)
+        )
+        .country('AU'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/necklace-KmP7rQDP.png'
+        )
+        .dimensions({ w: 209, h: 241 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('type').value({
+        key: 'Jewelry',
+        label: 'Jewelry',
+      }),
+    ])
+    .assets([]);
+
+export default necklaceVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-02.ts
@@ -33,7 +33,6 @@ const necklaceVariant02 = (): TProductVariantDraftBuilder =>
         key: 'Jewelry',
         label: 'Jewelry',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default necklaceVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-01.spec.ts
@@ -1,0 +1,145 @@
+import { TProductVariantDraft } from '../../../types';
+import promDressVariant01 from './prom-dress-variant-01';
+
+describe(`with promDressVariant01 preset`, () => {
+  it(`should return a promDressVariant01 preset`, () => {
+    const promDressVariant01Preset =
+      promDressVariant01().build<TProductVariantDraft>();
+    expect(promDressVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "color",
+            "value": {
+              "key": "Floral",
+              "label": "Floral",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 420,
+              "w": 411,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/floral-_WoTefrz.jpeg",
+          },
+        ],
+        "key": "711595",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 24795,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 17500,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "711595",
+      }
+    `);
+  });
+
+  it(`should return a promDressVariant01 preset when built for graphql`, () => {
+    const promDressVariant01PresetGraphql =
+      promDressVariant01().buildGraphql<TProductVariantDraft>();
+    expect(promDressVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "Floral",
+              "label": "Floral",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 420,
+              "w": 411,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/floral-_WoTefrz.jpeg",
+          },
+        ],
+        "key": "711595",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 24795,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 17500,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "711595",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with promDressVariant01 preset`, () => {
       promDressVariant01().build<TProductVariantDraft>();
     expect(promDressVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "color",
@@ -75,7 +75,7 @@ describe(`with promDressVariant01 preset`, () => {
     expect(promDressVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-01.ts
@@ -41,7 +41,6 @@ const promDressVariant01 = (): TProductVariantDraftBuilder =>
         key: 'Floral',
         label: 'Floral',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default promDressVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-01.ts
@@ -1,0 +1,47 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const promDressVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('711595')
+    .key('711595')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(24795)
+        )
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(17500)
+        )
+        .country('US'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/floral-_WoTefrz.jpeg'
+        )
+        .dimensions({ w: 411, h: 420 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('color').value({
+        key: 'Floral',
+        label: 'Floral',
+      }),
+    ])
+    .assets([]);
+
+export default promDressVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-02.spec.ts
@@ -1,0 +1,145 @@
+import { TProductVariantDraft } from '../../../types';
+import promDressVariant02 from './prom-dress-variant-02';
+
+describe(`with promDressVariant02 preset`, () => {
+  it(`should return a promDressVariant02 preset`, () => {
+    const promDressVariant02Preset =
+      promDressVariant02().build<TProductVariantDraft>();
+    expect(promDressVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "color",
+            "value": {
+              "key": "Pink",
+              "label": "Pink",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 1920,
+              "w": 1779,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/dress2-_nh_EhPL.png",
+          },
+        ],
+        "key": "214452",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 12500,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 15000,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "214452",
+      }
+    `);
+  });
+
+  it(`should return a promDressVariant02 preset when built for graphql`, () => {
+    const promDressVariant02PresetGraphql =
+      promDressVariant02().buildGraphql<TProductVariantDraft>();
+    expect(promDressVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "Pink",
+              "label": "Pink",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 1920,
+              "w": 1779,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/dress2-_nh_EhPL.png",
+          },
+        ],
+        "key": "214452",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 12500,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 15000,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "214452",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with promDressVariant02 preset`, () => {
       promDressVariant02().build<TProductVariantDraft>();
     expect(promDressVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "color",
@@ -75,7 +75,7 @@ describe(`with promDressVariant02 preset`, () => {
     expect(promDressVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-02.ts
@@ -1,0 +1,47 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const promDressVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('214452')
+    .key('214452')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(12500)
+        )
+        .country('ES'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('AUD')
+            .centAmount(15000)
+        )
+        .country('AU'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/dress2-_nh_EhPL.png'
+        )
+        .dimensions({ w: 1779, h: 1920 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('color').value({
+        key: 'Pink',
+        label: 'Pink',
+      }),
+    ])
+    .assets([]);
+
+export default promDressVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-02.ts
@@ -41,7 +41,6 @@ const promDressVariant02 = (): TProductVariantDraftBuilder =>
         key: 'Pink',
         label: 'Pink',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default promDressVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-01.spec.ts
@@ -1,0 +1,217 @@
+import { TProductVariantDraft } from '../../../types';
+import sandalsVariant01 from './sandals-variant-01';
+
+describe(`with sandals variant preset`, () => {
+  it(`should return a sandals preset`, () => {
+    const sandalsVariant01Preset =
+      sandalsVariant01().build<TProductVariantDraft>();
+    expect(sandalsVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "type",
+            "value": {
+              "key": "Shoes",
+              "label": "Shoes",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 222,
+              "w": 227,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/sandals-hd5LHY6T.png",
+          },
+        ],
+        "key": "148096",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 2500,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 3000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 2799,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 3000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "148096",
+      }
+    `);
+  });
+
+  it(`should return a sandals preset when built for graphql`, () => {
+    const sandalsVariant01PresetGraphql =
+      sandalsVariant01().buildGraphql<TProductVariantDraft>();
+    expect(sandalsVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "type",
+            "value": {
+              "key": "Shoes",
+              "label": "Shoes",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 222,
+              "w": 227,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/sandals-hd5LHY6T.png",
+          },
+        ],
+        "key": "148096",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 2500,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 3000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 2799,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 3000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "148096",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with sandals variant preset`, () => {
       sandalsVariant01().build<TProductVariantDraft>();
     expect(sandalsVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "type",
@@ -109,7 +109,7 @@ describe(`with sandals variant preset`, () => {
     expect(sandalsVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-01.ts
@@ -1,0 +1,63 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const sandalsVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('148096')
+    .key('148096')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('AUD')
+            .centAmount(2500)
+        )
+        .country('AU'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(3000)
+        )
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(2799)
+        )
+        .country('US'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(3000)
+        )
+        .country('ES'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/sandals-hd5LHY6T.png'
+        )
+        .dimensions({ w: 227, h: 222 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('type').value({
+        key: 'Shoes',
+        label: 'Shoes',
+      }),
+    ])
+    .assets([]);
+
+export default sandalsVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-01.ts
@@ -57,7 +57,6 @@ const sandalsVariant01 = (): TProductVariantDraftBuilder =>
         key: 'Shoes',
         label: 'Shoes',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default sandalsVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-02.spec.ts
@@ -1,0 +1,145 @@
+import { TProductVariantDraft } from '../../../types';
+import sandalsVariant02 from './sandals-variant-02';
+
+describe(`with sandalsAU variant preset`, () => {
+  it(`should return a sandalsAU preset`, () => {
+    const sandalsVariant02Preset =
+      sandalsVariant02().build<TProductVariantDraft>();
+    expect(sandalsVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "type",
+            "value": {
+              "key": "Shoes",
+              "label": "Shoes",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 230,
+              "w": 219,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/sandals-nDN7Ajoe.jpeg",
+          },
+        ],
+        "key": "148097",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1199,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1000,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "148097",
+      }
+    `);
+  });
+
+  it(`should return a sandalsAU preset when built for graphql`, () => {
+    const sandalsVariant02PresetGraphql =
+      sandalsVariant02().buildGraphql<TProductVariantDraft>();
+    expect(sandalsVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "type",
+            "value": {
+              "key": "Shoes",
+              "label": "Shoes",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 230,
+              "w": 219,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/sandals-nDN7Ajoe.jpeg",
+          },
+        ],
+        "key": "148097",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 1199,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 1000,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "148097",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with sandalsAU variant preset`, () => {
       sandalsVariant02().build<TProductVariantDraft>();
     expect(sandalsVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "type",
@@ -75,7 +75,7 @@ describe(`with sandalsAU variant preset`, () => {
     expect(sandalsVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-02.ts
@@ -1,0 +1,47 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const sandalsVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('148097')
+    .key('148097')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('AUD')
+            .centAmount(1199)
+        )
+        .country('AU'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(1000)
+        )
+        .country('US'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/sandals-nDN7Ajoe.jpeg'
+        )
+        .dimensions({ w: 219, h: 230 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('type').value({
+        key: 'Shoes',
+        label: 'Shoes',
+      }),
+    ])
+    .assets([]);
+
+export default sandalsVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-02.ts
@@ -41,7 +41,6 @@ const sandalsVariant02 = (): TProductVariantDraftBuilder =>
         key: 'Shoes',
         label: 'Shoes',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default sandalsVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-01.spec.ts
@@ -1,0 +1,124 @@
+import { TProductVariantDraft } from '../../../types';
+import skinnyJeansVariant01 from './skinny-jeans-variant-01';
+
+describe(`with skinnyJeansVariant01 preset`, () => {
+  it(`should return a skinnyJeansVariant01 preset`, () => {
+    const skinnyJeansVariant01Preset =
+      skinnyJeansVariant01().build<TProductVariantDraft>();
+    expect(skinnyJeansVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "fit",
+            "value": {
+              "key": "Slim",
+              "label": "Slim",
+            },
+          },
+          {
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 275,
+              "w": 183,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/skinny-QJz4Jcme.jpeg",
+          },
+        ],
+        "key": "396594",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 4999,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "396594",
+      }
+    `);
+  });
+
+  it(`should return a skinnyJeansVariant01 preset when built for graphql`, () => {
+    const skinnyJeansVariant01PresetGraphql =
+      skinnyJeansVariant01().buildGraphql<TProductVariantDraft>();
+    expect(skinnyJeansVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "fit",
+            "value": {
+              "key": "Slim",
+              "label": "Slim",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 275,
+              "w": 183,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/skinny-QJz4Jcme.jpeg",
+          },
+        ],
+        "key": "396594",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 4999,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "396594",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with skinnyJeansVariant01 preset`, () => {
       skinnyJeansVariant01().build<TProductVariantDraft>();
     expect(skinnyJeansVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "fit",
@@ -65,7 +65,7 @@ describe(`with skinnyJeansVariant01 preset`, () => {
     expect(skinnyJeansVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-01.ts
@@ -37,7 +37,6 @@ const skinnyJeansVariant01 = (): TProductVariantDraftBuilder =>
         key: 'Medium',
         label: 'Medium',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default skinnyJeansVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-01.ts
@@ -1,0 +1,43 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const skinnyJeansVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('396594')
+    .key('396594')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(4999)
+        )
+        .country('DE'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/skinny-QJz4Jcme.jpeg'
+        )
+        .dimensions({ w: 183, h: 275 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('fit').value({
+        key: 'Slim',
+        label: 'Slim',
+      }),
+      AttributeDraft.random().name('size').value({
+        key: 'Medium',
+        label: 'Medium',
+      }),
+    ])
+    .assets([]);
+
+export default skinnyJeansVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with skinnyJeansVariant02 preset`, () => {
       skinnyJeansVariant02().build<TProductVariantDraft>();
     expect(skinnyJeansVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -65,7 +65,7 @@ describe(`with skinnyJeansVariant02 preset`, () => {
     expect(skinnyJeansVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-02.spec.ts
@@ -1,0 +1,124 @@
+import { TProductVariantDraft } from '../../../types';
+import skinnyJeansVariant02 from './skinny-jeans-variant-02';
+
+describe(`with skinnyJeansVariant02 preset`, () => {
+  it(`should return a skinnyJeansVariant02 preset`, () => {
+    const skinnyJeansVariant02Preset =
+      skinnyJeansVariant02().build<TProductVariantDraft>();
+    expect(skinnyJeansVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+          {
+            "name": "fit",
+            "value": {
+              "key": "Slim",
+              "label": "Slim",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 150,
+              "w": 100,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/pants-qbuZJH9h.jpeg",
+          },
+        ],
+        "key": "349700",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 4999,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "349700",
+      }
+    `);
+  });
+
+  it(`should return a skinnyJeansVariant02 preset when built for graphql`, () => {
+    const skinnyJeansVariant02PresetGraphql =
+      skinnyJeansVariant02().buildGraphql<TProductVariantDraft>();
+    expect(skinnyJeansVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "fit",
+            "value": {
+              "key": "Slim",
+              "label": "Slim",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 150,
+              "w": 100,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/pants-qbuZJH9h.jpeg",
+          },
+        ],
+        "key": "349700",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 4999,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "349700",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-02.ts
@@ -1,0 +1,43 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const skinnyJeansVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('349700')
+    .key('349700')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(4999)
+        )
+        .country('DE'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/pants-qbuZJH9h.jpeg'
+        )
+        .dimensions({ w: 100, h: 150 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Large',
+        label: 'Large',
+      }),
+      AttributeDraft.random().name('fit').value({
+        key: 'Slim',
+        label: 'Slim',
+      }),
+    ])
+    .assets([]);
+
+export default skinnyJeansVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-02.ts
@@ -37,7 +37,6 @@ const skinnyJeansVariant02 = (): TProductVariantDraftBuilder =>
         key: 'Slim',
         label: 'Slim',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default skinnyJeansVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-01.spec.ts
@@ -1,0 +1,109 @@
+import { TProductVariantDraft } from '../../../types';
+import sportCoatVariant01 from './sport-coat-variant-01';
+
+describe(`with sportCoatVariant01 preset`, () => {
+  it(`should return a sportCoatVariant01 preset`, () => {
+    const sportCoatVariant01Preset =
+      sportCoatVariant01().build<TProductVariantDraft>();
+    expect(sportCoatVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "sleeve_length",
+            "value": {
+              "key": "Crop",
+              "label": "Crop",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 225,
+              "w": 225,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/coat-VmXqw3Xo.jpeg",
+          },
+        ],
+        "key": "692457",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 20000,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "692457",
+      }
+    `);
+  });
+
+  it(`should return a sportCoatVariant01 preset when built for graphql`, () => {
+    const sportCoatVariant01PresetGraphql =
+      sportCoatVariant01().buildGraphql<TProductVariantDraft>();
+    expect(sportCoatVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "sleeve_length",
+            "value": {
+              "key": "Crop",
+              "label": "Crop",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 225,
+              "w": 225,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/coat-VmXqw3Xo.jpeg",
+          },
+        ],
+        "key": "692457",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 20000,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "692457",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with sportCoatVariant01 preset`, () => {
       sportCoatVariant01().build<TProductVariantDraft>();
     expect(sportCoatVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "sleeve_length",
@@ -58,7 +58,7 @@ describe(`with sportCoatVariant01 preset`, () => {
     expect(sportCoatVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-01.ts
@@ -33,7 +33,6 @@ const sportCoatVariant01 = (): TProductVariantDraftBuilder =>
         key: 'Crop',
         label: 'Crop',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default sportCoatVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-01.ts
@@ -1,0 +1,39 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const sportCoatVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('692457')
+    .key('692457')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('AUD')
+            .centAmount(20000)
+        )
+        .country('AU'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/coat-VmXqw3Xo.jpeg'
+        )
+        .dimensions({ w: 225, h: 225 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('sleeve_length').value({
+        key: 'Crop',
+        label: 'Crop',
+      }),
+    ])
+    .assets([]);
+
+export default sportCoatVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with sportCoatVariant02 preset`, () => {
       sportCoatVariant02().build<TProductVariantDraft>();
     expect(sportCoatVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "sleeve_length",
@@ -58,7 +58,7 @@ describe(`with sportCoatVariant02 preset`, () => {
     expect(sportCoatVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-02.spec.ts
@@ -1,0 +1,109 @@
+import { TProductVariantDraft } from '../../../types';
+import sportCoatVariant02 from './sport-coat-variant-02';
+
+describe(`with sportCoatVariant02 preset`, () => {
+  it(`should return a sportCoatVariant02 preset`, () => {
+    const sportCoatVariant02Preset =
+      sportCoatVariant02().build<TProductVariantDraft>();
+    expect(sportCoatVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "sleeve_length",
+            "value": {
+              "key": "Normal",
+              "label": "Normal",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 150,
+              "w": 150,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/coat-Keqv_ZSU.jpeg",
+          },
+        ],
+        "key": "692458",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 20000,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "692458",
+      }
+    `);
+  });
+
+  it(`should return a sportCoatVariant02 preset when built for graphql`, () => {
+    const sportCoatVariant02PresetGraphql =
+      sportCoatVariant02().buildGraphql<TProductVariantDraft>();
+    expect(sportCoatVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "sleeve_length",
+            "value": {
+              "key": "Normal",
+              "label": "Normal",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 150,
+              "w": 150,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/coat-Keqv_ZSU.jpeg",
+          },
+        ],
+        "key": "692458",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "AU",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 20000,
+              "currencyCode": "AUD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "692458",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-02.ts
@@ -1,0 +1,39 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const sportCoatVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('692458')
+    .key('692458')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('AUD')
+            .centAmount(20000)
+        )
+        .country('AU'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/coat-Keqv_ZSU.jpeg'
+        )
+        .dimensions({ w: 150, h: 150 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('sleeve_length').value({
+        key: 'Normal',
+        label: 'Normal',
+      }),
+    ])
+    .assets([]);
+
+export default sportCoatVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-02.ts
@@ -33,7 +33,6 @@ const sportCoatVariant02 = (): TProductVariantDraftBuilder =>
         key: 'Normal',
         label: 'Normal',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default sportCoatVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-01.spec.ts
@@ -1,0 +1,145 @@
+import { TProductVariantDraft } from '../../../types';
+import summerDressVariant01 from './summer-dress-variant-01';
+
+describe(`with summerDressVariant01 preset`, () => {
+  it(`should return a summerDressVariant01 preset`, () => {
+    const summerDressVariant01Preset =
+      summerDressVariant01().build<TProductVariantDraft>();
+    expect(summerDressVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "color",
+            "value": {
+              "key": "White",
+              "label": "White",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 298,
+              "w": 276,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/dress-nsVCck7f.jpeg",
+          },
+        ],
+        "key": "791840",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 7500,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 8000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "791840",
+      }
+    `);
+  });
+
+  it(`should return a summerDressVariant01 preset when built for graphql`, () => {
+    const summerDressVariant01PresetGraphql =
+      summerDressVariant01().buildGraphql<TProductVariantDraft>();
+    expect(summerDressVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "White",
+              "label": "White",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 298,
+              "w": 276,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/dress-nsVCck7f.jpeg",
+          },
+        ],
+        "key": "791840",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 7500,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "ES",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 8000,
+              "currencyCode": "EUR",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "791840",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with summerDressVariant01 preset`, () => {
       summerDressVariant01().build<TProductVariantDraft>();
     expect(summerDressVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "color",
@@ -75,7 +75,7 @@ describe(`with summerDressVariant01 preset`, () => {
     expect(summerDressVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-01.ts
@@ -1,0 +1,47 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const summerDressVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('791840')
+    .key('791840')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(7500)
+        )
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('EUR')
+            .centAmount(8000)
+        )
+        .country('ES'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/dress-nsVCck7f.jpeg'
+        )
+        .dimensions({ w: 276, h: 298 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('color').value({
+        key: 'White',
+        label: 'White',
+      }),
+    ])
+    .assets([]);
+
+export default summerDressVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-01.ts
@@ -41,7 +41,6 @@ const summerDressVariant01 = (): TProductVariantDraftBuilder =>
         key: 'White',
         label: 'White',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default summerDressVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-02.spec.ts
@@ -1,0 +1,109 @@
+import { TProductVariantDraft } from '../../../types';
+import summerDressVariant02 from './summer-dress-variant-02';
+
+describe(`with summerDressVariant02 preset`, () => {
+  it(`should return a summerDressVariant02 preset`, () => {
+    const summerDressVariant02Preset =
+      summerDressVariant02().build<TProductVariantDraft>();
+    expect(summerDressVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "color",
+            "value": {
+              "key": "Pink",
+              "label": "Pink",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 254,
+              "w": 199,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/pinkdress-kKvWVHgG.png",
+          },
+        ],
+        "key": "439502",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 7500,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "439502",
+      }
+    `);
+  });
+
+  it(`should return a summerDressVariant02 preset when built for graphql`, () => {
+    const summerDressVariant02PresetGraphql =
+      summerDressVariant02().buildGraphql<TProductVariantDraft>();
+    expect(summerDressVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "Pink",
+              "label": "Pink",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 254,
+              "w": 199,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/pinkdress-kKvWVHgG.png",
+          },
+        ],
+        "key": "439502",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 7500,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "439502",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with summerDressVariant02 preset`, () => {
       summerDressVariant02().build<TProductVariantDraft>();
     expect(summerDressVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "color",
@@ -58,7 +58,7 @@ describe(`with summerDressVariant02 preset`, () => {
     expect(summerDressVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-02.ts
@@ -1,0 +1,39 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const summerDressVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('439502')
+    .key('439502')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(7500)
+        )
+        .country('US'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/pinkdress-kKvWVHgG.png'
+        )
+        .dimensions({ w: 199, h: 254 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('color').value({
+        key: 'Pink',
+        label: 'Pink',
+      }),
+    ])
+    .assets([]);
+
+export default summerDressVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-02.ts
@@ -33,7 +33,6 @@ const summerDressVariant02 = (): TProductVariantDraftBuilder =>
         key: 'Pink',
         label: 'Pink',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default summerDressVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-01.spec.ts
@@ -1,0 +1,154 @@
+import { TProductVariantDraft } from '../../../types';
+import toddlerTrousersVariant01 from './toddler-trousers-variant-02';
+
+describe(`with toddlerTrousersVariant01 preset`, () => {
+  it(`should return a toddlerTrousersVariant01 preset`, () => {
+    const toddlerTrousersVariant01Preset =
+      toddlerTrousersVariant01().build<TProductVariantDraft>();
+    expect(toddlerTrousersVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+          {
+            "name": "fit",
+            "value": {
+              "key": "Straight",
+              "label": "Straight",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "key": "White",
+              "label": "White",
+            },
+          },
+          {
+            "name": "length",
+            "value": {
+              "key": "Ankle",
+              "label": "Ankle",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 792,
+              "w": 612,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-SbjnediW.gif",
+          },
+        ],
+        "key": "855485",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 2599,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "855485",
+      }
+    `);
+  });
+
+  it(`should return a toddlerTrousersVariant01 preset when built for graphql`, () => {
+    const toddlerTrousersVariant01PresetGraphql =
+      toddlerTrousersVariant01().buildGraphql<TProductVariantDraft>();
+    expect(toddlerTrousersVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "fit",
+            "value": {
+              "key": "Straight",
+              "label": "Straight",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "White",
+              "label": "White",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "length",
+            "value": {
+              "key": "Ankle",
+              "label": "Ankle",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 792,
+              "w": 612,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-SbjnediW.gif",
+          },
+        ],
+        "key": "855485",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 2599,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "855485",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with toddlerTrousersVariant01 preset`, () => {
       toddlerTrousersVariant01().build<TProductVariantDraft>();
     expect(toddlerTrousersVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -79,7 +79,7 @@ describe(`with toddlerTrousersVariant01 preset`, () => {
     expect(toddlerTrousersVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-01.ts
@@ -45,7 +45,6 @@ const toddlerTrousersVariant01 = (): TProductVariantDraftBuilder =>
         key: 'Ankle',
         label: 'Ankle',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default toddlerTrousersVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-01.ts
@@ -1,0 +1,51 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const toddlerTrousersVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('855484')
+    .key('855484')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(2599)
+        )
+        .country('US'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-Z7CSIEMu.gif'
+        )
+        .dimensions({ w: 612, h: 792 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Small',
+        label: 'Small',
+      }),
+      AttributeDraft.random().name('fit').value({
+        key: 'Straight',
+        label: 'Straight',
+      }),
+      AttributeDraft.random().name('color').value({
+        key: 'White',
+        label: 'White',
+      }),
+      AttributeDraft.random().name('length').value({
+        key: 'Ankle',
+        label: 'Ankle',
+      }),
+    ])
+    .assets([]);
+
+export default toddlerTrousersVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with toddlerTrousersVariant02 preset`, () => {
       toddlerTrousersVariant02().build<TProductVariantDraft>();
     expect(toddlerTrousersVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -79,7 +79,7 @@ describe(`with toddlerTrousersVariant02 preset`, () => {
     expect(toddlerTrousersVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-02.spec.ts
@@ -1,0 +1,154 @@
+import { TProductVariantDraft } from '../../../types';
+import toddlerTrousersVariant02 from './toddler-trousers-variant-02';
+
+describe(`with toddlerTrousersVariant02 preset`, () => {
+  it(`should return a toddlerTrousersVariant02 preset`, () => {
+    const toddlerTrousersVariant02Preset =
+      toddlerTrousersVariant02().build<TProductVariantDraft>();
+    expect(toddlerTrousersVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+          {
+            "name": "fit",
+            "value": {
+              "key": "Straight",
+              "label": "Straight",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "key": "White",
+              "label": "White",
+            },
+          },
+          {
+            "name": "length",
+            "value": {
+              "key": "Ankle",
+              "label": "Ankle",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 792,
+              "w": 612,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-SbjnediW.gif",
+          },
+        ],
+        "key": "855485",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 2599,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "855485",
+      }
+    `);
+  });
+
+  it(`should return a toddlerTrousersVariant02 preset when built for graphql`, () => {
+    const toddlerTrousersVariant02PresetGraphql =
+      toddlerTrousersVariant02().buildGraphql<TProductVariantDraft>();
+    expect(toddlerTrousersVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Medium",
+              "label": "Medium",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "fit",
+            "value": {
+              "key": "Straight",
+              "label": "Straight",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "White",
+              "label": "White",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "length",
+            "value": {
+              "key": "Ankle",
+              "label": "Ankle",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 792,
+              "w": 612,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-SbjnediW.gif",
+          },
+        ],
+        "key": "855485",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 2599,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "855485",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-02.ts
@@ -1,0 +1,51 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const toddlerTrousersVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('855485')
+    .key('855485')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(2599)
+        )
+        .country('US'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-SbjnediW.gif'
+        )
+        .dimensions({ w: 612, h: 792 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Medium',
+        label: 'Medium',
+      }),
+      AttributeDraft.random().name('fit').value({
+        key: 'Straight',
+        label: 'Straight',
+      }),
+      AttributeDraft.random().name('color').value({
+        key: 'White',
+        label: 'White',
+      }),
+      AttributeDraft.random().name('length').value({
+        key: 'Ankle',
+        label: 'Ankle',
+      }),
+    ])
+    .assets([]);
+
+export default toddlerTrousersVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-02.ts
@@ -45,7 +45,6 @@ const toddlerTrousersVariant02 = (): TProductVariantDraftBuilder =>
         key: 'Ankle',
         label: 'Ankle',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default toddlerTrousersVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-03.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-03.spec.ts
@@ -7,7 +7,7 @@ describe(`with toddlerTrousersVariant03 preset`, () => {
       toddlerTrousersVariant03().build<TProductVariantDraft>();
     expect(toddlerTrousersVariant03Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "size",
@@ -79,7 +79,7 @@ describe(`with toddlerTrousersVariant03 preset`, () => {
     expect(toddlerTrousersVariant03PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-03.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-03.spec.ts
@@ -1,0 +1,154 @@
+import { TProductVariantDraft } from '../../../types';
+import toddlerTrousersVariant03 from './toddler-trousers-variant-03';
+
+describe(`with toddlerTrousersVariant03 preset`, () => {
+  it(`should return a toddlerTrousersVariant03 preset`, () => {
+    const toddlerTrousersVariant03Preset =
+      toddlerTrousersVariant03().build<TProductVariantDraft>();
+    expect(toddlerTrousersVariant03Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+          {
+            "name": "fit",
+            "value": {
+              "key": "Straight",
+              "label": "Straight",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "key": "White",
+              "label": "White",
+            },
+          },
+          {
+            "name": "length",
+            "value": {
+              "key": "Ankle",
+              "label": "Ankle",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 792,
+              "w": 612,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-i2b2bEGD.gif",
+          },
+        ],
+        "key": "855486",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 2599,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "855486",
+      }
+    `);
+  });
+
+  it(`should return a toddlerTrousersVariant03 preset when built for graphql`, () => {
+    const toddlerTrousersVariant03PresetGraphql =
+      toddlerTrousersVariant03().buildGraphql<TProductVariantDraft>();
+    expect(toddlerTrousersVariant03PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "size",
+            "value": {
+              "key": "Large",
+              "label": "Large",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "fit",
+            "value": {
+              "key": "Straight",
+              "label": "Straight",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "color",
+            "value": {
+              "key": "White",
+              "label": "White",
+            },
+          },
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "length",
+            "value": {
+              "key": "Ankle",
+              "label": "Ankle",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 792,
+              "w": 612,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-i2b2bEGD.gif",
+          },
+        ],
+        "key": "855486",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 2599,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "855486",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-03.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-03.ts
@@ -45,7 +45,6 @@ const toddlerTrousersVariant03 = (): TProductVariantDraftBuilder =>
         key: 'Ankle',
         label: 'Ankle',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default toddlerTrousersVariant03;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-03.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-03.ts
@@ -1,0 +1,51 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const toddlerTrousersVariant03 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('855486')
+    .key('855486')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(2599)
+        )
+        .country('US'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-i2b2bEGD.gif'
+        )
+        .dimensions({ w: 612, h: 792 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('size').value({
+        key: 'Large',
+        label: 'Large',
+      }),
+      AttributeDraft.random().name('fit').value({
+        key: 'Straight',
+        label: 'Straight',
+      }),
+      AttributeDraft.random().name('color').value({
+        key: 'White',
+        label: 'White',
+      }),
+      AttributeDraft.random().name('length').value({
+        key: 'Ankle',
+        label: 'Ankle',
+      }),
+    ])
+    .assets([]);
+
+export default toddlerTrousersVariant03;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-01.spec.ts
@@ -7,7 +7,7 @@ describe(`with toteBagVariant01 preset`, () => {
       toteBagVariant01().build<TProductVariantDraft>();
     expect(toteBagVariant01Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "type",
@@ -58,7 +58,7 @@ describe(`with toteBagVariant01 preset`, () => {
     expect(toteBagVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-01.spec.ts
@@ -1,0 +1,109 @@
+import { TProductVariantDraft } from '../../../types';
+import toteBagVariant01 from './tote-bag-variant-01';
+
+describe(`with toteBagVariant01 preset`, () => {
+  it(`should return a toteBagVariant01 preset`, () => {
+    const toteBagVariant01Preset =
+      toteBagVariant01().build<TProductVariantDraft>();
+    expect(toteBagVariant01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "type",
+            "value": {
+              "key": "Bag",
+              "label": "Bag",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 800,
+              "w": 766,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/tote-V4lrDZ9Q.png",
+          },
+        ],
+        "key": "718289",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 13999,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "718289",
+      }
+    `);
+  });
+
+  it(`should return a toteBagVariant01 preset when built for graphql`, () => {
+    const toteBagVariant01PresetGraphql =
+      toteBagVariant01().buildGraphql<TProductVariantDraft>();
+    expect(toteBagVariant01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "type",
+            "value": {
+              "key": "Bag",
+              "label": "Bag",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 800,
+              "w": 766,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/tote-V4lrDZ9Q.png",
+          },
+        ],
+        "key": "718289",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 13999,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "718289",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-01.ts
@@ -1,0 +1,39 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const toteBagVariant01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('718289')
+    .key('718289')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(13999)
+        )
+        .country('US'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/tote-V4lrDZ9Q.png'
+        )
+        .dimensions({ w: 766, h: 800 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('type').value({
+        key: 'Bag',
+        label: 'Bag',
+      }),
+    ])
+    .assets([]);
+
+export default toteBagVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-01.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-01.ts
@@ -33,7 +33,6 @@ const toteBagVariant01 = (): TProductVariantDraftBuilder =>
         key: 'Bag',
         label: 'Bag',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default toteBagVariant01;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-02.spec.ts
@@ -7,7 +7,7 @@ describe(`with toteBagVariant02 preset`, () => {
       toteBagVariant02().build<TProductVariantDraft>();
     expect(toteBagVariant02Preset).toMatchInlineSnapshot(`
       {
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "name": "type",
@@ -58,7 +58,7 @@ describe(`with toteBagVariant02 preset`, () => {
     expect(toteBagVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
         "__typename": "ProductVariantInput",
-        "assets": [],
+        "assets": undefined,
         "attributes": [
           {
             "__typename": "ProductAttributeInput",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-02.spec.ts
@@ -1,0 +1,109 @@
+import { TProductVariantDraft } from '../../../types';
+import toteBagVariant02 from './tote-bag-variant-02';
+
+describe(`with toteBagVariant02 preset`, () => {
+  it(`should return a toteBagVariant02 preset`, () => {
+    const toteBagVariant02Preset =
+      toteBagVariant02().build<TProductVariantDraft>();
+    expect(toteBagVariant02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": [],
+        "attributes": [
+          {
+            "name": "type",
+            "value": {
+              "key": "Bag",
+              "label": "Bag",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 800,
+              "w": 675,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/bag-371ygCjz.png",
+          },
+        ],
+        "key": "124965",
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 17500,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "124965",
+      }
+    `);
+  });
+
+  it(`should return a toteBagVariant02 preset when built for graphql`, () => {
+    const toteBagVariant02PresetGraphql =
+      toteBagVariant02().buildGraphql<TProductVariantDraft>();
+    expect(toteBagVariant02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductVariantInput",
+        "assets": [],
+        "attributes": [
+          {
+            "__typename": "ProductAttributeInput",
+            "name": "type",
+            "value": {
+              "key": "Bag",
+              "label": "Bag",
+            },
+          },
+        ],
+        "images": [
+          {
+            "__typename": "Image",
+            "dimensions": {
+              "h": 800,
+              "w": 675,
+            },
+            "label": undefined,
+            "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/bag-371ygCjz.png",
+          },
+        ],
+        "key": "124965",
+        "prices": [
+          {
+            "__typename": "ProductPriceDataInput",
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "__typename": "MoneyInput",
+              "centAmount": 17500,
+              "currencyCode": "USD",
+              "fractionDigits": 2,
+              "type": "centPrecision",
+            },
+          },
+        ],
+        "sku": "124965",
+      }
+    `);
+  });
+});

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-02.ts
@@ -1,0 +1,39 @@
+import * as CentPrecisionMoney from '@commercetools-test-data/cent-precision-money';
+import { PriceDraft } from '@commercetools-test-data/price';
+import * as ProductVariantDraft from '../..';
+import { AttributeDraft } from '../../../../attribute/';
+import * as Image from '../../../../image';
+import { TProductVariantDraftBuilder } from '../../../types';
+
+const toteBagVariant02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('124965')
+    .key('124965')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(
+          CentPrecisionMoney.CentPrecisionMoneyDraft.random()
+            .currencyCode('USD')
+            .centAmount(17500)
+        )
+        .country('US'),
+    ])
+    .images([
+      Image.presets
+        .empty()
+        .url(
+          'https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/bag-371ygCjz.png'
+        )
+        .dimensions({ w: 675, h: 800 }),
+    ])
+    .attributes([
+      AttributeDraft.random().name('type').value({
+        key: 'Bag',
+        label: 'Bag',
+      }),
+    ])
+    .assets([]);
+
+export default toteBagVariant02;

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-02.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-02.ts
@@ -33,7 +33,6 @@ const toteBagVariant02 = (): TProductVariantDraftBuilder =>
         key: 'Bag',
         label: 'Bag',
       }),
-    ])
-    .assets([]);
+    ]);
 
 export default toteBagVariant02;

--- a/models/product/src/product/product-draft/generator.ts
+++ b/models/product/src/product/product-draft/generator.ts
@@ -1,4 +1,8 @@
-import { LocalizedString, Reference } from '@commercetools-test-data/commons';
+import {
+  LocalizedString,
+  Reference,
+  KeyReference,
+} from '@commercetools-test-data/commons';
 import { fake, Generator, oneOf } from '@commercetools-test-data/core';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import { productPriceMode } from '../constants';
@@ -13,7 +17,7 @@ const generator = Generator<TProductDraft>({
     slug: fake(() => LocalizedString.random()),
     key: fake((f) => f.lorem.slug()),
     description: fake(() => LocalizedString.random()),
-    categories: fake(() => [Reference.random().typeId('category')]),
+    categories: fake(() => [KeyReference.presets.category()]),
     categoryOrderHints: null,
     metaTitle: null,
     metaDescription: null,

--- a/models/product/src/product/product-draft/presets/empty.spec.ts
+++ b/models/product/src/product/product-draft/presets/empty.spec.ts
@@ -1,0 +1,36 @@
+import { TProductDraft } from '../../types';
+import empty from './empty';
+
+it(`should set all specified fields to undefined`, () => {
+  const emptyProductDraft = empty().build<TProductDraft>();
+  expect(emptyProductDraft.name).toEqual({
+    de: expect.any(String),
+    en: expect.any(String),
+    fr: expect.any(String),
+  });
+  expect(emptyProductDraft.productType).toEqual({
+    id: expect.any(String),
+    typeId: expect.any(String),
+  });
+  expect(emptyProductDraft.slug).toEqual({
+    de: expect.any(String),
+    en: expect.any(String),
+    fr: expect.any(String),
+  });
+  expect(emptyProductDraft.key).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.description).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.categories).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.categoryOrderHints).toMatchInlineSnapshot(
+    `undefined`
+  );
+  expect(emptyProductDraft.metaTitle).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.metaDescription).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.metaKeywords).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.masterVariant).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.variants).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.taxCategory).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.state).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.priceMode).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.searchKeywords).toMatchInlineSnapshot(`undefined`);
+  expect(emptyProductDraft.publish).toMatchInlineSnapshot(`undefined`);
+});

--- a/models/product/src/product/product-draft/presets/empty.ts
+++ b/models/product/src/product/product-draft/presets/empty.ts
@@ -1,0 +1,21 @@
+import type { TProductDraftBuilder } from '../../types';
+import ProductDraft from '../builder';
+
+const empty = (): TProductDraftBuilder =>
+  ProductDraft()
+    .key(undefined)
+    .description(undefined)
+    .categories(undefined)
+    .categoryOrderHints(undefined)
+    .metaTitle(undefined)
+    .metaDescription(undefined)
+    .metaKeywords(undefined)
+    .masterVariant(undefined)
+    .variants(undefined)
+    .taxCategory(undefined)
+    .state(undefined)
+    .priceMode(undefined)
+    .searchKeywords(undefined)
+    .publish(undefined);
+
+export default empty;

--- a/models/product/src/product/product-draft/presets/index.ts
+++ b/models/product/src/product/product-draft/presets/index.ts
@@ -1,3 +1,6 @@
-const presets = {};
+import empty from './empty';
+import sampleDataFashion from './sample-data-fashion';
+
+const presets = { empty, sampleDataFashion };
 
 export default presets;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.spec.ts
@@ -32,7 +32,7 @@ describe(`with anniversaryShirt preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Anniversary Shirt",
+          "en-US": "Sample Anniversary Shirt",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -45,7 +45,7 @@ describe(`with anniversaryShirt preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-anniversary-shirt",
+          "en-US": "sample-anniversary-shirt",
           "fr": undefined,
         },
         "state": undefined,
@@ -125,7 +125,7 @@ describe(`with anniversaryShirt preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Anniversary Shirt",
           },
         ],
@@ -140,7 +140,7 @@ describe(`with anniversaryShirt preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-anniversary-shirt",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.spec.ts
@@ -11,7 +11,7 @@ describe(`with anniversaryShirt preset`, () => {
         "description": undefined,
         "key": "anniversary_shirt",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "size",
@@ -21,9 +21,9 @@ describe(`with anniversaryShirt preset`, () => {
               },
             },
           ],
-          "images": [],
+          "images": undefined,
           "key": undefined,
-          "prices": [],
+          "prices": undefined,
           "sku": undefined,
         },
         "metaDescription": undefined,
@@ -55,7 +55,7 @@ describe(`with anniversaryShirt preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "size",
@@ -65,13 +65,13 @@ describe(`with anniversaryShirt preset`, () => {
                 },
               },
             ],
-            "images": [],
+            "images": undefined,
             "key": undefined,
-            "prices": [],
+            "prices": undefined,
             "sku": undefined,
           },
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "size",
@@ -81,9 +81,9 @@ describe(`with anniversaryShirt preset`, () => {
                 },
               },
             ],
-            "images": [],
+            "images": undefined,
             "key": undefined,
-            "prices": [],
+            "prices": undefined,
             "sku": undefined,
           },
         ],
@@ -103,7 +103,7 @@ describe(`with anniversaryShirt preset`, () => {
         "key": "anniversary_shirt",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -114,9 +114,9 @@ describe(`with anniversaryShirt preset`, () => {
               },
             },
           ],
-          "images": [],
+          "images": undefined,
           "key": undefined,
-          "prices": [],
+          "prices": undefined,
           "sku": undefined,
         },
         "metaDescription": undefined,
@@ -153,7 +153,7 @@ describe(`with anniversaryShirt preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",
@@ -164,14 +164,14 @@ describe(`with anniversaryShirt preset`, () => {
                 },
               },
             ],
-            "images": [],
+            "images": undefined,
             "key": undefined,
-            "prices": [],
+            "prices": undefined,
             "sku": undefined,
           },
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",
@@ -182,9 +182,9 @@ describe(`with anniversaryShirt preset`, () => {
                 },
               },
             ],
-            "images": [],
+            "images": undefined,
             "key": undefined,
-            "prices": [],
+            "prices": undefined,
             "sku": undefined,
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.spec.ts
@@ -1,0 +1,194 @@
+import { TProductDraft } from '../../../types';
+import anniversaryShirt from './anniversary-shirt';
+
+describe(`with anniversaryShirt preset`, () => {
+  it('should return a sample anniversaryShirt product preset', () => {
+    const anniversaryShirtPreset = anniversaryShirt().build<TProductDraft>();
+    expect(anniversaryShirtPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "anniversary_shirt",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "size",
+              "value": {
+                "key": "Small",
+                "label": "Small",
+              },
+            },
+          ],
+          "images": [],
+          "key": undefined,
+          "prices": [],
+          "sku": undefined,
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Anniversary Shirt",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "shirts",
+          "typeId": "product-type",
+        },
+        "publish": false,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-anniversary-shirt",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "size",
+                "value": {
+                  "key": "Medium",
+                  "label": "Medium",
+                },
+              },
+            ],
+            "images": [],
+            "key": undefined,
+            "prices": [],
+            "sku": undefined,
+          },
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "size",
+                "value": {
+                  "key": "Large",
+                  "label": "Large",
+                },
+              },
+            ],
+            "images": [],
+            "key": undefined,
+            "prices": [],
+            "sku": undefined,
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample anniversaryShirt product preset when built for graphql', () => {
+    const anniversaryShirtPresetGrahql =
+      anniversaryShirt().buildGraphql<TProductDraft>();
+    expect(anniversaryShirtPresetGrahql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "anniversary_shirt",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "size",
+              "value": {
+                "key": "Small",
+                "label": "Small",
+              },
+            },
+          ],
+          "images": [],
+          "key": undefined,
+          "prices": [],
+          "sku": undefined,
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Anniversary Shirt",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "shirts",
+          "typeId": "product-type",
+        },
+        "publish": false,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-anniversary-shirt",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "size",
+                "value": {
+                  "key": "Medium",
+                  "label": "Medium",
+                },
+              },
+            ],
+            "images": [],
+            "key": undefined,
+            "prices": [],
+            "sku": undefined,
+          },
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "size",
+                "value": {
+                  "key": "Large",
+                  "label": "Large",
+                },
+              },
+            ],
+            "images": [],
+            "key": undefined,
+            "prices": [],
+            "sku": undefined,
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const anniversaryShirt = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const anniversaryShirt = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Anniversary Shirt'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-anniversary-shirt'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Anniversary Shirt'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-anniversary-shirt'))
     .productType(KeyReference.presets.productType().key('shirts'))
     .publish(false)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.ts
@@ -1,0 +1,26 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const anniversaryShirt = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Anniversary Shirt'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-anniversary-shirt'))
+    .productType(KeyReference.presets.productType().key('shirts'))
+    .publish(false)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.anniversaryShirtVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.anniversaryShirtVariant02(),
+      ProductVariantDraft.presets.sampleDataFashion.anniversaryShirtVariant03(),
+    ])
+    .key('anniversary_shirt')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default anniversaryShirt;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const shirtProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .shirts()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const anniversaryShirt = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Anniversary Shirt'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-anniversary-shirt'))
-    .productType(KeyReference.presets.productType().key('shirts'))
+    .productType(
+      KeyReference.presets.productType().key(shirtProductTypeDraft.key!)
+    )
     .publish(false)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.anniversaryShirtVariant01()
@@ -21,6 +35,8 @@ const anniversaryShirt = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.anniversaryShirtVariant03(),
     ])
     .key('anniversary_shirt')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default anniversaryShirt;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.spec.ts
@@ -11,7 +11,7 @@ describe(`with denimJacket preset`, () => {
         "description": undefined,
         "key": "denim_jacket",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "sleeve_length",
@@ -103,7 +103,7 @@ describe(`with denimJacket preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "sleeve_length",
@@ -183,7 +183,7 @@ describe(`with denimJacket preset`, () => {
         "key": "denim_jacket",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -287,7 +287,7 @@ describe(`with denimJacket preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.spec.ts
@@ -1,0 +1,364 @@
+import { TProductDraft } from '../../../types';
+import denimJacket from './denim-jacket';
+
+describe(`with denimJacket preset`, () => {
+  it('should return a sample denimJacket product preset', () => {
+    const denimJacketPreset = denimJacket().build<TProductDraft>();
+    expect(denimJacketPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "denim_jacket",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "sleeve_length",
+              "value": {
+                "key": "Normal",
+                "label": "Normal",
+              },
+            },
+            {
+              "name": "cotton",
+              "value": false,
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 225,
+                "w": 225,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/denim-_KAoINSX.jpeg",
+            },
+          ],
+          "key": "996024",
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 10000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "ES",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 10000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "996024",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Denim Jacket",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "jackets",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-denim-jacket",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "sleeve_length",
+                "value": {
+                  "key": "Extra Long",
+                  "label": "Extra Long",
+                },
+              },
+              {
+                "name": "cotton",
+                "value": false,
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 225,
+                  "w": 225,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/denim-pmNAetyM.jpeg",
+              },
+            ],
+            "key": "996025",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 10000,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "ES",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 10000,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "996025",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample denimJacket product preset when built for graphql', () => {
+    const denimJacketPresetGraphql =
+      denimJacket().buildGraphql<TProductDraft>();
+    expect(denimJacketPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "denim_jacket",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "sleeve_length",
+              "value": {
+                "key": "Normal",
+                "label": "Normal",
+              },
+            },
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "cotton",
+              "value": false,
+            },
+          ],
+          "images": [
+            {
+              "__typename": "Image",
+              "dimensions": {
+                "h": 225,
+                "w": 225,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/denim-_KAoINSX.jpeg",
+            },
+          ],
+          "key": "996024",
+          "prices": [
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 10000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "ES",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 10000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "996024",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Denim Jacket",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "jackets",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-denim-jacket",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "sleeve_length",
+                "value": {
+                  "key": "Extra Long",
+                  "label": "Extra Long",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "cotton",
+                "value": false,
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 225,
+                  "w": 225,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/denim-pmNAetyM.jpeg",
+              },
+            ],
+            "key": "996025",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 10000,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "ES",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 10000,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "996025",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.spec.ts
@@ -80,7 +80,7 @@ describe(`with denimJacket preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Denim Jacket",
+          "en-US": "Sample Denim Jacket",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -93,7 +93,7 @@ describe(`with denimJacket preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-denim-jacket",
+          "en-US": "sample-denim-jacket",
           "fr": undefined,
         },
         "state": undefined,
@@ -259,7 +259,7 @@ describe(`with denimJacket preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Denim Jacket",
           },
         ],
@@ -274,7 +274,7 @@ describe(`with denimJacket preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-denim-jacket",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const denimJacket = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const denimJacket = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Denim Jacket'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-denim-jacket'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Denim Jacket'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-denim-jacket'))
     .productType(KeyReference.presets.productType().key('jackets'))
     .publish(true)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.ts
@@ -1,0 +1,25 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const denimJacket = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Denim Jacket'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-denim-jacket'))
+    .productType(KeyReference.presets.productType().key('jackets'))
+    .publish(true)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.denimJacketVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.denimJacketVariant02(),
+    ])
+    .key('denim_jacket')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default denimJacket;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const jacketsProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .jackets()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const denimJacket = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Denim Jacket'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-denim-jacket'))
-    .productType(KeyReference.presets.productType().key('jackets'))
+    .productType(
+      KeyReference.presets.productType().key(jacketsProductTypeDraft.key!)
+    )
     .publish(true)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.denimJacketVariant01()
@@ -20,6 +34,8 @@ const denimJacket = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.denimJacketVariant02(),
     ])
     .key('denim_jacket')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default denimJacket;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.spec.ts
@@ -11,7 +11,7 @@ describe(`with flairJeans preset`, () => {
         "description": undefined,
         "key": "flair_jeans",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "size",
@@ -42,9 +42,9 @@ describe(`with flairJeans preset`, () => {
               },
             },
           ],
-          "images": [],
+          "images": undefined,
           "key": undefined,
-          "prices": [],
+          "prices": undefined,
           "sku": undefined,
         },
         "metaDescription": undefined,
@@ -76,7 +76,7 @@ describe(`with flairJeans preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "size",
@@ -107,9 +107,9 @@ describe(`with flairJeans preset`, () => {
                 },
               },
             ],
-            "images": [],
+            "images": undefined,
             "key": undefined,
-            "prices": [],
+            "prices": undefined,
             "sku": undefined,
           },
         ],
@@ -128,7 +128,7 @@ describe(`with flairJeans preset`, () => {
         "key": "flair_jeans",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -163,9 +163,9 @@ describe(`with flairJeans preset`, () => {
               },
             },
           ],
-          "images": [],
+          "images": undefined,
           "key": undefined,
-          "prices": [],
+          "prices": undefined,
           "sku": undefined,
         },
         "metaDescription": undefined,
@@ -202,7 +202,7 @@ describe(`with flairJeans preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",
@@ -237,9 +237,9 @@ describe(`with flairJeans preset`, () => {
                 },
               },
             ],
-            "images": [],
+            "images": undefined,
             "key": undefined,
-            "prices": [],
+            "prices": undefined,
             "sku": undefined,
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.spec.ts
@@ -53,7 +53,7 @@ describe(`with flairJeans preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Flair Jeans",
+          "en-US": "Sample Flair Jeans",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -66,7 +66,7 @@ describe(`with flairJeans preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-flair-jeans",
+          "en-US": "sample-flair-jeans",
           "fr": undefined,
         },
         "state": undefined,
@@ -174,7 +174,7 @@ describe(`with flairJeans preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Flair Jeans",
           },
         ],
@@ -189,7 +189,7 @@ describe(`with flairJeans preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-flair-jeans",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.spec.ts
@@ -1,0 +1,249 @@
+import { TProductDraft } from '../../../types';
+import flairJeans from './flair-jeans';
+
+describe(`with flairJeans preset`, () => {
+  it('should return a sample flairJeans product preset', () => {
+    const flairJeansPreset = flairJeans().build<TProductDraft>();
+    expect(flairJeansPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "flair_jeans",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "size",
+              "value": {
+                "key": "Large",
+                "label": "Large",
+              },
+            },
+            {
+              "name": "fit",
+              "value": {
+                "key": "Flair",
+                "label": "Flair",
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "key": "Blue",
+                "label": "Blue",
+              },
+            },
+            {
+              "name": "length",
+              "value": {
+                "key": "Crop",
+                "label": "Crop",
+              },
+            },
+          ],
+          "images": [],
+          "key": undefined,
+          "prices": [],
+          "sku": undefined,
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Flair Jeans",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "pants",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-flair-jeans",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "size",
+                "value": {
+                  "key": "Medium",
+                  "label": "Medium",
+                },
+              },
+              {
+                "name": "fit",
+                "value": {
+                  "key": "Flair",
+                  "label": "Flair",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "key": "Black",
+                  "label": "Black",
+                },
+              },
+              {
+                "name": "length",
+                "value": {
+                  "key": "Extra Long",
+                  "label": "Extra Long",
+                },
+              },
+            ],
+            "images": [],
+            "key": undefined,
+            "prices": [],
+            "sku": undefined,
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample flairJeans product preset when built for graphql', () => {
+    const flairJeansPresetGraphql = flairJeans().buildGraphql<TProductDraft>();
+    expect(flairJeansPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "flair_jeans",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "size",
+              "value": {
+                "key": "Large",
+                "label": "Large",
+              },
+            },
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "fit",
+              "value": {
+                "key": "Flair",
+                "label": "Flair",
+              },
+            },
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "color",
+              "value": {
+                "key": "Blue",
+                "label": "Blue",
+              },
+            },
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "length",
+              "value": {
+                "key": "Crop",
+                "label": "Crop",
+              },
+            },
+          ],
+          "images": [],
+          "key": undefined,
+          "prices": [],
+          "sku": undefined,
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Flair Jeans",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "pants",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-flair-jeans",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "size",
+                "value": {
+                  "key": "Medium",
+                  "label": "Medium",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "fit",
+                "value": {
+                  "key": "Flair",
+                  "label": "Flair",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "color",
+                "value": {
+                  "key": "Black",
+                  "label": "Black",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "length",
+                "value": {
+                  "key": "Extra Long",
+                  "label": "Extra Long",
+                },
+              },
+            ],
+            "images": [],
+            "key": undefined,
+            "prices": [],
+            "sku": undefined,
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const flairJeans = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Flair Jeans'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-flair-jeans'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Flair Jeans'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-flair-jeans'))
     .productType(KeyReference.presets.productType().key('pants'))
     .publish(true)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.ts
@@ -1,0 +1,25 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const flairJeans = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Flair Jeans'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-flair-jeans'))
+    .productType(KeyReference.presets.productType().key('pants'))
+    .publish(true)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.flairJeansVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.flairJeansVariant02(),
+    ])
+    .key('flair_jeans')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default flairJeans;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const flairJeans = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const pantsProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .pants()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const flairJeans = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Flair Jeans'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-flair-jeans'))
-    .productType(KeyReference.presets.productType().key('pants'))
+    .productType(
+      KeyReference.presets.productType().key(pantsProductTypeDraft.key!)
+    )
     .publish(true)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.flairJeansVariant01()
@@ -20,6 +34,8 @@ const flairJeans = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.flairJeansVariant02(),
     ])
     .key('flair_jeans')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default flairJeans;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.spec.ts
@@ -100,7 +100,7 @@ describe(`with halloweenTop preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Halloween Top",
+          "en-US": "Sample Halloween Top",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -113,7 +113,7 @@ describe(`with halloweenTop preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-halloween-top",
+          "en-US": "sample-halloween-top",
           "fr": undefined,
         },
         "state": undefined,
@@ -321,7 +321,7 @@ describe(`with halloweenTop preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Halloween Top",
           },
         ],
@@ -336,7 +336,7 @@ describe(`with halloweenTop preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-halloween-top",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.spec.ts
@@ -11,7 +11,7 @@ describe(`with halloweenTop preset`, () => {
         "description": undefined,
         "key": "Halloween Top",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "size",
@@ -123,7 +123,7 @@ describe(`with halloweenTop preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "size",
@@ -223,7 +223,7 @@ describe(`with halloweenTop preset`, () => {
         "key": "Halloween Top",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -349,7 +349,7 @@ describe(`with halloweenTop preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.spec.ts
@@ -1,0 +1,448 @@
+import { TProductDraft } from '../../../types';
+import halloweenTop from './halloween-top';
+
+describe(`with halloweenTop preset`, () => {
+  it('should return a sample halloweenTop product preset', () => {
+    const halloweenTopPreset = halloweenTop().build<TProductDraft>();
+    expect(halloweenTopPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "Halloween Top",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "size",
+              "value": {
+                "key": "Medium",
+                "label": "Medium",
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "key": "Purple",
+                "label": "Purple",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 235,
+                "w": 215,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/purple-5xg50uIz.png",
+            },
+          ],
+          "key": "888035",
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 2500,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 2500,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "ES",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 2500,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "888035",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Halloween Top",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "shirts",
+          "typeId": "product-type",
+        },
+        "publish": false,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-halloween-top",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "size",
+                "value": {
+                  "key": "Large",
+                  "label": "Large",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "key": "Multi-Color",
+                  "label": "Multi-Color",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 700,
+                  "w": 900,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/multi-TjZTRFuz.jpeg",
+              },
+            ],
+            "key": "828329",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 3000,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 3000,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "ES",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 3300,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "828329",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample halloweenTop product preset when built for graphql', () => {
+    const halloweenTopPresetGraphql =
+      halloweenTop().buildGraphql<TProductDraft>();
+    expect(halloweenTopPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "Halloween Top",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "size",
+              "value": {
+                "key": "Medium",
+                "label": "Medium",
+              },
+            },
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "color",
+              "value": {
+                "key": "Purple",
+                "label": "Purple",
+              },
+            },
+          ],
+          "images": [
+            {
+              "__typename": "Image",
+              "dimensions": {
+                "h": 235,
+                "w": 215,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/purple-5xg50uIz.png",
+            },
+          ],
+          "key": "888035",
+          "prices": [
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 2500,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 2500,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "ES",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 2500,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "888035",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Halloween Top",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "shirts",
+          "typeId": "product-type",
+        },
+        "publish": false,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-halloween-top",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "size",
+                "value": {
+                  "key": "Large",
+                  "label": "Large",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "color",
+                "value": {
+                  "key": "Multi-Color",
+                  "label": "Multi-Color",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 700,
+                  "w": 900,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/multi-TjZTRFuz.jpeg",
+              },
+            ],
+            "key": "828329",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 3000,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 3000,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "ES",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 3300,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "828329",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.ts
@@ -1,0 +1,25 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const halloweenTop = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Halloween Top'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-halloween-top'))
+    .productType(KeyReference.presets.productType().key('shirts'))
+    .publish(false)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.halloweenTopVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.halloweenTopVariant02(),
+    ])
+    .key('Halloween Top')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default halloweenTop;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const halloweenTop = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const shirtProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .shirts()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const halloweenTop = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Halloween Top'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-halloween-top'))
-    .productType(KeyReference.presets.productType().key('shirts'))
+    .productType(
+      KeyReference.presets.productType().key(shirtProductTypeDraft.key!)
+    )
     .publish(false)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.halloweenTopVariant01()
@@ -20,6 +34,8 @@ const halloweenTop = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.halloweenTopVariant02(),
     ])
     .key('Halloween Top')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default halloweenTop;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const halloweenTop = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Halloween Top'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-halloween-top'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Halloween Top'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-halloween-top'))
     .productType(KeyReference.presets.productType().key('shirts'))
     .publish(false)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/index.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/index.ts
@@ -1,0 +1,31 @@
+import anniversaryShirt from './anniversary-shirt';
+import denimJacket from './denim-jacket';
+import flairJeans from './flair-jeans';
+import halloweenTop from './halloween-top';
+import maternityTop from './maternity-top';
+import necklace from './necklace';
+import promDress from './prom-dress';
+import sandals from './sandals';
+import skinnyJeans from './skinny-jeans';
+import sportCoat from './sport-coat';
+import summerDress from './summer-dress';
+import ToddlerTrousers from './toddler-trousers';
+import toteBag from './tote-bag';
+
+const presets = {
+  anniversaryShirt,
+  denimJacket,
+  flairJeans,
+  halloweenTop,
+  maternityTop,
+  necklace,
+  promDress,
+  sandals,
+  skinnyJeans,
+  sportCoat,
+  summerDress,
+  ToddlerTrousers,
+  toteBag,
+};
+
+export default presets;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.spec.ts
@@ -11,7 +11,7 @@ describe(`with maternityTop preset`, () => {
         "description": undefined,
         "key": "maternity_top",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "size",
@@ -89,7 +89,7 @@ describe(`with maternityTop preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "size",
@@ -139,7 +139,7 @@ describe(`with maternityTop preset`, () => {
             "sku": "118717",
           },
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "size",
@@ -166,7 +166,7 @@ describe(`with maternityTop preset`, () => {
                 "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-lOB-DcqK.png",
               },
             ],
-            "key": "118717",
+            "key": "118718",
             "prices": [
               {
                 "channel": undefined,
@@ -186,7 +186,7 @@ describe(`with maternityTop preset`, () => {
                 },
               },
             ],
-            "sku": "118717",
+            "sku": "118718",
           },
         ],
       }
@@ -205,7 +205,7 @@ describe(`with maternityTop preset`, () => {
         "key": "maternity_top",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -293,7 +293,7 @@ describe(`with maternityTop preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",
@@ -349,7 +349,7 @@ describe(`with maternityTop preset`, () => {
           },
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",
@@ -379,7 +379,7 @@ describe(`with maternityTop preset`, () => {
                 "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-lOB-DcqK.png",
               },
             ],
-            "key": "118717",
+            "key": "118718",
             "prices": [
               {
                 "__typename": "ProductPriceDataInput",
@@ -401,7 +401,7 @@ describe(`with maternityTop preset`, () => {
                 },
               },
             ],
-            "sku": "118717",
+            "sku": "118718",
           },
         ],
       }

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.spec.ts
@@ -1,0 +1,410 @@
+import { TProductDraft } from '../../../types';
+import maternityTop from './maternity-top';
+
+describe(`with maternityTop preset`, () => {
+  it('should return a sample maternityTop product preset', () => {
+    const maternityTopPreset = maternityTop().build<TProductDraft>();
+    expect(maternityTopPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "maternity_top",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "size",
+              "value": {
+                "key": "Small",
+                "label": "Small",
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "key": "Green",
+                "label": "Green",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 300,
+                "w": 262,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-__gg4rwo.png",
+            },
+          ],
+          "key": "118716",
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 2695,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "118716",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Maternity Top",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "shirts",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-maternity-top",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "size",
+                "value": {
+                  "key": "Medium",
+                  "label": "Medium",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "key": "Green",
+                  "label": "Green",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 300,
+                  "w": 262,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-7_8SGLVB.png",
+              },
+            ],
+            "key": "118717",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 2695,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "118717",
+          },
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "size",
+                "value": {
+                  "key": "Large",
+                  "label": "Large",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "key": "Green",
+                  "label": "Green",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 300,
+                  "w": 262,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-lOB-DcqK.png",
+              },
+            ],
+            "key": "118717",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 2695,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "118717",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample prom dress product preset when built for graphql', () => {
+    const maternityTopPresetGraphql =
+      maternityTop().buildGraphql<TProductDraft>();
+    expect(maternityTopPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "maternity_top",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "size",
+              "value": {
+                "key": "Small",
+                "label": "Small",
+              },
+            },
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "color",
+              "value": {
+                "key": "Green",
+                "label": "Green",
+              },
+            },
+          ],
+          "images": [
+            {
+              "__typename": "Image",
+              "dimensions": {
+                "h": 300,
+                "w": 262,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-__gg4rwo.png",
+            },
+          ],
+          "key": "118716",
+          "prices": [
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 2695,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "118716",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Maternity Top",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "shirts",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-maternity-top",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "size",
+                "value": {
+                  "key": "Medium",
+                  "label": "Medium",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "color",
+                "value": {
+                  "key": "Green",
+                  "label": "Green",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 300,
+                  "w": 262,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-7_8SGLVB.png",
+              },
+            ],
+            "key": "118717",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 2695,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "118717",
+          },
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "size",
+                "value": {
+                  "key": "Large",
+                  "label": "Large",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "color",
+                "value": {
+                  "key": "Green",
+                  "label": "Green",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 300,
+                  "w": 262,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/greenshirt-lOB-DcqK.png",
+              },
+            ],
+            "key": "118717",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 2695,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "118717",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.spec.ts
@@ -66,7 +66,7 @@ describe(`with maternityTop preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Maternity Top",
+          "en-US": "Sample Maternity Top",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -79,7 +79,7 @@ describe(`with maternityTop preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-maternity-top",
+          "en-US": "sample-maternity-top",
           "fr": undefined,
         },
         "state": undefined,
@@ -265,7 +265,7 @@ describe(`with maternityTop preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Maternity Top",
           },
         ],
@@ -280,7 +280,7 @@ describe(`with maternityTop preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-maternity-top",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const maternityTop = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Maternity Top'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-maternity-top'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Maternity Top'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-maternity-top'))
     .productType(KeyReference.presets.productType().key('shirts'))
     .publish(true)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.ts
@@ -1,0 +1,26 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const maternityTop = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Maternity Top'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-maternity-top'))
+    .productType(KeyReference.presets.productType().key('shirts'))
+    .publish(true)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.maternityTopVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.maternityTopVariant02(),
+      ProductVariantDraft.presets.sampleDataFashion.maternityTopVariant03(),
+    ])
+    .key('maternity_top')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default maternityTop;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const shirtProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .shirts()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const maternityTop = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Maternity Top'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-maternity-top'))
-    .productType(KeyReference.presets.productType().key('shirts'))
+    .productType(
+      KeyReference.presets.productType().key(shirtProductTypeDraft.key!)
+    )
     .publish(true)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.maternityTopVariant01()
@@ -21,6 +35,8 @@ const maternityTop = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.maternityTopVariant03(),
     ])
     .key('maternity_top')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default maternityTop;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const maternityTop = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.spec.ts
@@ -11,7 +11,7 @@ describe(`with necklace preset`, () => {
         "description": undefined,
         "key": "necklace",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "type",
@@ -120,7 +120,7 @@ describe(`with necklace preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "type",
@@ -178,7 +178,7 @@ describe(`with necklace preset`, () => {
         "key": "necklace",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -301,7 +301,7 @@ describe(`with necklace preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.spec.ts
@@ -1,0 +1,354 @@
+import { TProductDraft } from '../../../types';
+import necklace from './necklace';
+
+describe(`with necklace preset`, () => {
+  it('should return a sample necklace product preset', () => {
+    const necklacePreset = necklace().build<TProductDraft>();
+    expect(necklacePreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "necklace",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "type",
+              "value": {
+                "key": "Jewelry",
+                "label": "Jewelry",
+              },
+            },
+            {
+              "name": "engraving",
+              "value": "Happy Anniversary",
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 122,
+                "w": 103,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/necklace-TRlWhVSq.png",
+            },
+          ],
+          "key": "752502",
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 5000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 5000,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "ES",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 5000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "752502",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Necklace",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "accessories",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-necklace",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "type",
+                "value": {
+                  "key": "Jewelry",
+                  "label": "Jewelry",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 241,
+                  "w": 209,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/necklace-KmP7rQDP.png",
+              },
+            ],
+            "key": "42610",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "AU",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1575,
+                  "currencyCode": "AUD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "42610",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample necklace product preset when built for graphql', () => {
+    const necklacePresetGraphql = necklace().buildGraphql<TProductDraft>();
+    expect(necklacePresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "necklace",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "type",
+              "value": {
+                "key": "Jewelry",
+                "label": "Jewelry",
+              },
+            },
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "engraving",
+              "value": "Happy Anniversary",
+            },
+          ],
+          "images": [
+            {
+              "__typename": "Image",
+              "dimensions": {
+                "h": 122,
+                "w": 103,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/necklace-TRlWhVSq.png",
+            },
+          ],
+          "key": "752502",
+          "prices": [
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 5000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 5000,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "ES",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 5000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "752502",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Necklace",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "accessories",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-necklace",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "type",
+                "value": {
+                  "key": "Jewelry",
+                  "label": "Jewelry",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 241,
+                  "w": 209,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/necklace-KmP7rQDP.png",
+              },
+            ],
+            "key": "42610",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "AU",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 1575,
+                  "currencyCode": "AUD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "42610",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.spec.ts
@@ -97,7 +97,7 @@ describe(`with necklace preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Necklace",
+          "en-US": "Sample Necklace",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -110,7 +110,7 @@ describe(`with necklace preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-necklace",
+          "en-US": "sample-necklace",
           "fr": undefined,
         },
         "state": undefined,
@@ -273,7 +273,7 @@ describe(`with necklace preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Necklace",
           },
         ],
@@ -288,7 +288,7 @@ describe(`with necklace preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-necklace",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const necklace = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const accessoriesProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .accessories()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const necklace = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Necklace'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-necklace'))
-    .productType(KeyReference.presets.productType().key('accessories'))
+    .productType(
+      KeyReference.presets.productType().key(accessoriesProductTypeDraft.key!)
+    )
     .publish(true)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.necklaceVariant01()
@@ -20,6 +34,8 @@ const necklace = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.necklaceVariant02(),
     ])
     .key('necklace')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default necklace;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const necklace = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Necklace'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-necklace'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Necklace'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-necklace'))
     .productType(KeyReference.presets.productType().key('accessories'))
     .publish(true)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.ts
@@ -1,0 +1,25 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const necklace = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Necklace'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-necklace'))
+    .productType(KeyReference.presets.productType().key('accessories'))
+    .publish(true)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.necklaceVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.necklaceVariant02(),
+    ])
+    .key('necklace')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default necklace;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.spec.ts
@@ -76,7 +76,7 @@ describe(`with promDress preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Prom Dress",
+          "en-US": "Sample Prom Dress",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -89,7 +89,7 @@ describe(`with promDress preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-prom-dress",
+          "en-US": "sample-prom-dress",
           "fr": undefined,
         },
         "state": undefined,
@@ -245,7 +245,7 @@ describe(`with promDress preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Prom Dress",
           },
         ],
@@ -260,7 +260,7 @@ describe(`with promDress preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-prom-dress",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.spec.ts
@@ -1,0 +1,345 @@
+import { TProductDraft } from '../../../types';
+import promDress from './prom-dress';
+
+describe(`with promDress preset`, () => {
+  it('should return a sample prom dress product preset', () => {
+    const promDressPreset = promDress().build<TProductDraft>();
+    expect(promDressPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "prom_dress",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "color",
+              "value": {
+                "key": "Floral",
+                "label": "Floral",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 420,
+                "w": 411,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/floral-_WoTefrz.jpeg",
+            },
+          ],
+          "key": "711595",
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 24795,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 17500,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "711595",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Prom Dress",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "dresses",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-prom-dress",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "color",
+                "value": {
+                  "key": "Pink",
+                  "label": "Pink",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 1920,
+                  "w": 1779,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/dress2-_nh_EhPL.png",
+              },
+            ],
+            "key": "214452",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "ES",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 12500,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "AU",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 15000,
+                  "currencyCode": "AUD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "214452",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample prom dress product preset when built for graphql', () => {
+    const promDressPresetGraphql = promDress().buildGraphql<TProductDraft>();
+    expect(promDressPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "prom_dress",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "color",
+              "value": {
+                "key": "Floral",
+                "label": "Floral",
+              },
+            },
+          ],
+          "images": [
+            {
+              "__typename": "Image",
+              "dimensions": {
+                "h": 420,
+                "w": 411,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/floral-_WoTefrz.jpeg",
+            },
+          ],
+          "key": "711595",
+          "prices": [
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 24795,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 17500,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "711595",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Prom Dress",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "dresses",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-prom-dress",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "color",
+                "value": {
+                  "key": "Pink",
+                  "label": "Pink",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 1920,
+                  "w": 1779,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/dress2-_nh_EhPL.png",
+              },
+            ],
+            "key": "214452",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "ES",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 12500,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "AU",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 15000,
+                  "currencyCode": "AUD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "214452",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.spec.ts
@@ -11,7 +11,7 @@ describe(`with promDress preset`, () => {
         "description": undefined,
         "key": "prom_dress",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "color",
@@ -99,7 +99,7 @@ describe(`with promDress preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "color",
@@ -174,7 +174,7 @@ describe(`with promDress preset`, () => {
         "key": "prom_dress",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -273,7 +273,7 @@ describe(`with promDress preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const dressesProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .dresses()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const promDress = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Prom Dress'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-prom-dress'))
-    .productType(KeyReference.presets.productType().key('dresses'))
+    .productType(
+      KeyReference.presets.productType().key(dressesProductTypeDraft.key!)
+    )
     .publish(true)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.promDressVariant01()
@@ -20,6 +34,8 @@ const promDress = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.promDressVariant02(),
     ])
     .key('prom_dress')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default promDress;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const promDress = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Prom Dress'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-prom-dress'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Prom Dress'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-prom-dress'))
     .productType(KeyReference.presets.productType().key('dresses'))
     .publish(true)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.ts
@@ -1,0 +1,25 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const promDress = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Prom Dress'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-prom-dress'))
+    .productType(KeyReference.presets.productType().key('dresses'))
+    .publish(true)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.promDressVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.promDressVariant02(),
+    ])
+    .key('prom_dress')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default promDress;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const promDress = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.spec.ts
@@ -1,0 +1,418 @@
+import { TProductDraft } from '../../../types';
+import sampleSandals from './sandals';
+
+describe(`with sampleSandals preset`, () => {
+  it('should return a sample sandals product preset', () => {
+    const sampleSandalsPreset = sampleSandals().build<TProductDraft>();
+    expect(sampleSandalsPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "sandals",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "type",
+              "value": {
+                "key": "Shoes",
+                "label": "Shoes",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 222,
+                "w": 227,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/sandals-hd5LHY6T.png",
+            },
+          ],
+          "key": "148096",
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "AU",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 2500,
+                "currencyCode": "AUD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 3000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 2799,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "ES",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 3000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "148096",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Sandals",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "accessories",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-sandals",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "type",
+                "value": {
+                  "key": "Shoes",
+                  "label": "Shoes",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 230,
+                  "w": 219,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/sandals-nDN7Ajoe.jpeg",
+              },
+            ],
+            "key": "148097",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "AU",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1199,
+                  "currencyCode": "AUD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1000,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "148097",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample sandals product preset when built for graphql', () => {
+    const sampleSandalsPresetGraphql =
+      sampleSandals().buildGraphql<TProductDraft>();
+    expect(sampleSandalsPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "sandals",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "type",
+              "value": {
+                "key": "Shoes",
+                "label": "Shoes",
+              },
+            },
+          ],
+          "images": [
+            {
+              "__typename": "Image",
+              "dimensions": {
+                "h": 222,
+                "w": 227,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/sandals-hd5LHY6T.png",
+            },
+          ],
+          "key": "148096",
+          "prices": [
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "AU",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 2500,
+                "currencyCode": "AUD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 3000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 2799,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "ES",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 3000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "148096",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Sandals",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "accessories",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-sandals",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "type",
+                "value": {
+                  "key": "Shoes",
+                  "label": "Shoes",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 230,
+                  "w": 219,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/sandals-nDN7Ajoe.jpeg",
+              },
+            ],
+            "key": "148097",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "AU",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 1199,
+                  "currencyCode": "AUD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 1000,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "148097",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.spec.ts
@@ -11,7 +11,7 @@ describe(`with sampleSandals preset`, () => {
         "description": undefined,
         "key": "sandals",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "type",
@@ -133,7 +133,7 @@ describe(`with sampleSandals preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "type",
@@ -209,7 +209,7 @@ describe(`with sampleSandals preset`, () => {
         "key": "sandals",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -346,7 +346,7 @@ describe(`with sampleSandals preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.spec.ts
@@ -110,7 +110,7 @@ describe(`with sampleSandals preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Sandals",
+          "en-US": "Sample Sandals",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -123,7 +123,7 @@ describe(`with sampleSandals preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-sandals",
+          "en-US": "sample-sandals",
           "fr": undefined,
         },
         "state": undefined,
@@ -318,7 +318,7 @@ describe(`with sampleSandals preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Sandals",
           },
         ],
@@ -333,7 +333,7 @@ describe(`with sampleSandals preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-sandals",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const accessoriesProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .accessories()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const sandals = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Sandals'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-sandals'))
-    .productType(KeyReference.presets.productType().key('accessories'))
+    .productType(
+      KeyReference.presets.productType().key(accessoriesProductTypeDraft.key!)
+    )
     .publish(true)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.sandalsVariant01()
@@ -20,6 +34,8 @@ const sandals = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.sandalsVariant02(),
     ])
     .key('sandals')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default sandals;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.ts
@@ -1,0 +1,25 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const sandals = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Sandals'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-sandals'))
+    .productType(KeyReference.presets.productType().key('accessories'))
+    .publish(true)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.sandalsVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.sandalsVariant02(),
+    ])
+    .key('sandals')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default sandals;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const sandals = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Sandals'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-sandals'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Sandals'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-sandals'))
     .productType(KeyReference.presets.productType().key('accessories'))
     .publish(true)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const sandals = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.spec.ts
@@ -66,7 +66,7 @@ describe(`with skinnyJeans preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Skinny Jeans",
+          "en-US": "Sample Skinny Jeans",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -79,7 +79,7 @@ describe(`with skinnyJeans preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-skinny-jeans",
+          "en-US": "sample-skinny-jeans",
           "fr": undefined,
         },
         "state": undefined,
@@ -215,7 +215,7 @@ describe(`with skinnyJeans preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Skinny Jeans",
           },
         ],
@@ -230,7 +230,7 @@ describe(`with skinnyJeans preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-skinny-jeans",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.spec.ts
@@ -11,7 +11,7 @@ describe(`with skinnyJeans preset`, () => {
         "description": undefined,
         "key": "skinny_jeans",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "fit",
@@ -89,7 +89,7 @@ describe(`with skinnyJeans preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "size",
@@ -155,7 +155,7 @@ describe(`with skinnyJeans preset`, () => {
         "key": "skinny_jeans",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -243,7 +243,7 @@ describe(`with skinnyJeans preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.spec.ts
@@ -1,0 +1,304 @@
+import { TProductDraft } from '../../../types';
+import skinnyJeans from './skinny-jeans';
+
+describe(`with skinnyJeans preset`, () => {
+  it('should return a sample skinnyJeans product preset', () => {
+    const skinnyJeansPreset = skinnyJeans().build<TProductDraft>();
+    expect(skinnyJeansPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "skinny_jeans",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "fit",
+              "value": {
+                "key": "Slim",
+                "label": "Slim",
+              },
+            },
+            {
+              "name": "size",
+              "value": {
+                "key": "Medium",
+                "label": "Medium",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 275,
+                "w": 183,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/skinny-QJz4Jcme.jpeg",
+            },
+          ],
+          "key": "396594",
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 4999,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "396594",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Skinny Jeans",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "pants",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-skinny-jeans",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "size",
+                "value": {
+                  "key": "Large",
+                  "label": "Large",
+                },
+              },
+              {
+                "name": "fit",
+                "value": {
+                  "key": "Slim",
+                  "label": "Slim",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 150,
+                  "w": 100,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/pants-qbuZJH9h.jpeg",
+              },
+            ],
+            "key": "349700",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 4999,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "349700",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample skinnyJeans product preset when built for graphql', () => {
+    const skinnyJeansPresetGraphql =
+      skinnyJeans().buildGraphql<TProductDraft>();
+    expect(skinnyJeansPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "skinny_jeans",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "fit",
+              "value": {
+                "key": "Slim",
+                "label": "Slim",
+              },
+            },
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "size",
+              "value": {
+                "key": "Medium",
+                "label": "Medium",
+              },
+            },
+          ],
+          "images": [
+            {
+              "__typename": "Image",
+              "dimensions": {
+                "h": 275,
+                "w": 183,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/skinny-QJz4Jcme.jpeg",
+            },
+          ],
+          "key": "396594",
+          "prices": [
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 4999,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "396594",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Skinny Jeans",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "pants",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-skinny-jeans",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "size",
+                "value": {
+                  "key": "Large",
+                  "label": "Large",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "fit",
+                "value": {
+                  "key": "Slim",
+                  "label": "Slim",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 150,
+                  "w": 100,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/pants-qbuZJH9h.jpeg",
+              },
+            ],
+            "key": "349700",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 4999,
+                  "currencyCode": "EUR",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "349700",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const pantsProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .pants()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const skinnyJeans = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Skinny Jeans'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-skinny-jeans'))
-    .productType(KeyReference.presets.productType().key('pants'))
+    .productType(
+      KeyReference.presets.productType().key(pantsProductTypeDraft.key!)
+    )
     .publish(true)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.skinnyJeansVariant01()
@@ -20,6 +34,8 @@ const skinnyJeans = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.skinnyJeansVariant02(),
     ])
     .key('skinny_jeans')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default skinnyJeans;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.ts
@@ -1,0 +1,25 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const skinnyJeans = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Skinny Jeans'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-skinny-jeans'))
+    .productType(KeyReference.presets.productType().key('pants'))
+    .publish(true)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.skinnyJeansVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.skinnyJeansVariant02(),
+    ])
+    .key('skinny_jeans')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default skinnyJeans;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const skinnyJeans = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Skinny Jeans'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-skinny-jeans'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Skinny Jeans'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-skinny-jeans'))
     .productType(KeyReference.presets.productType().key('pants'))
     .publish(true)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const skinnyJeans = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.spec.ts
@@ -59,7 +59,7 @@ describe(`with sportCoat preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Sport Coat",
+          "en-US": "Sample Sport Coat",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -72,7 +72,7 @@ describe(`with sportCoat preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-sport-coat",
+          "en-US": "sample-sport-coat",
           "fr": undefined,
         },
         "state": undefined,
@@ -192,7 +192,7 @@ describe(`with sportCoat preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Sport Coat",
           },
         ],
@@ -207,7 +207,7 @@ describe(`with sportCoat preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-sport-coat",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.spec.ts
@@ -1,0 +1,273 @@
+import { TProductDraft } from '../../../types';
+import sportCoat from './sport-coat';
+
+describe(`with sportCoat preset`, () => {
+  it('should return a sample sportCoat product preset', () => {
+    const sportCoatPreset = sportCoat().build<TProductDraft>();
+    expect(sportCoatPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "sport_coat",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "sleeve_length",
+              "value": {
+                "key": "Crop",
+                "label": "Crop",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 225,
+                "w": 225,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/coat-VmXqw3Xo.jpeg",
+            },
+          ],
+          "key": "692457",
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "AU",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 20000,
+                "currencyCode": "AUD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "692457",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Sport Coat",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "jackets",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-sport-coat",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "sleeve_length",
+                "value": {
+                  "key": "Normal",
+                  "label": "Normal",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 150,
+                  "w": 150,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/coat-Keqv_ZSU.jpeg",
+              },
+            ],
+            "key": "692458",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "AU",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 20000,
+                  "currencyCode": "AUD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "692458",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample sportCoat product preset when built for graphql', () => {
+    const sportCoatPresetGraphql = sportCoat().buildGraphql<TProductDraft>();
+    expect(sportCoatPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "sport_coat",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "sleeve_length",
+              "value": {
+                "key": "Crop",
+                "label": "Crop",
+              },
+            },
+          ],
+          "images": [
+            {
+              "__typename": "Image",
+              "dimensions": {
+                "h": 225,
+                "w": 225,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/coat-VmXqw3Xo.jpeg",
+            },
+          ],
+          "key": "692457",
+          "prices": [
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "AU",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 20000,
+                "currencyCode": "AUD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "692457",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Sport Coat",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "jackets",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-sport-coat",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "sleeve_length",
+                "value": {
+                  "key": "Normal",
+                  "label": "Normal",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 150,
+                  "w": 150,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/coat-Keqv_ZSU.jpeg",
+              },
+            ],
+            "key": "692458",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "AU",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 20000,
+                  "currencyCode": "AUD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "692458",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.spec.ts
@@ -11,7 +11,7 @@ describe(`with sportCoat preset`, () => {
         "description": undefined,
         "key": "sport_coat",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "sleeve_length",
@@ -82,7 +82,7 @@ describe(`with sportCoat preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "sleeve_length",
@@ -140,7 +140,7 @@ describe(`with sportCoat preset`, () => {
         "key": "sport_coat",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -220,7 +220,7 @@ describe(`with sportCoat preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const jacketsProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .jackets()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const sportCoat = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Sport Coat'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-sport-coat'))
-    .productType(KeyReference.presets.productType().key('jackets'))
+    .productType(
+      KeyReference.presets.productType().key(jacketsProductTypeDraft.key!)
+    )
     .publish(true)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.sportCoatVariant01()
@@ -20,6 +34,8 @@ const sportCoat = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.sportCoatVariant02(),
     ])
     .key('sport_coat')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default sportCoat;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const sportCoat = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const sportCoat = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Sport Coat'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-sport-coat'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Sport Coat'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-sport-coat'))
     .productType(KeyReference.presets.productType().key('jackets'))
     .publish(true)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.ts
@@ -1,0 +1,25 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const sportCoat = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Sport Coat'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-sport-coat'))
+    .productType(KeyReference.presets.productType().key('jackets'))
+    .publish(true)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.sportCoatVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.sportCoatVariant02(),
+    ])
+    .key('sport_coat')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default sportCoat;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
@@ -1,0 +1,310 @@
+import { TProductDraft } from '../../../types';
+import summerDress from './summer-dress';
+
+describe(`with summerDress preset`, () => {
+  it('should return a sample summerDress product preset', () => {
+    const summerDressPreset = summerDress().build<TProductDraft>();
+    expect(summerDressPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "summer_dress",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "color",
+              "value": {
+                "key": "White",
+                "label": "White",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 298,
+                "w": 276,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/dress-nsVCck7f.jpeg",
+            },
+          ],
+          "key": "791840",
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 7500,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "ES",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 8000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "791840",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Summer Dress",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "dress",
+          "typeId": "product-type",
+        },
+        "publish": false,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-summer-dress",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "color",
+                "value": {
+                  "key": "Pink",
+                  "label": "Pink",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 254,
+                  "w": 199,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/pinkdress-kKvWVHgG.png",
+              },
+            ],
+            "key": "439502",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 7500,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "439502",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample summerDress product preset when built for graphql', () => {
+    const summerDressPresetGraphql =
+      summerDress().buildGraphql<TProductDraft>();
+    expect(summerDressPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "summer_dress",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "color",
+              "value": {
+                "key": "White",
+                "label": "White",
+              },
+            },
+          ],
+          "images": [
+            {
+              "__typename": "Image",
+              "dimensions": {
+                "h": 298,
+                "w": 276,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/dress-nsVCck7f.jpeg",
+            },
+          ],
+          "key": "791840",
+          "prices": [
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 7500,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "ES",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 8000,
+                "currencyCode": "EUR",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "791840",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Summer Dress",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "dress",
+          "typeId": "product-type",
+        },
+        "publish": false,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-summer-dress",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "color",
+                "value": {
+                  "key": "Pink",
+                  "label": "Pink",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 254,
+                  "w": 199,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/pinkdress-kKvWVHgG.png",
+              },
+            ],
+            "key": "439502",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 7500,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "439502",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
@@ -81,7 +81,7 @@ describe(`with summerDress preset`, () => {
         },
         "priceMode": undefined,
         "productType": {
-          "key": "dress",
+          "key": "dresses",
           "typeId": "product-type",
         },
         "publish": false,
@@ -236,7 +236,7 @@ describe(`with summerDress preset`, () => {
         "priceMode": undefined,
         "productType": {
           "__typename": "Reference",
-          "key": "dress",
+          "key": "dresses",
           "typeId": "product-type",
         },
         "publish": false,

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
@@ -11,7 +11,7 @@ describe(`with summerDress preset`, () => {
         "description": undefined,
         "key": "summer_dress",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "color",
@@ -99,7 +99,7 @@ describe(`with summerDress preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "color",
@@ -158,7 +158,7 @@ describe(`with summerDress preset`, () => {
         "key": "summer_dress",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -257,7 +257,7 @@ describe(`with summerDress preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
@@ -76,7 +76,7 @@ describe(`with summerDress preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Summer Dress",
+          "en-US": "Sample Summer Dress",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -89,7 +89,7 @@ describe(`with summerDress preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-summer-dress",
+          "en-US": "sample-summer-dress",
           "fr": undefined,
         },
         "state": undefined,
@@ -229,7 +229,7 @@ describe(`with summerDress preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Summer Dress",
           },
         ],
@@ -244,7 +244,7 @@ describe(`with summerDress preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-summer-dress",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.ts
@@ -1,0 +1,25 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const summerDress = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Summer Dress'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-summer-dress'))
+    .productType(KeyReference.presets.productType().key('dress'))
+    .publish(false)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.summerDressVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.summerDressVariant02(),
+    ])
+    .key('summer_dress')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default summerDress;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const dressesProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .dresses()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const summerDress = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Summer Dress'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-summer-dress'))
-    .productType(KeyReference.presets.productType().key('dress'))
+    .productType(
+      KeyReference.presets.productType().key(dressesProductTypeDraft.key!)
+    )
     .publish(false)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.summerDressVariant01()
@@ -20,6 +34,8 @@ const summerDress = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.summerDressVariant02(),
     ])
     .key('summer_dress')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default summerDress;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const summerDress = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Summer Dress'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-summer-dress'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Summer Dress'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-summer-dress'))
     .productType(KeyReference.presets.productType().key('dress'))
     .publish(false)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const summerDress = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.spec.ts
@@ -1,0 +1,500 @@
+import { TProductDraft } from '../../../types';
+import toddlerTrousers from './toddler-trousers';
+
+describe(`with toddlerTrousers preset`, () => {
+  it('should return a sample toddlerTrousers product preset', () => {
+    const toddlerTrousersPreset = toddlerTrousers().build<TProductDraft>();
+    expect(toddlerTrousersPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "toddler_trousers",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "size",
+              "value": {
+                "key": "Small",
+                "label": "Small",
+              },
+            },
+            {
+              "name": "fit",
+              "value": {
+                "key": "Straight",
+                "label": "Straight",
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "key": "White",
+                "label": "White",
+              },
+            },
+            {
+              "name": "length",
+              "value": {
+                "key": "Ankle",
+                "label": "Ankle",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 792,
+                "w": 612,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-Z7CSIEMu.gif",
+            },
+          ],
+          "key": "855484",
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 2599,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "855484",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Toddler Trousers",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "pants",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-toddler-trousers",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "size",
+                "value": {
+                  "key": "Medium",
+                  "label": "Medium",
+                },
+              },
+              {
+                "name": "fit",
+                "value": {
+                  "key": "Straight",
+                  "label": "Straight",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "key": "White",
+                  "label": "White",
+                },
+              },
+              {
+                "name": "length",
+                "value": {
+                  "key": "Ankle",
+                  "label": "Ankle",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 792,
+                  "w": 612,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-SbjnediW.gif",
+              },
+            ],
+            "key": "855485",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 2599,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "855485",
+          },
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "size",
+                "value": {
+                  "key": "Large",
+                  "label": "Large",
+                },
+              },
+              {
+                "name": "fit",
+                "value": {
+                  "key": "Straight",
+                  "label": "Straight",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "key": "White",
+                  "label": "White",
+                },
+              },
+              {
+                "name": "length",
+                "value": {
+                  "key": "Ankle",
+                  "label": "Ankle",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 792,
+                  "w": 612,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-i2b2bEGD.gif",
+              },
+            ],
+            "key": "855486",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 2599,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "855486",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample toddlerTrousers product preset when built for graphql', () => {
+    const toddlerTrousersPresetGraphql =
+      toddlerTrousers().buildGraphql<TProductDraft>();
+    expect(toddlerTrousersPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "toddler_trousers",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "size",
+              "value": {
+                "key": "Small",
+                "label": "Small",
+              },
+            },
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "fit",
+              "value": {
+                "key": "Straight",
+                "label": "Straight",
+              },
+            },
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "color",
+              "value": {
+                "key": "White",
+                "label": "White",
+              },
+            },
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "length",
+              "value": {
+                "key": "Ankle",
+                "label": "Ankle",
+              },
+            },
+          ],
+          "images": [
+            {
+              "__typename": "Image",
+              "dimensions": {
+                "h": 792,
+                "w": 612,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-Z7CSIEMu.gif",
+            },
+          ],
+          "key": "855484",
+          "prices": [
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 2599,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "855484",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Toddler Trousers",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "pants",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-toddler-trousers",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "size",
+                "value": {
+                  "key": "Medium",
+                  "label": "Medium",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "fit",
+                "value": {
+                  "key": "Straight",
+                  "label": "Straight",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "color",
+                "value": {
+                  "key": "White",
+                  "label": "White",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "length",
+                "value": {
+                  "key": "Ankle",
+                  "label": "Ankle",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 792,
+                  "w": 612,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-SbjnediW.gif",
+              },
+            ],
+            "key": "855485",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 2599,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "855485",
+          },
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "size",
+                "value": {
+                  "key": "Large",
+                  "label": "Large",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "fit",
+                "value": {
+                  "key": "Straight",
+                  "label": "Straight",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "color",
+                "value": {
+                  "key": "White",
+                  "label": "White",
+                },
+              },
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "length",
+                "value": {
+                  "key": "Ankle",
+                  "label": "Ankle",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 792,
+                  "w": 612,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/whitepants-i2b2bEGD.gif",
+              },
+            ],
+            "key": "855486",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 2599,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "855486",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.spec.ts
@@ -11,7 +11,7 @@ describe(`with toddlerTrousers preset`, () => {
         "description": undefined,
         "key": "toddler_trousers",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "size",
@@ -103,7 +103,7 @@ describe(`with toddlerTrousers preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "size",
@@ -167,7 +167,7 @@ describe(`with toddlerTrousers preset`, () => {
             "sku": "855485",
           },
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "size",
@@ -247,7 +247,7 @@ describe(`with toddlerTrousers preset`, () => {
         "key": "toddler_trousers",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -351,7 +351,7 @@ describe(`with toddlerTrousers preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",
@@ -423,7 +423,7 @@ describe(`with toddlerTrousers preset`, () => {
           },
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.spec.ts
@@ -80,7 +80,7 @@ describe(`with toddlerTrousers preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Toddler Trousers",
+          "en-US": "Sample Toddler Trousers",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -93,7 +93,7 @@ describe(`with toddlerTrousers preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-toddler-trousers",
+          "en-US": "sample-toddler-trousers",
           "fr": undefined,
         },
         "state": undefined,
@@ -323,7 +323,7 @@ describe(`with toddlerTrousers preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Toddler Trousers",
           },
         ],
@@ -338,7 +338,7 @@ describe(`with toddlerTrousers preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-toddler-trousers",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const ToddlerTrousers = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const ToddlerTrousers = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Toddler Trousers'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-toddler-trousers'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Toddler Trousers'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-toddler-trousers'))
     .productType(KeyReference.presets.productType().key('pants'))
     .publish(true)
     .masterVariant(

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.ts
@@ -1,0 +1,26 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const ToddlerTrousers = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Toddler Trousers'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-toddler-trousers'))
+    .productType(KeyReference.presets.productType().key('pants'))
+    .publish(true)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.toddlerTrousersVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.toddlerTrousersVariant02(),
+      ProductVariantDraft.presets.sampleDataFashion.toddlerTrousersVariant03(),
+    ])
+    .key('toddler_trousers')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default ToddlerTrousers;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const pantsProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .pants()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const ToddlerTrousers = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Toddler Trousers'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-toddler-trousers'))
-    .productType(KeyReference.presets.productType().key('pants'))
+    .productType(
+      KeyReference.presets.productType().key(pantsProductTypeDraft.key!)
+    )
     .publish(true)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.toddlerTrousersVariant01()
@@ -21,6 +35,8 @@ const ToddlerTrousers = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.toddlerTrousersVariant03(),
     ])
     .key('toddler_trousers')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default ToddlerTrousers;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.spec.ts
@@ -59,7 +59,7 @@ describe(`with toteBag preset`, () => {
         "name": {
           "de": undefined,
           "en": undefined,
-          "en-us": "Sample Tote Bag",
+          "en-US": "Sample Tote Bag",
           "fr": undefined,
         },
         "priceMode": undefined,
@@ -72,7 +72,7 @@ describe(`with toteBag preset`, () => {
         "slug": {
           "de": undefined,
           "en": undefined,
-          "en-us": "sample-tote-bag",
+          "en-US": "sample-tote-bag",
           "fr": undefined,
         },
         "state": undefined,
@@ -192,7 +192,7 @@ describe(`with toteBag preset`, () => {
         "name": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "Sample Tote Bag",
           },
         ],
@@ -207,7 +207,7 @@ describe(`with toteBag preset`, () => {
         "slug": [
           {
             "__typename": "LocalizedString",
-            "locale": "en-us",
+            "locale": "en-US",
             "value": "sample-tote-bag",
           },
         ],

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.spec.ts
@@ -11,7 +11,7 @@ describe(`with toteBag preset`, () => {
         "description": undefined,
         "key": "tote_bag",
         "masterVariant": {
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "name": "type",
@@ -82,7 +82,7 @@ describe(`with toteBag preset`, () => {
         },
         "variants": [
           {
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "name": "type",
@@ -140,7 +140,7 @@ describe(`with toteBag preset`, () => {
         "key": "tote_bag",
         "masterVariant": {
           "__typename": "ProductVariantInput",
-          "assets": [],
+          "assets": undefined,
           "attributes": [
             {
               "__typename": "ProductAttributeInput",
@@ -220,7 +220,7 @@ describe(`with toteBag preset`, () => {
         "variants": [
           {
             "__typename": "ProductVariantInput",
-            "assets": [],
+            "assets": undefined,
             "attributes": [
               {
                 "__typename": "ProductAttributeInput",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.spec.ts
@@ -1,0 +1,273 @@
+import { TProductDraft } from '../../../types';
+import toteBag from './tote-bag';
+
+describe(`with toteBag preset`, () => {
+  it('should return a sample toteBag product preset', () => {
+    const toteBagPreset = toteBag().build<TProductDraft>();
+    expect(toteBagPreset).toMatchInlineSnapshot(`
+      {
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "tote_bag",
+        "masterVariant": {
+          "assets": [],
+          "attributes": [
+            {
+              "name": "type",
+              "value": {
+                "key": "Bag",
+                "label": "Bag",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 800,
+                "w": 766,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/tote-V4lrDZ9Q.png",
+            },
+          ],
+          "key": "718289",
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 13999,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "718289",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "Sample Tote Bag",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
+          "key": "accessories",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "en": undefined,
+          "en-us": "sample-tote-bag",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "assets": [],
+            "attributes": [
+              {
+                "name": "type",
+                "value": {
+                  "key": "Bag",
+                  "label": "Bag",
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 800,
+                  "w": 675,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/bag-371ygCjz.png",
+              },
+            ],
+            "key": "124965",
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 17500,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "124965",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a sample toteBag product preset when built for graphql', () => {
+    const toteBagPresetGraphql = toteBag().buildGraphql<TProductDraft>();
+    expect(toteBagPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "ProductDraft",
+        "categories": undefined,
+        "categoryOrderHints": undefined,
+        "description": undefined,
+        "key": "tote_bag",
+        "masterVariant": {
+          "__typename": "ProductVariantInput",
+          "assets": [],
+          "attributes": [
+            {
+              "__typename": "ProductAttributeInput",
+              "name": "type",
+              "value": {
+                "key": "Bag",
+                "label": "Bag",
+              },
+            },
+          ],
+          "images": [
+            {
+              "__typename": "Image",
+              "dimensions": {
+                "h": 800,
+                "w": 766,
+              },
+              "label": undefined,
+              "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/tote-V4lrDZ9Q.png",
+            },
+          ],
+          "key": "718289",
+          "prices": [
+            {
+              "__typename": "ProductPriceDataInput",
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "__typename": "MoneyInput",
+                "centAmount": 13999,
+                "currencyCode": "USD",
+                "fractionDigits": 2,
+                "type": "centPrecision",
+              },
+            },
+          ],
+          "sku": "718289",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "Sample Tote Bag",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "accessories",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-us",
+            "value": "sample-tote-bag",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": [
+          {
+            "__typename": "ProductVariantInput",
+            "assets": [],
+            "attributes": [
+              {
+                "__typename": "ProductAttributeInput",
+                "name": "type",
+                "value": {
+                  "key": "Bag",
+                  "label": "Bag",
+                },
+              },
+            ],
+            "images": [
+              {
+                "__typename": "Image",
+                "dimensions": {
+                  "h": 800,
+                  "w": 675,
+                },
+                "label": undefined,
+                "url": "https://607c34ad0a5bf735fdf7-ec12c9005026a0c273dadf2c3ac4444b.ssl.cf3.rackcdn.com/bag-371ygCjz.png",
+              },
+            ],
+            "key": "124965",
+            "prices": [
+              {
+                "__typename": "ProductPriceDataInput",
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "__typename": "MoneyInput",
+                  "centAmount": 17500,
+                  "currencyCode": "USD",
+                  "fractionDigits": 2,
+                  "type": "centPrecision",
+                },
+              },
+            ],
+            "sku": "124965",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.ts
@@ -1,0 +1,25 @@
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import * as ProductDraft from '../../../../product-catalog-data';
+import { TProductDraftBuilder } from '../../../types';
+
+const toteBag = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .name(LocalizedString.presets.empty()['en-us']('Sample Tote Bag'))
+    .slug(LocalizedString.presets.empty()['en-us']('sample-tote-bag'))
+    .productType(KeyReference.presets.productType().key('accessories'))
+    .publish(true)
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataFashion.toteBagVariant01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataFashion.toteBagVariant02(),
+    ])
+    .key('tote_bag')
+    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+
+export default toteBag;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.ts
@@ -2,16 +2,30 @@ import {
   KeyReference,
   LocalizedString,
 } from '@commercetools-test-data/commons';
+import { ProductTypeDraft } from '@commercetools-test-data/product-type';
+import type { TProductTypeDraft } from '@commercetools-test-data/product-type';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
+import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
+
+const accessoriesProductTypeDraft = ProductTypeDraft.presets.sampleDataFashion
+  .accessories()
+  .build<TProductTypeDraft>();
+
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
+  .standardTaxCategory()
+  .build<TTaxCategoryDraft>();
 
 const toteBag = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
     .name(LocalizedString.presets.empty()['en-US']('Sample Tote Bag'))
     .slug(LocalizedString.presets.empty()['en-US']('sample-tote-bag'))
-    .productType(KeyReference.presets.productType().key('accessories'))
+    .productType(
+      KeyReference.presets.productType().key(accessoriesProductTypeDraft.key!)
+    )
     .publish(true)
     .masterVariant(
       ProductVariantDraft.presets.sampleDataFashion.toteBagVariant01()
@@ -20,6 +34,8 @@ const toteBag = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataFashion.toteBagVariant02(),
     ])
     .key('tote_bag')
-    .taxCategory(KeyReference.presets.taxCategory().key('standard-tax'));
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
+    );
 
 export default toteBag;

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.ts
@@ -3,7 +3,7 @@ import {
   LocalizedString,
 } from '@commercetools-test-data/commons';
 import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
-import * as ProductDraft from '../../../../product-catalog-data';
+import * as ProductDraft from '../../../product-draft';
 import { TProductDraftBuilder } from '../../../types';
 
 const toteBag = (): TProductDraftBuilder =>

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.ts
@@ -9,8 +9,8 @@ import { TProductDraftBuilder } from '../../../types';
 const toteBag = (): TProductDraftBuilder =>
   ProductDraft.presets
     .empty()
-    .name(LocalizedString.presets.empty()['en-us']('Sample Tote Bag'))
-    .slug(LocalizedString.presets.empty()['en-us']('sample-tote-bag'))
+    .name(LocalizedString.presets.empty()['en-US']('Sample Tote Bag'))
+    .slug(LocalizedString.presets.empty()['en-US']('sample-tote-bag'))
     .productType(KeyReference.presets.productType().key('accessories'))
     .publish(true)
     .masterVariant(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,6 +760,9 @@ importers:
       '@commercetools-test-data/attribute-definition':
         specifier: 4.11.1
         version: link:../attribute-definition
+      '@commercetools-test-data/cent-precision-money':
+        specifier: 4.11.1
+        version: link:../cent-precision-money
       '@commercetools-test-data/commons':
         specifier: 4.11.1
         version: link:../commons

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
         version: 8.0.3
       jest:
         specifier: 29.5.0
-        version: 29.5.0(@types/node@18.15.11)(ts-node@10.9.1)
+        version: 29.5.0(@types/node@18.15.11)
       jest-fail-on-console:
         specifier: 3.1.1
         version: 3.1.1
@@ -3028,7 +3028,7 @@ packages:
       slash: 3.0.0
     dev: false
 
-  /@jest/core@29.5.0(ts-node@10.9.1):
+  /@jest/core@29.5.0:
     resolution: {integrity: sha512-28UzQc7ulUrOQw1IsN/kv1QES3q2kkbl/wGslyhAclqZ/8cMdB5M68BffkIdSJgKBUt50d3hbwJ92XESlE7LiQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -3049,7 +3049,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@18.15.11)(ts-node@10.9.1)
+      jest-config: 29.5.0(@types/node@18.15.11)
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -5180,7 +5180,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.37.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 5.57.1(eslint@8.37.0)(typescript@4.9.5)
       eslint: 8.37.0
-      jest: 29.5.0(@types/node@18.15.11)(ts-node@10.9.1)
+      jest: 29.5.0(@types/node@18.15.11)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6377,7 +6377,7 @@ packages:
       - supports-color
     dev: false
 
-  /jest-cli@29.5.0(@types/node@18.15.11)(ts-node@10.9.1):
+  /jest-cli@29.5.0(@types/node@18.15.11):
     resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -6387,14 +6387,14 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.9.1)
+      '@jest/core': 29.5.0
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 29.5.0(@types/node@18.15.11)(ts-node@10.9.1)
+      jest-config: 29.5.0(@types/node@18.15.11)
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
@@ -6405,7 +6405,7 @@ packages:
       - ts-node
     dev: false
 
-  /jest-config@29.5.0(@types/node@18.15.11)(ts-node@10.9.1):
+  /jest-config@29.5.0(@types/node@18.15.11):
     resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -6440,7 +6440,6 @@ packages:
       pretty-format: 29.5.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@18.15.11)(typescript@4.9.5)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6611,7 +6610,7 @@ packages:
       create-jest-runner: 0.6.0
       dot-prop: 5.3.0
       eslint: 8.37.0
-      jest: 29.5.0(@types/node@18.15.11)(ts-node@10.9.1)
+      jest: 29.5.0(@types/node@18.15.11)
     dev: false
 
   /jest-runner@29.5.0:
@@ -6755,7 +6754,7 @@ packages:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.2.0
-      jest: 29.5.0(@types/node@18.15.11)(ts-node@10.9.1)
+      jest: 29.5.0(@types/node@18.15.11)
       jest-regex-util: 29.4.3
       jest-watcher: 29.4.3
       slash: 5.0.0
@@ -6818,7 +6817,7 @@ packages:
       supports-color: 8.1.1
     dev: false
 
-  /jest@29.5.0(@types/node@18.15.11)(ts-node@10.9.1):
+  /jest@29.5.0(@types/node@18.15.11):
     resolution: {integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -6828,10 +6827,10 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.9.1)
+      '@jest/core': 29.5.0
       '@jest/types': 29.5.0
       import-local: 3.1.0
-      jest-cli: 29.5.0(@types/node@18.15.11)(ts-node@10.9.1)
+      jest-cli: 29.5.0(@types/node@18.15.11)
     transitivePeerDependencies:
       - '@types/node'
       - supports-color


### PR DESCRIPTION
#### Summary

[Product draft presets](https://github.com/commercetools/test-data-research/blob/main/src/entity-drafts/products.ts) for Fashion Sample Data.

Also adds necessary `ProductVariant` presets, two `KeyReference` presets (`product-type` and `tax-category`), and `empty` presets for `PriceDraft` and `Image`.