### PR TITLE
PANGOLIN-2727: Update handling of SKU's to be more random/unique, update handling of slug in product-draft

### DIFF
--- a/.changeset/heavy-owls-relate.md
+++ b/.changeset/heavy-owls-relate.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-test-data/product-variant': patch
+'@commercetools-test-data/line-item': patch
+'@commercetools-test-data/product': patch
+---
+
+refactor(sku and slug): update handling of sku to use a random word followed by 3 random alphanumeric characters to insure sku uniqueness in line-item, product-variant, product-variant-draft, product-data, and product generator.ts files. update slug to use localizedString slug preset in product-draft generator.ts file.

--- a/models/line-item/src/line-item-draft/generator.ts
+++ b/models/line-item/src/line-item-draft/generator.ts
@@ -16,7 +16,7 @@ const [addedAt] = createRelatedDates();
 const generator = Generator<TLineItemDraft>({
   fields: {
     productId: fake((f) => f.datatype.uuid()),
-    sku: fake((f) => f.lorem.word()),
+    sku: fake((f) => `${f.random.word()}-${f.random.alphaNumeric(3)}`),
     quantity: fake((f) =>
       f.datatype.number({
         min: 1,

--- a/models/product-variant/src/product-variant/generator.ts
+++ b/models/product-variant/src/product-variant/generator.ts
@@ -10,7 +10,7 @@ const generator = Generator<TProductVariant>({
   fields: {
     id: fake((f) => f.datatype.uuid()),
     key: fake((f) => f.lorem.slug(2)),
-    sku: fake((f) => f.random.word()),
+    sku: fake((f) => `${f.random.word()}-${f.random.alphaNumeric(3)}`),
     prices: fake(() => [Price.random()]),
     price: null,
     attributes: fake(() => [Attribute.random()]),

--- a/models/product-variant/src/product-variant/product-variant-draft/generator.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/generator.ts
@@ -9,7 +9,7 @@ import type { TProductVariantDraft } from '../types';
 const generator = Generator<TProductVariantDraft>({
   fields: {
     key: fake((f) => f.lorem.slug(2)),
-    sku: fake((f) => f.random.word()),
+    sku: fake((f) => `${f.random.word()}-${f.random.alphaNumeric(3)}`),
     prices: fake(() => [Price.PriceDraft.random()]),
     attributes: fake(() => [Attribute.AttributeDraft.random()]),
     images: fake(() => [Image.ImageDraft.random()]),

--- a/models/product/src/product-data/generator.ts
+++ b/models/product/src/product-data/generator.ts
@@ -29,7 +29,7 @@ const generator = Generator<TProductData>({
     searchKeywords: null,
     // TODO: Include random SearchKeywords[] when available
     searchKeyword: [],
-    skus: fake((f) => [f.lorem.word()]),
+    skus: fake((f) => [`${f.random.word()}-${f.random.alphaNumeric(3)}`]),
   },
 });
 

--- a/models/product/src/product/generator.ts
+++ b/models/product/src/product/generator.ts
@@ -22,7 +22,7 @@ const generator = Generator<TProduct>({
     state: null,
     reviewRatingStatistics: null,
     priceMode: oneOf(...Object.values(productPriceMode)),
-    skus: [],
+    skus: fake((f) => [`${f.random.word()}-${f.random.alphaNumeric(3)}`]),
     createdAt: fake(getOlderDate),
     createdBy: fake(() => ClientLogging.random()),
     lastModifiedAt: fake(getNewerDate),

--- a/models/product/src/product/product-draft/generator.ts
+++ b/models/product/src/product/product-draft/generator.ts
@@ -14,7 +14,7 @@ const generator = Generator<TProductDraft>({
   fields: {
     name: fake(() => LocalizedString.random()),
     productType: fake(() => Reference.random().typeId('product-type')),
-    slug: fake(() => LocalizedString.random()),
+    slug: fake(() => LocalizedString.presets.ofSlugs()),
     key: fake((f) => f.lorem.slug()),
     description: fake(() => LocalizedString.random()),
     categories: fake(() => [KeyReference.presets.category()]),


### PR DESCRIPTION
refactor(sku and slug): update handling of sku to use a random word followed by 3 random alphanumeric characters to insure sku uniqueness in line-item, product-variant, product-variant-draft, product-data, and product generator.ts files.  update slug to use localizedString slug preset in product-draft generator.ts file