### PR TITLE
fix(test-data): fix minor incorrect import

### DIFF
--- a/.changeset/funny-lemons-boil.md
+++ b/.changeset/funny-lemons-boil.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/tax-category': minor
+---
+
+fix incorrect import for tax rate drafts

--- a/models/tax-category/src/tax-category/tax-category-draft/presets/empty.spec.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/empty.spec.ts
@@ -1,0 +1,11 @@
+import { TTaxCategoryDraft } from '../../types';
+import empty from './empty';
+
+it(`should set all specified fields to undefined`, () => {
+  const emptyTaxCategoryDraft = empty().build<TTaxCategoryDraft>();
+  expect(emptyTaxCategoryDraft).toMatchObject({
+    description: undefined,
+    key: undefined,
+    rates: undefined,
+  });
+});

--- a/models/tax-category/src/tax-category/tax-category-draft/presets/empty.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/empty.ts
@@ -1,0 +1,7 @@
+import type { TTaxCategoryDraftBuilder } from '../../types';
+import TaxCategoryDraft from '../builder';
+
+const empty = (): TTaxCategoryDraftBuilder =>
+  TaxCategoryDraft().key(undefined).description(undefined).rates(undefined);
+
+export default empty;

--- a/models/tax-category/src/tax-category/tax-category-draft/presets/index.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/index.ts
@@ -1,6 +1,11 @@
+import empty from './empty';
 import sampleDataFashion from './sample-data-fashion';
 import withTaxRateCountryUsaAndIncludedInPrice from './with-tax-rate-country-usa-and-included-in-price';
 
-const presets = { withTaxRateCountryUsaAndIncludedInPrice, sampleDataFashion };
+const presets = {
+  empty,
+  withTaxRateCountryUsaAndIncludedInPrice,
+  sampleDataFashion,
+};
 
 export default presets;

--- a/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-fashion/standard-tax-category.spec.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-fashion/standard-tax-category.spec.ts
@@ -1,113 +1,66 @@
-import type {
-  TTaxCategoryDraft,
-  TTaxCategoryDraftGraphql,
-} from '../../../types';
+import type { TTaxCategoryDraft } from '../../../types';
 import standardTaxCategory from './standard-tax-category';
 
 describe('with a tax rate preset `standard tax category`', () => {
   it('should return a tax category with name `Standard Tax Category` and 6 tax rates', () => {
     const taxCategory = standardTaxCategory().build<TTaxCategoryDraft>();
 
-    expect(taxCategory).toEqual(
-      expect.objectContaining({
-        key: expect.stringContaining('standard-tax'),
-        name: expect.stringContaining('Standard Tax Category'),
-        description: expect.any(String),
-        rates: expect.arrayContaining([
-          expect.objectContaining({
-            name: 'VAT',
-            amount: 0.19,
-            includedInPrice: true,
-            country: 'DE',
-          }),
-          expect.objectContaining({
-            name: 'GST',
-            amount: 0.1,
-            includedInPrice: true,
-            country: 'AU',
-          }),
-          expect.objectContaining({
-            name: 'VAT',
-            amount: 0.21,
-            includedInPrice: true,
-            country: 'ES',
-          }),
-          expect.objectContaining({
-            name: 'MA State Tax',
-            amount: 0.0625,
-            includedInPrice: false,
-            country: 'US',
-            state: 'Massachusetts',
-          }),
-          expect.objectContaining({
-            name: 'NJ Sales Tax',
-            amount: 0.0663,
-            includedInPrice: false,
-            country: 'US',
-            state: 'New Jersey',
-          }),
-          expect.objectContaining({
-            name: 'CA Sales Tax',
-            amount: 0.07,
-            includedInPrice: false,
-            country: 'US',
-            state: 'California',
-          }),
-        ]),
-      })
-    );
-  });
-  it('should return a category with the name `Standard Tax Category` when built for GraphQL', () => {
-    const taxCategory =
-      standardTaxCategory().buildGraphql<TTaxCategoryDraftGraphql>();
-
-    expect(taxCategory).toEqual(
-      expect.objectContaining({
-        key: expect.stringContaining('standard-tax'),
-        name: expect.stringContaining('Standard Tax Category'),
-        description: expect.any(String),
-        rates: expect.arrayContaining([
-          expect.objectContaining({
-            name: 'VAT',
-            amount: 0.19,
-            includedInPrice: true,
-            country: 'DE',
-          }),
-          expect.objectContaining({
-            name: 'GST',
-            amount: 0.1,
-            includedInPrice: true,
-            country: 'AU',
-          }),
-          expect.objectContaining({
-            name: 'VAT',
-            amount: 0.21,
-            includedInPrice: true,
-            country: 'ES',
-          }),
-          expect.objectContaining({
-            name: 'MA State Tax',
-            amount: 0.0625,
-            includedInPrice: false,
-            country: 'US',
-            state: 'Massachusetts',
-          }),
-          expect.objectContaining({
-            name: 'NJ Sales Tax',
-            amount: 0.0663,
-            includedInPrice: false,
-            country: 'US',
-            state: 'New Jersey',
-          }),
-          expect.objectContaining({
-            name: 'CA Sales Tax',
-            amount: 0.07,
-            includedInPrice: false,
-            country: 'US',
-            state: 'California',
-          }),
-        ]),
-      })
-    );
+    expect(taxCategory).toMatchInlineSnapshot(`
+      {
+        "description": "",
+        "key": "standard-tax",
+        "name": "Standard Tax Category",
+        "rates": [
+          {
+            "amount": 0.19,
+            "country": "DE",
+            "includedInPrice": true,
+            "name": "VAT",
+            "state": undefined,
+            "subRates": [],
+          },
+          {
+            "amount": 0.1,
+            "country": "AU",
+            "includedInPrice": true,
+            "name": "GST",
+            "state": undefined,
+            "subRates": [],
+          },
+          {
+            "amount": 0.21,
+            "country": "ES",
+            "includedInPrice": true,
+            "name": "VAT",
+            "state": undefined,
+            "subRates": [],
+          },
+          {
+            "amount": 0.0625,
+            "country": "US",
+            "includedInPrice": false,
+            "name": "MA State Tax",
+            "state": "Massachusetts",
+            "subRates": [],
+          },
+          {
+            "amount": 0.0663,
+            "country": "US",
+            "includedInPrice": false,
+            "name": "NJ Sales Tax",
+            "state": "New Jersey",
+            "subRates": [],
+          },
+          {
+            "amount": 0.07,
+            "country": "US",
+            "includedInPrice": false,
+            "name": "CA Sales Tax",
+            "state": "California",
+            "subRates": [],
+          },
+        ],
+      }
+    `);
   });
 });

