### PR TITLE
fix(taxCategory): add graphql snapshot test

### DIFF
--- a/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-fashion/standard-tax-category.spec.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-fashion/standard-tax-category.spec.ts
@@ -1,4 +1,7 @@
-import type { TTaxCategoryDraft } from '../../../types';
+import type {
+  TTaxCategoryDraft,
+  TTaxCategoryDraftGraphql,
+} from '../../../types';
 import standardTaxCategory from './standard-tax-category';
 
 describe('with a tax rate preset `standard tax category`', () => {
@@ -52,6 +55,75 @@ describe('with a tax rate preset `standard tax category`', () => {
             "subRates": [],
           },
           {
+            "amount": 0.07,
+            "country": "US",
+            "includedInPrice": false,
+            "name": "CA Sales Tax",
+            "state": "California",
+            "subRates": [],
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a tax category with name `Standard Tax Category` when built for graphql', () => {
+    const taxCategoryGraphql =
+      standardTaxCategory().buildGraphql<TTaxCategoryDraftGraphql>();
+    expect(taxCategoryGraphql).toMatchInlineSnapshot(`
+      {
+        "__typename": "TaxCategoryDraft",
+        "description": "",
+        "key": "standard-tax",
+        "name": "Standard Tax Category",
+        "rates": [
+          {
+            "__typename": "TaxRateDraft",
+            "amount": 0.19,
+            "country": "DE",
+            "includedInPrice": true,
+            "name": "VAT",
+            "state": undefined,
+            "subRates": [],
+          },
+          {
+            "__typename": "TaxRateDraft",
+            "amount": 0.1,
+            "country": "AU",
+            "includedInPrice": true,
+            "name": "GST",
+            "state": undefined,
+            "subRates": [],
+          },
+          {
+            "__typename": "TaxRateDraft",
+            "amount": 0.21,
+            "country": "ES",
+            "includedInPrice": true,
+            "name": "VAT",
+            "state": undefined,
+            "subRates": [],
+          },
+          {
+            "__typename": "TaxRateDraft",
+            "amount": 0.0625,
+            "country": "US",
+            "includedInPrice": false,
+            "name": "MA State Tax",
+            "state": "Massachusetts",
+            "subRates": [],
+          },
+          {
+            "__typename": "TaxRateDraft",
+            "amount": 0.0663,
+            "country": "US",
+            "includedInPrice": false,
+            "name": "NJ Sales Tax",
+            "state": "New Jersey",
+            "subRates": [],
+          },
+          {
+            "__typename": "TaxRateDraft",
             "amount": 0.07,
             "country": "US",
             "includedInPrice": false,


### PR DESCRIPTION
This PR adds a graphql build snapshot test for the Fashion Sample Data `taxCategory` preset.