--- a/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-fashion/standard-tax-category.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-fashion/standard-tax-category.ts
@@ -1,45 +1,52 @@
-import * as TaxRateDraft from '../../../../tax-rate';
-import TaxCategoryDraft from '../../builder';
+import * as TaxRateDraft from '../../../../tax-rate/tax-rate-draft';
+import * as TaxCategoryDraft from '../../index';
 
 const standardTaxCategory = () =>
-  TaxCategoryDraft()
+  TaxCategoryDraft.presets
+    .empty()
     .key('standard-tax')
     .name('Standard Tax Category')
     .description('')
     .rates([
-      TaxRateDraft.random()
+      TaxRateDraft.presets
+        .empty()
         .name('VAT')
         .amount(0.19)
         .includedInPrice(true)
         .country('DE')
         .subRates([]),
-      TaxRateDraft.random()
+      TaxRateDraft.presets
+        .empty()
         .name('GST')
         .amount(0.1)
         .includedInPrice(true)
         .country('AU')
         .subRates([]),
-      TaxRateDraft.random()
+      TaxRateDraft.presets
+        .empty()
         .name('VAT')
         .amount(0.21)
         .includedInPrice(true)
         .country('ES')
         .subRates([]),
-      TaxRateDraft.random()
+      TaxRateDraft.presets
+        .empty()
         .name('MA State Tax')
         .amount(0.0625)
         .includedInPrice(false)
         .country('US')
         .state('Massachusetts')
         .subRates([]),
-      TaxRateDraft.random()
+      TaxRateDraft.presets
+        .empty()
         .name('NJ Sales Tax')
         .amount(0.0663)
         .includedInPrice(false)
         .country('US')
         .state('New Jersey')
         .subRates([]),
-      TaxRateDraft.random()
+      TaxRateDraft.presets
+        .empty()
         .name('CA Sales Tax')
         .amount(0.07)
         .includedInPrice(false)

--- a/models/tax-category/src/tax-rate/tax-rate-draft/presets/empty.spec.ts
+++ b/models/tax-category/src/tax-rate/tax-rate-draft/presets/empty.spec.ts
@@ -1,0 +1,11 @@
+import { TTaxRateDraft } from '../../types';
+import empty from './empty';
+
+it(`should set all specified fields to undefined`, () => {
+  const emptyTaxRateDraft = empty().build<TTaxRateDraft>();
+  expect(emptyTaxRateDraft).toMatchObject({
+    amount: undefined,
+    state: undefined,
+    subRates: undefined,
+  });
+});

--- a/models/tax-category/src/tax-rate/tax-rate-draft/presets/empty.ts
+++ b/models/tax-category/src/tax-rate/tax-rate-draft/presets/empty.ts
@@ -1,0 +1,7 @@
+import type { TTaxRateDraftBuilder } from '../../types';
+import TaxRateDraft from '../builder';
+
+const empty = (): TTaxRateDraftBuilder =>
+  TaxRateDraft().amount(undefined).state(undefined).subRates(undefined);
+
+export default empty;

--- a/models/tax-category/src/tax-rate/tax-rate-draft/presets/index.ts
+++ b/models/tax-category/src/tax-rate/tax-rate-draft/presets/index.ts
@@ -1,5 +1,6 @@
+import empty from './empty';
 import withCountryUsaAndIncludedInPrice from './with-country-usa-and-included-in-price';
 
-const presets = { withCountryUsaAndIncludedInPrice };
+const presets = { empty, withCountryUsaAndIncludedInPrice };
 
 export default presets;


### PR DESCRIPTION
## Summary

This PR fixes an incorrect import in the tax category package, which caused non-draft entities to be stubbed rather than draft entities. Additionally, I've created `empty` presets where necessary to support snapshot testing.