### PR TITLE
chore(test-data): resolve data inconsistencies via types

### DIFF
--- a/.changeset/fuzzy-hotels-deny.md
+++ b/.changeset/fuzzy-hotels-deny.md
@@ -1,0 +1,9 @@
+---
+'@commercetools-test-data/attribute-definition': minor
+'@commercetools-test-data/product-discount': minor
+'@commercetools-test-data/cart-discount': minor
+'@commercetools-test-data/category': minor
+'@commercetools-test-data/product': minor
+---
+
+fix graphql draft types

--- a/.changeset/modern-cameras-beam.md
+++ b/.changeset/modern-cameras-beam.md
@@ -1,0 +1,23 @@
+---
+'@commercetools-test-data/attribute-definition': minor
+'@commercetools-test-data/product-discount': minor
+'@commercetools-test-data/product-variant': minor
+'@commercetools-test-data/shipping-method': minor
+'@commercetools-test-data/customer-group': minor
+'@commercetools-test-data/cart-discount': minor
+'@commercetools-test-data/discount-code': minor
+'@commercetools-test-data/product-type': minor
+'@commercetools-test-data/tax-category': minor
+'@commercetools-test-data/line-item': minor
+'@commercetools-test-data/category': minor
+'@commercetools-test-data/customer': minor
+'@commercetools-test-data/channel': minor
+'@commercetools-test-data/commons': minor
+'@commercetools-test-data/product': minor
+'@commercetools-test-data/review': minor
+'@commercetools-test-data/order': minor
+'@commercetools-test-data/cart': minor
+'@commercetools-test-data/zone': minor
+---
+
+remove \_\_typename from drafts

--- a/models/attribute-definition/src/attribute-definition-draft/builder.spec.ts
+++ b/models/attribute-definition/src/attribute-definition-draft/builder.spec.ts
@@ -89,7 +89,6 @@ describe('builder', () => {
         ]),
         inputHint: expect.any(String),
         isSearchable: expect.any(Boolean),
-        __typename: 'AttributeDefinitionDraft',
       })
     )
   );

--- a/models/attribute-definition/src/attribute-definition-draft/transformers.ts
+++ b/models/attribute-definition/src/attribute-definition-draft/transformers.ts
@@ -22,7 +22,6 @@ const transformers = {
     addFields: ({ fields }) => {
       return {
         label: LocalizedString.toLocalizedField(fields.label)!,
-        __typename: 'AttributeDefinitionDraft',
       };
     },
   }),

--- a/models/attribute-definition/src/attribute-definition-draft/transformers.ts
+++ b/models/attribute-definition/src/attribute-definition-draft/transformers.ts
@@ -1,3 +1,4 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type {
   TAttributeDefinitionDraft,
@@ -18,7 +19,12 @@ const transformers = {
     TAttributeDefinitionDraftGraphql
   >('graphql', {
     buildFields: ['label', 'inputTip', 'type'],
-    addFields: () => ({ __typename: 'AttributeDefinitionDraft' }),
+    addFields: ({ fields }) => {
+      return {
+        label: LocalizedString.toLocalizedField(fields.label)!,
+        __typename: 'AttributeDefinitionDraft',
+      };
+    },
   }),
 };
 

--- a/models/attribute-definition/src/types.ts
+++ b/models/attribute-definition/src/types.ts
@@ -10,7 +10,7 @@ export type TAttributeDefinition = AttributeDefinition;
 export type TAttributeDefinitionDraft = AttributeDefinitionDraft;
 
 export type TAttributeDefinitionGraphql = TAttributeDefinition & {
-  __typename: TAttributeDefinition['name'];
+  __typename: 'AttributeDefinition';
 };
 
 export type TAttributeDefinitionDraftGraphql = Omit<
@@ -18,7 +18,7 @@ export type TAttributeDefinitionDraftGraphql = Omit<
   'label'
 > & {
   label: TLocalizedStringGraphql;
-  __typename: TAttributeDefinitionDraft['name'];
+  __typename: 'AttributeDefinitionDraft';
 };
 
 export type TAttributeDefinitionBuilder = TBuilder<TAttributeDefinition>;

--- a/models/attribute-definition/src/types.ts
+++ b/models/attribute-definition/src/types.ts
@@ -2,6 +2,7 @@ import {
   AttributeDefinition,
   AttributeDefinitionDraft,
 } from '@commercetools/platform-sdk';
+import { TLocalizedStringGraphql } from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TAttributeDefinition = AttributeDefinition;
@@ -12,7 +13,11 @@ export type TAttributeDefinitionGraphql = TAttributeDefinition & {
   __typename: TAttributeDefinition['name'];
 };
 
-export type TAttributeDefinitionDraftGraphql = TAttributeDefinitionDraft & {
+export type TAttributeDefinitionDraftGraphql = Omit<
+  TAttributeDefinitionDraft,
+  'label'
+> & {
+  label: TLocalizedStringGraphql;
   __typename: TAttributeDefinitionDraft['name'];
 };
 

--- a/models/attribute-definition/src/types.ts
+++ b/models/attribute-definition/src/types.ts
@@ -15,10 +15,10 @@ export type TAttributeDefinitionGraphql = TAttributeDefinition & {
 
 export type TAttributeDefinitionDraftGraphql = Omit<
   TAttributeDefinitionDraft,
-  'label'
+  'label' | 'inputTip'
 > & {
   label: TLocalizedStringGraphql;
-  __typename: 'AttributeDefinitionDraft';
+  inputTip?: TLocalizedStringGraphql | null;
 };
 
 export type TAttributeDefinitionBuilder = TBuilder<TAttributeDefinition>;

--- a/models/cart-discount/src/cart-discount-line-items-target/cart-discount-line-items-target-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-line-items-target/cart-discount-line-items-target-draft/builder.spec.ts
@@ -33,9 +33,7 @@ describe('builder', () => {
         lineItems: {
           type: 'lineItems',
           predicate: expect.any(String),
-          __typename: 'LineItemsTargetInput',
         },
-        __typename: 'CartDiscountTargetInput',
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-line-items-target/cart-discount-line-items-target-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-line-items-target/cart-discount-line-items-target-draft/transformers.ts
@@ -16,9 +16,7 @@ const transformers = {
     replaceFields: ({ fields }) => ({
       lineItems: {
         ...fields,
-        __typename: 'LineItemsTargetInput',
       },
-      __typename: 'CartDiscountTargetInput',
     }),
   }),
 };

--- a/models/cart-discount/src/cart-discount-line-items-target/types.ts
+++ b/models/cart-discount/src/cart-discount-line-items-target/types.ts
@@ -10,10 +10,7 @@ export type TCartDiscountLineItemsTargetGraphql =
   };
 
 export type TCartDiscountLineItemsTargetDraftGraphql = {
-  lineItems: TCartDiscountLineItemsTarget & {
-    __typename: 'LineItemsTargetInput';
-  };
-  __typename: 'CartDiscountTargetInput';
+  lineItems: TCartDiscountLineItemsTarget;
 };
 
 export type TCartDiscountLineItemsTargetBuilder =

--- a/models/cart-discount/src/cart-discount-multi-buy-line-items-target/cart-discount-multi-buy-line-items-target-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-multi-buy-line-items-target/cart-discount-multi-buy-line-items-target-draft/builder.spec.ts
@@ -41,9 +41,7 @@ describe('builder', () => {
           discountedQuantity: expect.any(Number),
           maxOccurrence: expect.any(Number),
           selectionMode: expect.any(String),
-          __typename: 'MultiBuyLineItemsTargetInput',
         },
-        __typename: 'CartDiscountTargetInput',
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-multi-buy-line-items-target/cart-discount-multi-buy-line-items-target-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-multi-buy-line-items-target/cart-discount-multi-buy-line-items-target-draft/transformers.ts
@@ -16,9 +16,7 @@ const transformers = {
     replaceFields: ({ fields }) => ({
       multiBuyLineItems: {
         ...fields,
-        __typename: 'MultiBuyLineItemsTargetInput',
       },
-      __typename: 'CartDiscountTargetInput',
     }),
   }),
 };

--- a/models/cart-discount/src/cart-discount-multi-buy-line-items-target/types.ts
+++ b/models/cart-discount/src/cart-discount-multi-buy-line-items-target/types.ts
@@ -12,10 +12,7 @@ export type TCartDiscountMultiBuyLineItemsTargetGraphql =
   };
 
 export type TCartDiscountMultiBuyLineItemsTargetDraftGraphql = {
-  multiBuyLineItems: TCartDiscountMultiBuyLineItemsTarget & {
-    __typename: 'MultiBuyLineItemsTargetInput';
-  };
-  __typename: 'CartDiscountTargetInput';
+  multiBuyLineItems: TCartDiscountMultiBuyLineItemsTarget;
 };
 
 export type TCartDiscountMultiBuyLineItemsTargetBuilder =

--- a/models/cart-discount/src/cart-discount-shipping-cost-target/cart-discount-shipping-cost-target-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-shipping-cost-target/cart-discount-shipping-cost-target-draft/builder.spec.ts
@@ -31,10 +31,7 @@ describe('builder', () => {
       expect.objectContaining({
         shipping: {
           type: 'shipping',
-
-          __typename: 'ShippingTargetInput',
         },
-        __typename: 'CartDiscountTargetInput',
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-shipping-cost-target/cart-discount-shipping-cost-target-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-shipping-cost-target/cart-discount-shipping-cost-target-draft/transformers.ts
@@ -16,9 +16,7 @@ const transformers = {
     replaceFields: ({ fields }) => ({
       shipping: {
         ...fields,
-        __typename: 'ShippingTargetInput',
       },
-      __typename: 'CartDiscountTargetInput',
     }),
   }),
 };

--- a/models/cart-discount/src/cart-discount-shipping-cost-target/types.ts
+++ b/models/cart-discount/src/cart-discount-shipping-cost-target/types.ts
@@ -11,10 +11,7 @@ export type TCartDiscountShippingCostTargetGraphql =
   };
 
 export type TCartDiscountShippingCostTargetDraftGraphql = {
-  shipping: TCartDiscountShippingCostTarget & {
-    __typename: 'ShippingTargetInput';
-  };
-  __typename: 'CartDiscountTargetInput';
+  shipping: TCartDiscountShippingCostTarget;
 };
 
 export type TCartDiscountShippingCostTargetBuilder =

--- a/models/cart-discount/src/cart-discount-value-absolute/cart-discount-value-absolute-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-absolute/cart-discount-value-absolute-draft/builder.spec.ts
@@ -58,7 +58,6 @@ describe('builder', () => {
             centAmount: expect.any(Number),
           }),
         ]),
-        __typename: 'CartDiscountValueAbsoluteDraft',
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-value-absolute/cart-discount-value-absolute-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-absolute/cart-discount-value-absolute-draft/transformers.ts
@@ -22,9 +22,6 @@ const transformers = {
     TCartDiscountValueAbsoluteDraftGraphql
   >('graphql', {
     buildFields: ['money'],
-    addFields: () => ({
-      __typename: 'CartDiscountValueAbsoluteDraft',
-    }),
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-value-absolute/types.ts
+++ b/models/cart-discount/src/cart-discount-value-absolute/types.ts
@@ -11,9 +11,7 @@ export type TCartDiscountValueAbsoluteGraphql = TCartDiscountValueAbsolute & {
   __typename: 'CartDiscountValueAbsolute';
 };
 export type TCartDiscountValueAbsoluteDraftGraphql =
-  TCartDiscountValueAbsoluteDraft & {
-    __typename: 'CartDiscountValueAbsoluteDraft';
-  };
+  TCartDiscountValueAbsoluteDraft;
 
 export type TCartDiscountValueAbsoluteBuilder =
   TBuilder<TCartDiscountValueAbsolute>;

--- a/models/cart-discount/src/cart-discount-value-fixed/cart-discount-value-fixed-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-fixed/cart-discount-value-fixed-draft/builder.spec.ts
@@ -58,7 +58,6 @@ describe('builder', () => {
             centAmount: expect.any(Number),
           }),
         ]),
-        __typename: 'CartDiscountValueFixedDraft',
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-value-fixed/cart-discount-value-fixed-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-fixed/cart-discount-value-fixed-draft/transformers.ts
@@ -22,9 +22,6 @@ const transformers = {
     TCartDiscountValueFixedDraftGraphql
   >('graphql', {
     buildFields: ['money'],
-    addFields: () => ({
-      __typename: 'CartDiscountValueFixedDraft',
-    }),
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-value-fixed/types.ts
+++ b/models/cart-discount/src/cart-discount-value-fixed/types.ts
@@ -10,10 +10,7 @@ export type TCartDiscountValueFixedDraft = CartDiscountValueFixedDraft;
 export type TCartDiscountValueFixedGraphql = TCartDiscountValueFixed & {
   __typename: 'CartDiscountValueFixed';
 };
-export type TCartDiscountValueFixedDraftGraphql =
-  TCartDiscountValueFixedDraft & {
-    __typename: 'CartDiscountValueFixedDraft';
-  };
+export type TCartDiscountValueFixedDraftGraphql = TCartDiscountValueFixedDraft;
 
 export type TCartDiscountValueFixedBuilder = TBuilder<TCartDiscountValueFixed>;
 export type TCartDiscountValueFixedDraftBuilder =

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/cart-discount-value-gift-line-item-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/cart-discount-value-gift-line-item-draft/builder.spec.ts
@@ -82,7 +82,6 @@ describe('builder', () => {
           id: expect.any(String),
           typeId: 'channel',
         }),
-        __typename: 'CartDiscountValueGiftLineItemDraft',
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/cart-discount-value-gift-line-item-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/cart-discount-value-gift-line-item-draft/transformers.ts
@@ -22,9 +22,6 @@ const transformers = {
     TCartDiscountValueGiftLineItemDraftGraphql
   >('graphql', {
     buildFields: ['product', 'supplyChannel', 'distributionChannel'],
-    addFields: () => ({
-      __typename: 'CartDiscountValueGiftLineItemDraft',
-    }),
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
@@ -13,9 +13,7 @@ export type TCartDiscountValueGiftLineItemGraphql =
     __typename: 'CartDiscountValueGiftLineItem';
   };
 export type TCartDiscountValueGiftLineItemDraftGraphql =
-  TCartDiscountValueGiftLineItemDraft & {
-    __typename: 'CartDiscountValueGiftLineItemDraft';
-  };
+  TCartDiscountValueGiftLineItemDraft;
 
 export type TCartDiscountValueGiftLineItemBuilder =
   TBuilder<TCartDiscountValueGiftLineItem>;

--- a/models/cart-discount/src/cart-discount-value-relative/cart-discount-value-relative-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-relative/cart-discount-value-relative-draft/builder.spec.ts
@@ -46,7 +46,6 @@ describe('builder', () => {
       expect.objectContaining({
         type: 'relative',
         permyriad: expect.any(Number),
-        __typename: 'CartDiscountValueRelativeDraft',
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-value-relative/cart-discount-value-relative-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-relative/cart-discount-value-relative-draft/transformers.ts
@@ -22,9 +22,6 @@ const transformers = {
     TCartDiscountValueRelativeDraftGraphql
   >('graphql', {
     buildFields: [],
-    addFields: () => ({
-      __typename: 'CartDiscountValueRelativeDraft',
-    }),
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-value-relative/types.ts
+++ b/models/cart-discount/src/cart-discount-value-relative/types.ts
@@ -11,9 +11,7 @@ export type TCartDiscountValueRelativeGraphql = TCartDiscountValueRelative & {
   __typename: 'CartDiscountValueRelative';
 };
 export type TCartDiscountValueRelativeDraftGraphql =
-  TCartDiscountValueRelativeDraft & {
-    __typename: 'CartDiscountValueRelativeDraft';
-  };
+  TCartDiscountValueRelativeDraft;
 
 export type TCartDiscountValueRelativeBuilder =
   TBuilder<TCartDiscountValueRelative>;

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/builder.spec.ts
@@ -87,7 +87,6 @@ describe('builder', () => {
         validUntil: expect.any(String),
         requiresDiscountCode: expect.any(Boolean),
         stackingMode: expect.any(String),
-        __typename: 'CartDiscountDraft',
       })
     )
   );

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/employee-sale.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/employee-sale.spec.ts
@@ -49,7 +49,6 @@ describe('with the preset `employeeSale`', () => {
 
     expect(cartDiscountDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDiscountDraft",
         "cartPredicate": "customer.customerGroup.key = "employee"",
         "custom": undefined,
         "description": [
@@ -72,9 +71,7 @@ describe('with the preset `employeeSale`', () => {
         "sortOrder": "0.8",
         "stackingMode": "Stacking",
         "target": {
-          "__typename": "CartDiscountTargetInput",
           "lineItems": {
-            "__typename": "LineItemsTargetInput",
             "predicate": "customer.customerGroup.key = "employee"",
             "type": "lineItems",
           },
@@ -82,7 +79,6 @@ describe('with the preset `employeeSale`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "__typename": "CartDiscountValueRelativeDraft",
           "permyriad": 1500,
           "type": "relative",
         },

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/free-shipping.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/free-shipping.spec.ts
@@ -48,7 +48,6 @@ describe('with the preset `freeShipping`', () => {
 
     expect(cartDiscountDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDiscountDraft",
         "cartPredicate": "1 = 1",
         "custom": undefined,
         "description": [
@@ -71,16 +70,13 @@ describe('with the preset `freeShipping`', () => {
         "sortOrder": "0.222",
         "stackingMode": "Stacking",
         "target": {
-          "__typename": "CartDiscountTargetInput",
           "shipping": {
-            "__typename": "ShippingTargetInput",
             "type": "shipping",
           },
         },
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "__typename": "CartDiscountValueRelativeDraft",
           "permyriad": 10000,
           "type": "relative",
         },

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.spec.ts
@@ -54,7 +54,6 @@ describe('with the preset `luxeSpend`', () => {
 
     expect(cartDiscountDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDiscountDraft",
         "cartPredicate": "totalPrice = "500.00 EUR" and customer.customerGroup.key = "luxe"",
         "custom": undefined,
         "description": [
@@ -77,9 +76,7 @@ describe('with the preset `luxeSpend`', () => {
         "sortOrder": "0.876899",
         "stackingMode": "Stacking",
         "target": {
-          "__typename": "CartDiscountTargetInput",
           "lineItems": {
-            "__typename": "LineItemsTargetInput",
             "predicate": "1=1",
             "type": "lineItems",
           },
@@ -87,9 +84,7 @@ describe('with the preset `luxeSpend`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "__typename": "CartDiscountValueAbsoluteDraft",
           "money": {
-            "__typename": "MoneyInput",
             "centAmount": 3000,
             "currencyCode": "EUR",
             "fractionDigits": 2,

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/percent-off-womens-wear.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/percent-off-womens-wear.spec.ts
@@ -50,7 +50,6 @@ describe('with the preset `percentOffWomensWear`', () => {
 
     expect(cartDiscountDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDiscountDraft",
         "cartPredicate": "1 = 1",
         "custom": undefined,
         "description": [
@@ -73,9 +72,7 @@ describe('with the preset `percentOffWomensWear`', () => {
         "sortOrder": "0.3445",
         "stackingMode": "Stacking",
         "target": {
-          "__typename": "CartDiscountTargetInput",
           "lineItems": {
-            "__typename": "LineItemsTargetInput",
             "predicate": "categories.key contains "bottoms-women" and price.discount.id is not defined",
             "type": "lineItems",
           },
@@ -83,7 +80,6 @@ describe('with the preset `percentOffWomensWear`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "__typename": "CartDiscountValueRelativeDraft",
           "permyriad": 1500,
           "type": "relative",
         },

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
@@ -53,7 +53,6 @@ describe('with the preset `shirtsBogo`', () => {
 
     expect(cartDiscountDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDiscountDraft",
         "cartPredicate": "1 = 1",
         "custom": undefined,
         "description": [
@@ -76,9 +75,7 @@ describe('with the preset `shirtsBogo`', () => {
         "sortOrder": "0.2",
         "stackingMode": "Stacking",
         "target": {
-          "__typename": "CartDiscountTargetInput",
           "multiBuyLineItems": {
-            "__typename": "MultiBuyLineItemsTargetInput",
             "discountedQuantity": 1,
             "maxOccurrence": undefined,
             "predicate": "productType.key = "shirts"",
@@ -90,7 +87,6 @@ describe('with the preset `shirtsBogo`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "__typename": "CartDiscountValueRelativeDraft",
           "permyriad": 10000,
           "type": "relative",
         },

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.spec.ts
@@ -54,7 +54,6 @@ describe('with the preset `skinnyFixed`', () => {
 
     expect(cartDiscountDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDiscountDraft",
         "cartPredicate": "1 = 1",
         "custom": undefined,
         "description": [
@@ -77,9 +76,7 @@ describe('with the preset `skinnyFixed`', () => {
         "sortOrder": "0.6",
         "stackingMode": "Stacking",
         "target": {
-          "__typename": "CartDiscountTargetInput",
           "lineItems": {
-            "__typename": "LineItemsTargetInput",
             "predicate": "product.key = "skinny_jeans"",
             "type": "lineItems",
           },
@@ -87,9 +84,7 @@ describe('with the preset `skinnyFixed`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "__typename": "CartDiscountValueFixedDraft",
           "money": {
-            "__typename": "MoneyInput",
             "centAmount": 2500,
             "currencyCode": "EUR",
             "fractionDigits": 2,

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/spend-save-ten-percent.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/spend-save-ten-percent.spec.ts
@@ -49,7 +49,6 @@ describe('with the preset `spendSaveTenPercent`', () => {
 
     expect(cartDiscountDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDiscountDraft",
         "cartPredicate": "totalPrice = "100.00 EUR"",
         "custom": undefined,
         "description": [
@@ -72,9 +71,7 @@ describe('with the preset `spendSaveTenPercent`', () => {
         "sortOrder": "0.897987087",
         "stackingMode": "Stacking",
         "target": {
-          "__typename": "CartDiscountTargetInput",
           "lineItems": {
-            "__typename": "LineItemsTargetInput",
             "predicate": "1=1",
             "type": "lineItems",
           },
@@ -82,7 +79,6 @@ describe('with the preset `spendSaveTenPercent`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "__typename": "CartDiscountValueRelativeDraft",
           "permyriad": 1000,
           "type": "relative",
         },

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/summer-flips.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/summer-flips.spec.ts
@@ -52,7 +52,6 @@ describe('with the preset `summerFlips`', () => {
 
     expect(cartDiscountDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDiscountDraft",
         "cartPredicate": "lineItemExists(product.key = "summer_dress") = true",
         "custom": undefined,
         "description": [
@@ -78,7 +77,6 @@ describe('with the preset `summerFlips`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "__typename": "CartDiscountValueGiftLineItemDraft",
           "distributionChannel": undefined,
           "product": {
             "__typename": "Reference",

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/transformers.ts
@@ -12,9 +12,6 @@ const transformers = {
     'graphql',
     {
       buildFields: ['value', 'name', 'description', 'target'],
-      addFields: () => ({
-        __typename: 'CartDiscountDraft',
-      }),
     }
   ),
 };

--- a/models/cart-discount/src/cart-discount/types.ts
+++ b/models/cart-discount/src/cart-discount/types.ts
@@ -15,7 +15,12 @@ export type TCartDiscountGraphql = TCartDiscount & {
   nameAllLocales?: TLocalizedStringGraphql | null;
   descriptionAllLocales?: TLocalizedStringGraphql | null;
 };
-export type TCartDiscountDraftGraphql = TCartDiscountDraft & {
+export type TCartDiscountDraftGraphql = Omit<
+  TCartDiscountDraft,
+  'name' | 'description'
+> & {
+  name: TLocalizedStringGraphql;
+  description?: TLocalizedStringGraphql | null;
   __typename: 'CartDiscountDraft';
 };
 

--- a/models/cart-discount/src/cart-discount/types.ts
+++ b/models/cart-discount/src/cart-discount/types.ts
@@ -21,7 +21,6 @@ export type TCartDiscountDraftGraphql = Omit<
 > & {
   name: TLocalizedStringGraphql;
   description?: TLocalizedStringGraphql | null;
-  __typename: 'CartDiscountDraft';
 };
 
 export type TCartDiscountBuilder = TBuilder<TCartDiscount>;

--- a/models/cart/src/cart-draft/builder.spec.ts
+++ b/models/cart/src/cart-draft/builder.spec.ts
@@ -147,7 +147,6 @@ describe('builder', () => {
           expect.objectContaining({
             sku: expect.any(String),
             quantity: expect.any(Number),
-            __typename: 'LineItemDraft',
           }),
         ]),
         customLineItems: expect.arrayContaining([]),
@@ -176,7 +175,6 @@ describe('builder', () => {
         shipping: expect.arrayContaining([]),
         itemShippingAddresses: expect.arrayContaining([]),
         discountCodes: expect.arrayContaining([expect.any(String)]),
-        __typename: 'CartDraft',
       })
     )
   );

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/jamie-doe-01.spec.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/jamie-doe-01.spec.ts
@@ -133,10 +133,8 @@ describe('with the preset cart `jamieDoe01`', () => {
 
     expect(cartDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDraft",
         "anonymousId": undefined,
         "billingAddress": {
-          "__typename": "AddressDraft",
           "additionalAddressInfo": undefined,
           "additionalStreetInfo": undefined,
           "apartment": undefined,
@@ -185,7 +183,6 @@ describe('with the preset cart `jamieDoe01`', () => {
         "key": "jamie-01-cart",
         "lineItems": [
           {
-            "__typename": "LineItemDraft",
             "addedAt": undefined,
             "custom": undefined,
             "distributionChannel": undefined,
@@ -201,7 +198,6 @@ describe('with the preset cart `jamieDoe01`', () => {
             "variantId": undefined,
           },
           {
-            "__typename": "LineItemDraft",
             "addedAt": undefined,
             "custom": undefined,
             "distributionChannel": undefined,
@@ -221,7 +217,6 @@ describe('with the preset cart `jamieDoe01`', () => {
         "origin": "Merchant",
         "shipping": undefined,
         "shippingAddress": {
-          "__typename": "AddressDraft",
           "additionalAddressInfo": undefined,
           "additionalStreetInfo": undefined,
           "apartment": undefined,

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-01.spec.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-01.spec.ts
@@ -118,10 +118,8 @@ describe('with the preset cart `johnDoe01`', () => {
 
     expect(cartDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDraft",
         "anonymousId": undefined,
         "billingAddress": {
-          "__typename": "AddressDraft",
           "additionalAddressInfo": undefined,
           "additionalStreetInfo": undefined,
           "apartment": undefined,
@@ -170,7 +168,6 @@ describe('with the preset cart `johnDoe01`', () => {
         "key": "john-01-cart",
         "lineItems": [
           {
-            "__typename": "LineItemDraft",
             "addedAt": undefined,
             "custom": undefined,
             "distributionChannel": undefined,
@@ -190,7 +187,6 @@ describe('with the preset cart `johnDoe01`', () => {
         "origin": "Merchant",
         "shipping": undefined,
         "shippingAddress": {
-          "__typename": "AddressDraft",
           "additionalAddressInfo": undefined,
           "additionalStreetInfo": undefined,
           "apartment": undefined,

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-02.spec.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-02.spec.ts
@@ -120,10 +120,8 @@ describe('with the preset cart `johnDoe02`', () => {
 
     expect(cartDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDraft",
         "anonymousId": undefined,
         "billingAddress": {
-          "__typename": "AddressDraft",
           "additionalAddressInfo": undefined,
           "additionalStreetInfo": undefined,
           "apartment": undefined,
@@ -174,7 +172,6 @@ describe('with the preset cart `johnDoe02`', () => {
         "key": "john-02-cart",
         "lineItems": [
           {
-            "__typename": "LineItemDraft",
             "addedAt": undefined,
             "custom": undefined,
             "distributionChannel": undefined,
@@ -194,7 +191,6 @@ describe('with the preset cart `johnDoe02`', () => {
         "origin": "Merchant",
         "shipping": undefined,
         "shippingAddress": {
-          "__typename": "AddressDraft",
           "additionalAddressInfo": undefined,
           "additionalStreetInfo": undefined,
           "apartment": undefined,

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-01.spec.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-01.spec.ts
@@ -115,10 +115,8 @@ describe('with the preset cart `marySmith01`', () => {
 
     expect(cartDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDraft",
         "anonymousId": undefined,
         "billingAddress": {
-          "__typename": "AddressDraft",
           "additionalAddressInfo": undefined,
           "additionalStreetInfo": undefined,
           "apartment": undefined,
@@ -163,7 +161,6 @@ describe('with the preset cart `marySmith01`', () => {
         "key": "mary-01-cart",
         "lineItems": [
           {
-            "__typename": "LineItemDraft",
             "addedAt": undefined,
             "custom": undefined,
             "distributionChannel": undefined,
@@ -183,7 +180,6 @@ describe('with the preset cart `marySmith01`', () => {
         "origin": "Merchant",
         "shipping": undefined,
         "shippingAddress": {
-          "__typename": "AddressDraft",
           "additionalAddressInfo": undefined,
           "additionalStreetInfo": undefined,
           "apartment": undefined,

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-02.spec.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-02.spec.ts
@@ -117,10 +117,8 @@ describe('with the preset cart `marySmith01`', () => {
 
     expect(cartDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "CartDraft",
         "anonymousId": undefined,
         "billingAddress": {
-          "__typename": "AddressDraft",
           "additionalAddressInfo": undefined,
           "additionalStreetInfo": undefined,
           "apartment": undefined,
@@ -167,7 +165,6 @@ describe('with the preset cart `marySmith01`', () => {
         "key": "mary-02-cart",
         "lineItems": [
           {
-            "__typename": "LineItemDraft",
             "addedAt": undefined,
             "custom": undefined,
             "distributionChannel": undefined,
@@ -187,7 +184,6 @@ describe('with the preset cart `marySmith01`', () => {
         "origin": "Merchant",
         "shipping": undefined,
         "shippingAddress": {
-          "__typename": "AddressDraft",
           "additionalAddressInfo": undefined,
           "additionalStreetInfo": undefined,
           "apartment": undefined,

--- a/models/cart/src/cart-draft/transformers.ts
+++ b/models/cart/src/cart-draft/transformers.ts
@@ -31,7 +31,6 @@ const transformers = {
       'billingAddress',
       'shippingMethod',
     ],
-    addFields: () => ({ __typename: 'CartDraft' }),
   }),
 };
 

--- a/models/cart/src/types.ts
+++ b/models/cart/src/types.ts
@@ -7,9 +7,7 @@ export type TCartDraft = CartDraft;
 export type TCartGraphql = TCart & {
   __typename: 'Cart';
 };
-export type TCartDraftGraphql = TCartDraft & {
-  __typename: 'CartDraft';
-};
+export type TCartDraftGraphql = TCartDraft;
 
 export type TCartBuilder = TBuilder<TCart>;
 export type TCartDraftBuilder = TBuilder<TCartDraft>;

--- a/models/category/src/category-draft/builder.spec.ts
+++ b/models/category/src/category-draft/builder.spec.ts
@@ -62,7 +62,6 @@ describe('builder', () => {
       'graphql',
       CategoryDraft.random(),
       expect.objectContaining({
-        __typename: 'CategoryDraft',
         key: expect.any(String),
         externalId: expect.any(String),
         orderHint: expect.any(String),

--- a/models/category/src/category-draft/presets/sample-data-fashion/bottoms-kids.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/bottoms-kids.spec.ts
@@ -47,7 +47,6 @@ describe(`with bottomsKids preset`, () => {
 
     expect(bottomsKidsCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": [

--- a/models/category/src/category-draft/presets/sample-data-fashion/bottoms-kids.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/bottoms-kids.spec.ts
@@ -57,26 +57,12 @@ describe(`with bottomsKids preset`, () => {
             "value": "Bottoms",
           },
         ],
-        "descriptionAllLocales": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Bottoms",
-          },
-        ],
         "externalId": undefined,
         "key": "bottoms_kids",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Bottoms",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/bottoms-men.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/bottoms-men.spec.ts
@@ -46,20 +46,12 @@ describe(`with bottomsMen preset`, () => {
         "assets": undefined,
         "custom": undefined,
         "description": undefined,
-        "descriptionAllLocales": null,
         "externalId": undefined,
         "key": "bottoms-men",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Bottoms",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/bottoms-men.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/bottoms-men.spec.ts
@@ -42,7 +42,6 @@ describe(`with bottomsMen preset`, () => {
 
     expect(bottomsMenCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": undefined,

--- a/models/category/src/category-draft/presets/sample-data-fashion/bottoms-women.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/bottoms-women.spec.ts
@@ -42,7 +42,6 @@ describe(`with bottomsWomen preset`, () => {
 
     expect(bottomsWomenCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": undefined,

--- a/models/category/src/category-draft/presets/sample-data-fashion/bottoms-women.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/bottoms-women.spec.ts
@@ -46,20 +46,12 @@ describe(`with bottomsWomen preset`, () => {
         "assets": undefined,
         "custom": undefined,
         "description": undefined,
-        "descriptionAllLocales": null,
         "externalId": undefined,
         "key": "bottoms-women",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Bottoms",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/clothing-kids.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/clothing-kids.spec.ts
@@ -42,7 +42,6 @@ describe(`with clothingKids preset`, () => {
 
     expect(clothingKidsCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": undefined,

--- a/models/category/src/category-draft/presets/sample-data-fashion/clothing-kids.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/clothing-kids.spec.ts
@@ -46,20 +46,12 @@ describe(`with clothingKids preset`, () => {
         "assets": undefined,
         "custom": undefined,
         "description": undefined,
-        "descriptionAllLocales": null,
         "externalId": undefined,
         "key": "clothing-kids",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Clothing",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/kids.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/kids.spec.ts
@@ -54,26 +54,12 @@ describe(`with kids preset`, () => {
             "value": "Items for kids",
           },
         ],
-        "descriptionAllLocales": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Items for kids",
-          },
-        ],
         "externalId": undefined,
         "key": "kids",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Kids",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/kids.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/kids.spec.ts
@@ -44,7 +44,6 @@ describe(`with kids preset`, () => {
 
     expect(kidsCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": [

--- a/models/category/src/category-draft/presets/sample-data-fashion/men.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/men.spec.ts
@@ -43,7 +43,6 @@ describe(`with men preset`, () => {
 
     expect(menCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": [

--- a/models/category/src/category-draft/presets/sample-data-fashion/men.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/men.spec.ts
@@ -53,26 +53,12 @@ describe(`with men preset`, () => {
             "value": "Items for men",
           },
         ],
-        "descriptionAllLocales": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Items for men",
-          },
-        ],
         "externalId": undefined,
         "key": "men",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Men",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/other-kids.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/other-kids.spec.ts
@@ -46,20 +46,12 @@ describe(`with otherKids preset`, () => {
         "assets": undefined,
         "custom": undefined,
         "description": undefined,
-        "descriptionAllLocales": null,
         "externalId": undefined,
         "key": "other-kids",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Other",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/other-kids.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/other-kids.spec.ts
@@ -42,7 +42,6 @@ describe(`with otherKids preset`, () => {
 
     expect(otherKidsCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": undefined,

--- a/models/category/src/category-draft/presets/sample-data-fashion/other-men.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/other-men.spec.ts
@@ -42,7 +42,6 @@ describe(`with otherMen preset`, () => {
 
     expect(otherMenCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": undefined,

--- a/models/category/src/category-draft/presets/sample-data-fashion/other-men.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/other-men.spec.ts
@@ -46,20 +46,12 @@ describe(`with otherMen preset`, () => {
         "assets": undefined,
         "custom": undefined,
         "description": undefined,
-        "descriptionAllLocales": null,
         "externalId": undefined,
         "key": "other-men",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Other",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/other-women.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/other-women.spec.ts
@@ -42,7 +42,6 @@ describe(`with otherWomen preset`, () => {
 
     expect(otherWomenCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": [],
         "custom": undefined,
         "description": undefined,

--- a/models/category/src/category-draft/presets/sample-data-fashion/other-women.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/other-women.spec.ts
@@ -46,20 +46,12 @@ describe(`with otherWomen preset`, () => {
         "assets": [],
         "custom": undefined,
         "description": undefined,
-        "descriptionAllLocales": null,
         "externalId": undefined,
         "key": "other-women",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Other",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/tops-kids.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/tops-kids.spec.ts
@@ -57,26 +57,12 @@ describe(`with topsKids preset`, () => {
             "value": "Tops",
           },
         ],
-        "descriptionAllLocales": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Tops",
-          },
-        ],
         "externalId": undefined,
         "key": "tops-kids",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Tops",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/tops-kids.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/tops-kids.spec.ts
@@ -47,7 +47,6 @@ describe(`with topsKids preset`, () => {
 
     expect(topsKidsCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": [

--- a/models/category/src/category-draft/presets/sample-data-fashion/tops-men.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/tops-men.spec.ts
@@ -46,20 +46,12 @@ describe(`with topsMen preset`, () => {
         "assets": undefined,
         "custom": undefined,
         "description": undefined,
-        "descriptionAllLocales": null,
         "externalId": undefined,
         "key": "tops-men",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Tops",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/tops-men.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/tops-men.spec.ts
@@ -42,7 +42,6 @@ describe(`with topsMen preset`, () => {
 
     expect(topsMenCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": undefined,

--- a/models/category/src/category-draft/presets/sample-data-fashion/tops-women.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/tops-women.spec.ts
@@ -42,7 +42,6 @@ describe(`with topsWomen preset`, () => {
 
     expect(topsWomenCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": undefined,

--- a/models/category/src/category-draft/presets/sample-data-fashion/tops-women.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/tops-women.spec.ts
@@ -46,20 +46,12 @@ describe(`with topsWomen preset`, () => {
         "assets": undefined,
         "custom": undefined,
         "description": undefined,
-        "descriptionAllLocales": null,
         "externalId": undefined,
         "key": "tops-women",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Tops",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/presets/sample-data-fashion/women.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/women.spec.ts
@@ -44,7 +44,6 @@ describe(`with women preset`, () => {
 
     expect(womenCategoryDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "CategoryDraft",
         "assets": undefined,
         "custom": undefined,
         "description": [

--- a/models/category/src/category-draft/presets/sample-data-fashion/women.spec.ts
+++ b/models/category/src/category-draft/presets/sample-data-fashion/women.spec.ts
@@ -54,26 +54,12 @@ describe(`with women preset`, () => {
             "value": "Items for women",
           },
         ],
-        "descriptionAllLocales": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Items for women",
-          },
-        ],
         "externalId": undefined,
         "key": "women",
         "metaDescription": undefined,
         "metaKeywords": undefined,
         "metaTitle": undefined,
         "name": [
-          {
-            "__typename": "LocalizedString",
-            "locale": "en-US",
-            "value": "Women",
-          },
-        ],
-        "nameAllLocales": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",

--- a/models/category/src/category-draft/transformers.ts
+++ b/models/category/src/category-draft/transformers.ts
@@ -10,7 +10,6 @@ const transformers = {
   }),
   graphql: Transformer<TCategoryDraft, TCategoryDraftGraphql>('graphql', {
     buildFields: ['description', 'name', 'slug', 'parent'],
-    addFields: () => ({ __typename: 'CategoryDraft' }),
   }),
 };
 

--- a/models/category/src/category-draft/transformers.ts
+++ b/models/category/src/category-draft/transformers.ts
@@ -1,4 +1,3 @@
-import { LocalizedString } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type { TCategoryDraft, TCategoryDraftGraphql } from '../types';
 
@@ -11,18 +10,7 @@ const transformers = {
   }),
   graphql: Transformer<TCategoryDraft, TCategoryDraftGraphql>('graphql', {
     buildFields: ['description', 'name', 'slug', 'parent'],
-    addFields: ({ fields }) => {
-      const nameAllLocales = LocalizedString.toLocalizedField(fields.name);
-      const descriptionAllLocales = LocalizedString.toLocalizedField(
-        fields.description
-      );
-
-      return {
-        __typename: 'CategoryDraft',
-        nameAllLocales,
-        descriptionAllLocales,
-      };
-    },
+    addFields: () => ({ __typename: 'CategoryDraft' }),
   }),
 };
 

--- a/models/category/src/types.ts
+++ b/models/category/src/types.ts
@@ -9,10 +9,21 @@ import type { TBuilder } from '@commercetools-test-data/core';
 export type TCategoryDraft = CategoryDraft;
 export type TCategoryDraftBuilder = TBuilder<TCategoryDraft>;
 export type TCreateCategoryDraftBuilder = () => TCategoryDraftBuilder;
-export type TCategoryDraftGraphql = Omit<TCategory, 'name' | 'description'> & {
+export type TCategoryDraftGraphql = Omit<
+  TCategory,
+  | 'name'
+  | 'description'
+  | 'slug'
+  | 'metaTitle'
+  | 'metaDescription'
+  | 'metaKeywords'
+> & {
   name: TLocalizedStringGraphql;
   description?: TLocalizedStringGraphql | null;
-  __typename: 'CategoryDraft';
+  slug: TLocalizedStringGraphql;
+  metaTitle?: TLocalizedStringGraphql | null;
+  metaDescription?: TLocalizedStringGraphql | null;
+  metaKeywords?: TLocalizedStringGraphql | null;
 };
 
 //Category

--- a/models/category/src/types.ts
+++ b/models/category/src/types.ts
@@ -9,16 +9,10 @@ import type { TBuilder } from '@commercetools-test-data/core';
 export type TCategoryDraft = CategoryDraft;
 export type TCategoryDraftBuilder = TBuilder<TCategoryDraft>;
 export type TCreateCategoryDraftBuilder = () => TCategoryDraftBuilder;
-export type TCategoryDraftGraphql = Omit<
-  TCategory,
-  // In GraphQL, we prefer to use `nameAllLocales` instead of `name`.
-  | 'name'
-  // In GraphQL, we prefer to use `descriptionAllLocales` instead of `description`.
-  | 'description'
-> & {
+export type TCategoryDraftGraphql = Omit<TCategory, 'name' | 'description'> & {
+  name: TLocalizedStringGraphql;
+  description?: TLocalizedStringGraphql | null;
   __typename: 'CategoryDraft';
-  nameAllLocales?: TLocalizedStringGraphql | null;
-  descriptionAllLocales?: TLocalizedStringGraphql | null;
 };
 
 //Category

--- a/models/channel/src/channel-draft/builder.spec.ts
+++ b/models/channel/src/channel-draft/builder.spec.ts
@@ -55,7 +55,6 @@ describe('builder', () => {
       'graphql',
       ChannelDraft.random(),
       expect.objectContaining({
-        __typename: 'ChannelDraft',
         key: expect.any(String),
         name: expect.arrayContaining([
           expect.objectContaining({

--- a/models/channel/src/channel-draft/presets/sample-data-fashion/hub.spec.ts
+++ b/models/channel/src/channel-draft/presets/sample-data-fashion/hub.spec.ts
@@ -37,7 +37,6 @@ describe('hub channel', () => {
 
     expect(channel).toMatchInlineSnapshot(`
       {
-        "__typename": "ChannelDraft",
         "address": undefined,
         "custom": undefined,
         "description": [

--- a/models/channel/src/channel-draft/presets/sample-data-fashion/store-other.spec.ts
+++ b/models/channel/src/channel-draft/presets/sample-data-fashion/store-other.spec.ts
@@ -35,7 +35,6 @@ describe('store-other channel', () => {
 
     expect(channel).toMatchInlineSnapshot(`
       {
-        "__typename": "ChannelDraft",
         "address": undefined,
         "custom": undefined,
         "description": [

--- a/models/channel/src/channel-draft/presets/sample-data-fashion/store-usa.spec.ts
+++ b/models/channel/src/channel-draft/presets/sample-data-fashion/store-usa.spec.ts
@@ -35,7 +35,6 @@ describe('store-usa channel', () => {
 
     expect(channel).toMatchInlineSnapshot(`
       {
-        "__typename": "ChannelDraft",
         "address": undefined,
         "custom": undefined,
         "description": [

--- a/models/channel/src/channel-draft/transformers.ts
+++ b/models/channel/src/channel-draft/transformers.ts
@@ -10,9 +10,6 @@ const transformers = {
   }),
   graphql: Transformer<TChannelDraft, TChannelDraftGraphql>('graphql', {
     buildFields: ['name', 'description', 'address'],
-    addFields: () => ({
-      __typename: 'ChannelDraft',
-    }),
   }),
 };
 

--- a/models/channel/src/types.ts
+++ b/models/channel/src/types.ts
@@ -12,7 +12,6 @@ export type TChannelDraftGraphql = Omit<
   TChannelDraft,
   'name' | 'description'
 > & {
-  __typename: 'ChannelDraft';
   name?: TLocalizedStringGraphql;
   description?: TLocalizedStringGraphql;
 };

--- a/models/commons/src/address/address-draft/builder.spec.ts
+++ b/models/commons/src/address/address-draft/builder.spec.ts
@@ -76,8 +76,31 @@ describe('builder', () => {
       'graphql',
       AddressDraft.random(),
       expect.objectContaining({
-        __typename: 'AddressDraft',
-        // ...
+        id: null,
+        key: expect.any(String),
+        title: expect.any(String),
+        salutation: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        streetName: expect.any(String),
+        streetNumber: expect.any(String),
+        additionalStreetInfo: expect.any(String),
+        postalCode: expect.any(String),
+        city: expect.any(String),
+        region: null,
+        state: expect.any(String),
+        country: expect.any(String),
+        company: expect.any(String),
+        department: expect.any(String),
+        building: null,
+        apartment: null,
+        pOBox: 'PO Box 1033',
+        phone: expect.any(String),
+        mobile: expect.any(String),
+        fax: expect.any(String),
+        email: expect.any(String),
+        additionalAddressInfo: null,
+        externalId: null,
       })
     )
   );

--- a/models/commons/src/address/address-draft/presets/sample-data-fashion/jamie-doe.spec.ts
+++ b/models/commons/src/address/address-draft/presets/sample-data-fashion/jamie-doe.spec.ts
@@ -42,7 +42,6 @@ describe('with the preset `jamieDoe`', () => {
 
     expect(address).toMatchInlineSnapshot(`
       {
-        "__typename": "AddressDraft",
         "additionalAddressInfo": undefined,
         "additionalStreetInfo": undefined,
         "apartment": undefined,

--- a/models/commons/src/address/address-draft/presets/sample-data-fashion/john-doe.spec.ts
+++ b/models/commons/src/address/address-draft/presets/sample-data-fashion/john-doe.spec.ts
@@ -42,7 +42,6 @@ describe('with the preset `johnDoe`', () => {
 
     expect(address).toMatchInlineSnapshot(`
       {
-        "__typename": "AddressDraft",
         "additionalAddressInfo": undefined,
         "additionalStreetInfo": undefined,
         "apartment": undefined,

--- a/models/commons/src/address/address-draft/presets/sample-data-fashion/mary-smith.spec.ts
+++ b/models/commons/src/address/address-draft/presets/sample-data-fashion/mary-smith.spec.ts
@@ -42,7 +42,6 @@ describe('with the preset `marySmith`', () => {
 
     expect(address).toMatchInlineSnapshot(`
       {
-        "__typename": "AddressDraft",
         "additionalAddressInfo": undefined,
         "additionalStreetInfo": undefined,
         "apartment": undefined,

--- a/models/commons/src/address/address-draft/transformers.ts
+++ b/models/commons/src/address/address-draft/transformers.ts
@@ -4,11 +4,7 @@ import type { TAddressDraft, TAddressDraftGraphql } from '../types';
 const transformers = {
   default: Transformer<TAddressDraft, TAddressDraft>('default', {}),
   rest: Transformer<TAddressDraft, TAddressDraft>('rest', {}),
-  graphql: Transformer<TAddressDraft, TAddressDraftGraphql>('graphql', {
-    addFields: () => ({
-      __typename: 'AddressDraft',
-    }),
-  }),
+  graphql: Transformer<TAddressDraft, TAddressDraftGraphql>('graphql', {}),
 };
 
 export default transformers;

--- a/models/commons/src/address/types.ts
+++ b/models/commons/src/address/types.ts
@@ -7,9 +7,7 @@ export type TAddressDraft = AddressDraft;
 export type TAddressGraphql = TAddress & {
   __typename: 'Address';
 };
-export type TAddressDraftGraphql = TAddressDraft & {
-  __typename: 'AddressDraft';
-};
+export type TAddressDraftGraphql = TAddressDraft;
 
 export type TAddressBuilder = TBuilder<TAddress>;
 export type TAddressDraftBuilder = TBuilder<TAddressDraft>;

--- a/models/commons/src/cent-precision-money/cent-precision-money-draft/builder.spec.ts
+++ b/models/commons/src/cent-precision-money/cent-precision-money-draft/builder.spec.ts
@@ -46,7 +46,6 @@ describe('builder', () => {
         centAmount: expect.any(Number),
         currencyCode: expect.any(String),
         fractionDigits: 2,
-        __typename: 'MoneyInput',
       })
     )
   );

--- a/models/commons/src/cent-precision-money/cent-precision-money-draft/transformers.ts
+++ b/models/commons/src/cent-precision-money/cent-precision-money-draft/transformers.ts
@@ -18,7 +18,6 @@ const transformers = {
     TCentPrecisionMoneyDraftGraphql
   >('graphql', {
     buildFields: [],
-    addFields: () => ({ __typename: 'MoneyInput' }),
   }),
 };
 

--- a/models/commons/src/cent-precision-money/types.ts
+++ b/models/commons/src/cent-precision-money/types.ts
@@ -10,9 +10,7 @@ export type TCentPrecisionMoneyDraft = CentPrecisionMoneyDraft;
 export type TCentPrecisionMoneyGraphql = TCentPrecisionMoney & {
   __typename: 'Money';
 };
-export type TCentPrecisionMoneyDraftGraphql = TCentPrecisionMoneyDraft & {
-  __typename: 'MoneyInput';
-};
+export type TCentPrecisionMoneyDraftGraphql = TCentPrecisionMoneyDraft;
 
 export type TCentPrecisionMoneyBuilder = TBuilder<TCentPrecisionMoney>;
 export type TCentPrecisionMoneyDraftBuilder =

--- a/models/commons/src/money/builder.spec.ts
+++ b/models/commons/src/money/builder.spec.ts
@@ -34,7 +34,6 @@ describe('builder', () => {
       expect.objectContaining({
         centAmount: expect.any(Number),
         currencyCode: expect.any(String),
-        __typename: 'BaseMoneyInput',
       })
     )
   );

--- a/models/commons/src/money/transformers.ts
+++ b/models/commons/src/money/transformers.ts
@@ -10,9 +10,6 @@ const transformers = {
   }),
   graphql: Transformer<TMoney, TMoneyGraphql>('graphql', {
     buildFields: [],
-    addFields: () => ({
-      __typename: 'BaseMoneyInput',
-    }),
   }),
 };
 

--- a/models/commons/src/money/types.ts
+++ b/models/commons/src/money/types.ts
@@ -3,9 +3,7 @@ import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TMoney = Money;
 
-export type TMoneyGraphql = TMoney & {
-  __typename: 'BaseMoneyInput';
-};
+export type TMoneyGraphql = TMoney;
 
 export type TMoneyBuilder = TBuilder<TMoney>;
 export type TCreateMoneyBuilder = () => TMoneyBuilder;

--- a/models/commons/src/price/price-draft/builder.spec.ts
+++ b/models/commons/src/price/price-draft/builder.spec.ts
@@ -73,7 +73,6 @@ describe('builder', () => {
         tiers: null,
         discounted: null,
         custom: null,
-        __typename: 'ProductPriceDataInput',
       })
     )
   );

--- a/models/commons/src/price/price-draft/transformers.ts
+++ b/models/commons/src/price/price-draft/transformers.ts
@@ -31,9 +31,6 @@ const transformers = {
       'discounted',
       'custom',
     ],
-    addFields: () => ({
-      __typename: 'ProductPriceDataInput',
-    }),
   }),
 };
 

--- a/models/commons/src/price/types.ts
+++ b/models/commons/src/price/types.ts
@@ -7,9 +7,7 @@ export type TPriceDraft = PriceDraft;
 export type TPriceGraphql = TPrice & {
   __typename: 'ProductPrice';
 };
-export type TPriceDraftGraphql = TPriceDraft & {
-  __typename: 'ProductPriceDataInput';
-};
+export type TPriceDraftGraphql = TPriceDraft;
 
 export type TPriceBuilder = TBuilder<Price>;
 export type TPriceDraftBuilder = TBuilder<PriceDraft>;

--- a/models/customer-group/src/customer-group-draft/builder.spec.ts
+++ b/models/customer-group/src/customer-group-draft/builder.spec.ts
@@ -34,7 +34,6 @@ describe('builder', () => {
       'graphql',
       CustomerGroupDraft.random(),
       expect.objectContaining({
-        __typename: 'CustomerGroupDraft',
         groupName: expect.any(String),
         key: expect.any(String),
         custom: null,

--- a/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/employee.spec.ts
+++ b/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/employee.spec.ts
@@ -22,7 +22,6 @@ describe('with the preset `employee`', () => {
 
     expect(customerGroup).toMatchInlineSnapshot(`
       {
-        "__typename": "CustomerGroupDraft",
         "custom": null,
         "groupName": "Employee",
         "key": "employee",

--- a/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/luxe.spec.ts
+++ b/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/luxe.spec.ts
@@ -22,7 +22,6 @@ describe('with the preset `luxe`', () => {
 
     expect(customerGroup).toMatchInlineSnapshot(`
       {
-        "__typename": "CustomerGroupDraft",
         "custom": null,
         "groupName": "Luxe",
         "key": "luxe",

--- a/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/vip.spec.ts
+++ b/models/customer-group/src/customer-group-draft/presets/sample-data-fashion/vip.spec.ts
@@ -22,7 +22,6 @@ describe('with the preset `vip`', () => {
 
     expect(customerGroup).toMatchInlineSnapshot(`
       {
-        "__typename": "CustomerGroupDraft",
         "custom": null,
         "groupName": "VIP",
         "key": "vip",

--- a/models/customer-group/src/customer-group-draft/transformers.ts
+++ b/models/customer-group/src/customer-group-draft/transformers.ts
@@ -12,9 +12,6 @@ const transformers = {
     'graphql',
     {
       buildFields: [],
-      addFields: () => ({
-        __typename: 'CustomerGroupDraft',
-      }),
     }
   ),
 };

--- a/models/customer-group/src/types.ts
+++ b/models/customer-group/src/types.ts
@@ -10,9 +10,7 @@ export type TCustomerGroupDraft = CustomerGroupDraft;
 export type TCustomerGroupGraphql = TCustomerGroup & {
   __typename: 'CustomerGroup';
 };
-export type TCustomerGroupDraftGraphql = TCustomerGroupDraft & {
-  __typename: 'CustomerGroupDraft';
-};
+export type TCustomerGroupDraftGraphql = TCustomerGroupDraft;
 
 export type TCustomerGroupBuilder = TBuilder<TCustomerGroup>;
 export type TCustomerGroupDraftBuilder = TBuilder<TCustomerGroupDraft>;

--- a/models/customer/src/customer-draft/builder.spec.ts
+++ b/models/customer/src/customer-draft/builder.spec.ts
@@ -90,7 +90,6 @@ describe('builder', () => {
       'graphql',
       CustomerDraft.random(),
       expect.objectContaining({
-        __typename: 'CustomerDraft',
         customerNumber: expect.any(String),
         email: expect.any(String),
         key: expect.any(String),
@@ -114,7 +113,6 @@ describe('builder', () => {
             city: expect.any(String),
             firstName: expect.any(String),
             lastName: expect.any(String),
-            __typename: 'AddressDraft',
           }),
         ]),
         defaultBillingAddress: null,

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.spec.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/jamie-doe.spec.ts
@@ -73,10 +73,8 @@ describe('with the preset `jamieDoe`', () => {
 
     expect(customer).toMatchInlineSnapshot(`
       {
-        "__typename": "CustomerDraft",
         "addresses": [
           {
-            "__typename": "AddressDraft",
             "additionalAddressInfo": undefined,
             "additionalStreetInfo": undefined,
             "apartment": undefined,

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.spec.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/john-doe.spec.ts
@@ -73,10 +73,8 @@ describe('with the preset `johnDoe`', () => {
 
     expect(customer).toMatchInlineSnapshot(`
       {
-        "__typename": "CustomerDraft",
         "addresses": [
           {
-            "__typename": "AddressDraft",
             "additionalAddressInfo": undefined,
             "additionalStreetInfo": undefined,
             "apartment": undefined,

--- a/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.spec.ts
+++ b/models/customer/src/customer-draft/presets/sample-data-fashion/mary-smith.spec.ts
@@ -70,10 +70,8 @@ describe('with the preset `marySmith`', () => {
 
     expect(customer).toMatchInlineSnapshot(`
       {
-        "__typename": "CustomerDraft",
         "addresses": [
           {
-            "__typename": "AddressDraft",
             "additionalAddressInfo": undefined,
             "additionalStreetInfo": undefined,
             "apartment": undefined,

--- a/models/customer/src/customer-draft/transformers.ts
+++ b/models/customer/src/customer-draft/transformers.ts
@@ -10,9 +10,6 @@ const transformers = {
   }),
   graphql: Transformer<TCustomerDraft, TCustomerDraftGraphql>('graphql', {
     buildFields: ['addresses', 'customerGroup'],
-    addFields: () => ({
-      __typename: 'CustomerDraft',
-    }),
   }),
 };
 

--- a/models/customer/src/types.ts
+++ b/models/customer/src/types.ts
@@ -7,9 +7,7 @@ export type TCustomerDraft = CustomerDraft;
 export type TCustomerGraphql = TCustomer & {
   __typename: 'Customer';
 };
-export type TCustomerDraftGraphql = TCustomerDraft & {
-  __typename: 'CustomerDraft';
-};
+export type TCustomerDraftGraphql = TCustomerDraft;
 
 export type TCustomerBuilder = TBuilder<TCustomer>;
 export type TCustomerDraftBuilder = TBuilder<TCustomerDraft>;

--- a/models/discount-code/src/discount-code-draft/builder.spec.ts
+++ b/models/discount-code/src/discount-code-draft/builder.spec.ts
@@ -84,7 +84,6 @@ describe('builder', () => {
         validFrom: expect.any(String),
         validUntil: expect.any(String),
         custom: null,
-        __typename: 'DiscountCodeDraft',
       })
     )
   );

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.spec.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.spec.ts
@@ -43,7 +43,6 @@ describe('with the preset `employeeSale`', () => {
 
     expect(discountCodeDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "DiscountCodeDraft",
         "cartDiscounts": [
           {
             "__typename": "Reference",

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
@@ -43,7 +43,6 @@ describe('with the preset `employeeSale`', () => {
 
     expect(discountCodeDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "DiscountCodeDraft",
         "cartDiscounts": [
           {
             "__typename": "Reference",

--- a/models/discount-code/src/discount-code-draft/transformers.ts
+++ b/models/discount-code/src/discount-code-draft/transformers.ts
@@ -12,9 +12,6 @@ const transformers = {
     'graphql',
     {
       buildFields: ['name', 'description', 'cartDiscounts'],
-      addFields: () => ({
-        __typename: 'DiscountCodeDraft',
-      }),
     }
   ),
 };

--- a/models/discount-code/src/types.ts
+++ b/models/discount-code/src/types.ts
@@ -15,9 +15,7 @@ export type TDiscountCodeGraphql = TDiscountCode & {
   nameAllLocales?: TLocalizedStringGraphql | null;
   descriptionAllLocales?: TLocalizedStringGraphql | null;
 };
-export type TDiscountCodeDraftGraphql = TDiscountCodeDraft & {
-  __typename: 'DiscountCodeDraft';
-};
+export type TDiscountCodeDraftGraphql = TDiscountCodeDraft;
 
 export type TDiscountCodeBuilder = TBuilder<TDiscountCode>;
 export type TDiscountCodeDraftBuilder = TBuilder<TDiscountCodeDraft>;

--- a/models/line-item/src/line-item-draft/builder.spec.ts
+++ b/models/line-item/src/line-item-draft/builder.spec.ts
@@ -81,14 +81,12 @@ describe('builder', () => {
         externalTaxRate: null,
         externalPrice: expect.objectContaining({
           centAmount: expect.any(Number),
-          __typename: 'BaseMoneyInput',
         }),
         externalTotalPrice: null,
         custom: null,
         inventoryMode: expect.any(String),
         shippingDetails: null,
         addedAt: expect.any(String),
-        __typename: 'LineItemDraft',
       })
     )
   );

--- a/models/line-item/src/line-item-draft/transformers.ts
+++ b/models/line-item/src/line-item-draft/transformers.ts
@@ -10,7 +10,6 @@ const transformers = {
   }),
   graphql: Transformer<TLineItemDraft, TLineItemDraftGraphql>('graphql', {
     buildFields: ['supplyChannel', 'distributionChannel', 'externalPrice'],
-    addFields: () => ({ __typename: 'LineItemDraft' }),
   }),
 };
 

--- a/models/line-item/src/types.ts
+++ b/models/line-item/src/types.ts
@@ -29,8 +29,6 @@ export type TCreateLineItemBuilder = () => TLineItemBuilder;
 
 export type TLineItemDraft = LineItemDraft;
 
-export type TLineItemDraftGraphql = TLineItemDraft & {
-  __typename: 'LineItemDraft';
-};
+export type TLineItemDraftGraphql = TLineItemDraft;
 export type TLineItemDraftBuilder = TBuilder<TLineItemDraft>;
 export type TCreateLineItemDraftBuilder = () => TLineItemDraftBuilder;

--- a/models/order/src/order-from-cart-draft/builder.spec.ts
+++ b/models/order/src/order-from-cart-draft/builder.spec.ts
@@ -69,7 +69,6 @@ describe('builder', () => {
         }),
         shipmentState: expect.any(String),
         custom: null,
-        __typename: 'OrderCartCommand',
       })
     )
   );

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/jamie-cart-01.spec.ts
@@ -31,7 +31,6 @@ describe(`with jamieCart01 preset`, () => {
       jamieCart01(1).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(jamieCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "OrderCartCommand",
         "cart": {
           "__typename": "Reference",
           "key": "jamie-01-cart",

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-01.spec.ts
@@ -31,7 +31,6 @@ describe(`with johnCart01 preset`, () => {
       johnCart01(1).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(johnCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "OrderCartCommand",
         "cart": {
           "__typename": "Reference",
           "key": "john-01-cart",

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/john-cart-02.spec.ts
@@ -31,7 +31,6 @@ describe(`with johnCart02 preset`, () => {
       johnCart02(1).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(johnCart02OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "OrderCartCommand",
         "cart": {
           "__typename": "Reference",
           "key": "john-02-cart",

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-01.spec.ts
@@ -31,7 +31,6 @@ describe(`with maryCart01 preset`, () => {
       maryCart01(1).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(maryCart01OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "OrderCartCommand",
         "cart": {
           "__typename": "Reference",
           "key": "mary-01-cart",

--- a/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.spec.ts
+++ b/models/order/src/order-from-cart-draft/presets/sample-data-fashion/mary-cart-02.spec.ts
@@ -31,7 +31,6 @@ describe(`with maryCart02 preset`, () => {
       maryCart02(1).buildGraphql<TOrderFromCartDraftGraphql>();
     expect(maryCart02OrderFromCartDraftGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "OrderCartCommand",
         "cart": {
           "__typename": "Reference",
           "key": "mary-02-cart",

--- a/models/order/src/order-from-cart-draft/transformers.ts
+++ b/models/order/src/order-from-cart-draft/transformers.ts
@@ -12,7 +12,6 @@ const transformers = {
     'graphql',
     {
       buildFields: ['cart', 'state'],
-      addFields: () => ({ __typename: 'OrderCartCommand' }),
     }
   ),
 };

--- a/models/order/src/types.ts
+++ b/models/order/src/types.ts
@@ -46,9 +46,7 @@ export type TOrderGraphql = TOrder & {
 
 export type TOrderFromCartDraft = OrderFromCartDraft;
 
-export type TOrderFromCartDraftGraphql = TOrderFromCartDraft & {
-  __typename: 'OrderCartCommand';
-};
+export type TOrderFromCartDraftGraphql = TOrderFromCartDraft;
 
 export type TOrderBuilder = TBuilder<TOrder>;
 export type TOrderFromCartDraftBuilder = TBuilder<TOrderFromCartDraft>;

--- a/models/product-discount/src/product-discount-value-absolute/product-discount-value-absolute-draft/builder.spec.ts
+++ b/models/product-discount/src/product-discount-value-absolute/product-discount-value-absolute-draft/builder.spec.ts
@@ -58,7 +58,6 @@ describe('builder', () => {
             centAmount: expect.any(Number),
           }),
         ]),
-        __typename: 'ProductDiscountValueAbsoluteDraft',
       })
     )
   );

--- a/models/product-discount/src/product-discount-value-absolute/product-discount-value-absolute-draft/transformers.ts
+++ b/models/product-discount/src/product-discount-value-absolute/product-discount-value-absolute-draft/transformers.ts
@@ -22,9 +22,6 @@ const transformers = {
     TProductDiscountValueAbsoluteDraftGraphql
   >('graphql', {
     buildFields: ['money'],
-    addFields: () => ({
-      __typename: 'ProductDiscountValueAbsoluteDraft',
-    }),
   }),
 };
 

--- a/models/product-discount/src/product-discount-value-absolute/types.ts
+++ b/models/product-discount/src/product-discount-value-absolute/types.ts
@@ -13,9 +13,7 @@ export type TProductDiscountValueAbsoluteGraphql =
     __typename: 'ProductDiscountValueAbsolute';
   };
 export type TProductDiscountValueAbsoluteDraftGraphql =
-  TProductDiscountValueAbsoluteDraft & {
-    __typename: 'ProductDiscountValueAbsoluteDraft';
-  };
+  TProductDiscountValueAbsoluteDraft & {};
 
 export type TProductDiscountValueAbsoluteBuilder =
   TBuilder<TProductDiscountValueAbsolute>;

--- a/models/product-discount/src/product-discount-value-external/product-discount-value-external-draft/builder.spec.ts
+++ b/models/product-discount/src/product-discount-value-external/product-discount-value-external-draft/builder.spec.ts
@@ -43,7 +43,6 @@ describe('builder', () => {
       ProductDiscountValueExternalDraft.random(),
       expect.objectContaining({
         type: 'external',
-        __typename: 'ProductDiscountValueExternalDraft',
       })
     )
   );

--- a/models/product-discount/src/product-discount-value-external/product-discount-value-external-draft/transformers.ts
+++ b/models/product-discount/src/product-discount-value-external/product-discount-value-external-draft/transformers.ts
@@ -22,9 +22,6 @@ const transformers = {
     TProductDiscountValueExternalDraftGraphql
   >('graphql', {
     buildFields: [],
-    addFields: () => ({
-      __typename: 'ProductDiscountValueExternalDraft',
-    }),
   }),
 };
 

--- a/models/product-discount/src/product-discount-value-external/types.ts
+++ b/models/product-discount/src/product-discount-value-external/types.ts
@@ -13,9 +13,7 @@ export type TProductDiscountValueExternalGraphql =
     __typename: 'ProductDiscountValueExternal';
   };
 export type TProductDiscountValueExternalDraftGraphql =
-  TProductDiscountValueExternalDraft & {
-    __typename: 'ProductDiscountValueExternalDraft';
-  };
+  TProductDiscountValueExternalDraft;
 
 export type TProductDiscountValueExternalBuilder =
   TBuilder<TProductDiscountValueExternal>;

--- a/models/product-discount/src/product-discount-value-relative/product-discount-value-relative-draft/builder.spec.ts
+++ b/models/product-discount/src/product-discount-value-relative/product-discount-value-relative-draft/builder.spec.ts
@@ -46,7 +46,6 @@ describe('builder', () => {
       expect.objectContaining({
         type: 'relative',
         permyriad: expect.any(Number),
-        __typename: 'ProductDiscountValueRelativeDraft',
       })
     )
   );

--- a/models/product-discount/src/product-discount-value-relative/product-discount-value-relative-draft/transformers.ts
+++ b/models/product-discount/src/product-discount-value-relative/product-discount-value-relative-draft/transformers.ts
@@ -22,9 +22,6 @@ const transformers = {
     TProductDiscountValueRelativeDraftGraphql
   >('graphql', {
     buildFields: [],
-    addFields: () => ({
-      __typename: 'ProductDiscountValueRelativeDraft',
-    }),
   }),
 };
 

--- a/models/product-discount/src/product-discount-value-relative/types.ts
+++ b/models/product-discount/src/product-discount-value-relative/types.ts
@@ -13,9 +13,7 @@ export type TProductDiscountValueRelativeGraphql =
     __typename: 'ProductDiscountValueRelative';
   };
 export type TProductDiscountValueRelativeDraftGraphql =
-  TProductDiscountValueRelativeDraft & {
-    __typename: 'ProductDiscountValueRelativeDraft';
-  };
+  TProductDiscountValueRelativeDraft;
 
 export type TProductDiscountValueRelativeBuilder =
   TBuilder<TProductDiscountValueRelative>;

--- a/models/product-discount/src/product-discount/product-discount-draft/builder.spec.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/builder.spec.ts
@@ -79,7 +79,6 @@ describe('builder', () => {
         isActive: expect.any(Boolean),
         validFrom: expect.any(String),
         validUntil: expect.any(String),
-        __typename: 'ProductDiscountDraft',
       })
     )
   );

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-dresses.spec.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-dresses.spec.ts
@@ -48,7 +48,6 @@ describe('with the preset `discountDresses`', () => {
 
     expect(productDiscountDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDiscountDraft",
         "description": [
           {
             "__typename": "LocalizedString",
@@ -70,9 +69,7 @@ describe('with the preset `discountDresses`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "__typename": "ProductDiscountValueAbsoluteDraft",
           "money": {
-            "__typename": "MoneyInput",
             "centAmount": 500,
             "currencyCode": "EUR",
             "fractionDigits": 2,

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-kids.spec.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-kids.spec.ts
@@ -42,7 +42,6 @@ describe('with the preset `discountKids`', () => {
 
     expect(productDiscountDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDiscountDraft",
         "description": [
           {
             "__typename": "LocalizedString",
@@ -64,7 +63,6 @@ describe('with the preset `discountKids`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "__typename": "ProductDiscountValueRelativeDraft",
           "permyriad": 2000,
           "type": "relative",
         },

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-pants.spec.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-pants.spec.ts
@@ -42,7 +42,6 @@ describe('with the preset `discountPants`', () => {
 
     expect(productDiscountDraft).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDiscountDraft",
         "description": [
           {
             "__typename": "LocalizedString",
@@ -64,14 +63,10 @@ describe('with the preset `discountPants`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "__typename": "ProductDiscountValueRelativeDraft",
           "permyriad": 1000,
           "type": "relative",
         },
       }
     `);
-    expect(productDiscountDraft.__typename).toMatchInlineSnapshot(
-      `"ProductDiscountDraft"`
-    );
   });
 });

--- a/models/product-discount/src/product-discount/product-discount-draft/transformers.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/transformers.ts
@@ -16,9 +16,6 @@ const transformers = {
     'graphql',
     {
       buildFields: ['value', 'name', 'description'],
-      addFields: () => ({
-        __typename: 'ProductDiscountDraft',
-      }),
     }
   ),
 };

--- a/models/product-discount/src/product-discount/types.ts
+++ b/models/product-discount/src/product-discount/types.ts
@@ -24,7 +24,6 @@ export type TProductDiscountDraftGraphql = Omit<
 > & {
   name: TLocalizedStringGraphql;
   description?: TLocalizedStringGraphql | null;
-  __typename: 'ProductDiscountDraft';
 };
 
 export type TProductDiscountBuilder = TBuilder<TProductDiscount>;

--- a/models/product-discount/src/product-discount/types.ts
+++ b/models/product-discount/src/product-discount/types.ts
@@ -18,7 +18,12 @@ export type TProductDiscountGraphql = TProductDiscount & {
   nameAllLocales?: TLocalizedStringGraphql | null;
   descriptionAllLocales?: TLocalizedStringGraphql | null;
 };
-export type TProductDiscountDraftGraphql = TProductDiscountDraft & {
+export type TProductDiscountDraftGraphql = Omit<
+  TProductDiscountDraft,
+  'name' | 'description'
+> & {
+  name: TLocalizedStringGraphql;
+  description?: TLocalizedStringGraphql | null;
   __typename: 'ProductDiscountDraft';
 };
 

--- a/models/product-type/src/product-type-draft/builder.spec.ts
+++ b/models/product-type/src/product-type-draft/builder.spec.ts
@@ -74,13 +74,12 @@ describe('builder', () => {
       'graphql',
       ProductTypeDraft.random(),
       expect.objectContaining({
-        __typename: 'ProductTypeDraft',
         key: expect.any(String),
         name: expect.any(String),
         description: expect.any(String),
         attributeDefinitions: expect.arrayContaining([
           expect.objectContaining({
-            __typename: 'AttributeDefinitionDraft',
+            name: expect.any(String),
           }),
         ]),
       })

--- a/models/product-type/src/product-type-draft/presets/sample-data-fashion/accessories.spec.ts
+++ b/models/product-type/src/product-type-draft/presets/sample-data-fashion/accessories.spec.ts
@@ -85,7 +85,6 @@ describe(`with accessories preset`, () => {
         "__typename": "ProductTypeDraft",
         "attributeDefinitions": [
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "None",
             "inputHint": "SingleLine",
             "inputTip": [
@@ -125,7 +124,6 @@ describe(`with accessories preset`, () => {
             },
           },
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "None",
             "inputHint": "SingleLine",
             "inputTip": [

--- a/models/product-type/src/product-type-draft/presets/sample-data-fashion/dresses.spec.ts
+++ b/models/product-type/src/product-type-draft/presets/sample-data-fashion/dresses.spec.ts
@@ -100,7 +100,6 @@ describe(`with dresses preset`, () => {
         "__typename": "ProductTypeDraft",
         "attributeDefinitions": [
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "CombinationUnique",
             "inputHint": "SingleLine",
             "inputTip": [
@@ -140,7 +139,6 @@ describe(`with dresses preset`, () => {
             },
           },
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "CombinationUnique",
             "inputHint": "SingleLine",
             "inputTip": [

--- a/models/product-type/src/product-type-draft/presets/sample-data-fashion/jackets.spec.ts
+++ b/models/product-type/src/product-type-draft/presets/sample-data-fashion/jackets.spec.ts
@@ -86,7 +86,6 @@ describe(`with jackets preset`, () => {
         "__typename": "ProductTypeDraft",
         "attributeDefinitions": [
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "None",
             "inputHint": "SingleLine",
             "inputTip": [
@@ -126,7 +125,6 @@ describe(`with jackets preset`, () => {
             },
           },
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "None",
             "inputHint": "SingleLine",
             "inputTip": [

--- a/models/product-type/src/product-type-draft/presets/sample-data-fashion/pants.spec.ts
+++ b/models/product-type/src/product-type-draft/presets/sample-data-fashion/pants.spec.ts
@@ -172,7 +172,6 @@ describe(`with pants preset`, () => {
         "__typename": "ProductTypeDraft",
         "attributeDefinitions": [
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "None",
             "inputHint": "SingleLine",
             "inputTip": [
@@ -212,7 +211,6 @@ describe(`with pants preset`, () => {
             },
           },
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "None",
             "inputHint": "SingleLine",
             "inputTip": [
@@ -252,7 +250,6 @@ describe(`with pants preset`, () => {
             },
           },
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "None",
             "inputHint": "SingleLine",
             "inputTip": [
@@ -292,7 +289,6 @@ describe(`with pants preset`, () => {
             },
           },
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "None",
             "inputHint": "SingleLine",
             "inputTip": [

--- a/models/product-type/src/product-type-draft/presets/sample-data-fashion/shirts.spec.ts
+++ b/models/product-type/src/product-type-draft/presets/sample-data-fashion/shirts.spec.ts
@@ -104,7 +104,6 @@ describe(`with shirts preset`, () => {
         "__typename": "ProductTypeDraft",
         "attributeDefinitions": [
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "CombinationUnique",
             "inputHint": "SingleLine",
             "inputTip": [
@@ -144,7 +143,6 @@ describe(`with shirts preset`, () => {
             },
           },
           {
-            "__typename": "AttributeDefinitionDraft",
             "attributeConstraint": "CombinationUnique",
             "inputHint": "SingleLine",
             "inputTip": [

--- a/models/product-type/src/product-type-draft/transformers.ts
+++ b/models/product-type/src/product-type-draft/transformers.ts
@@ -15,7 +15,7 @@ const transformers = {
         __typename: 'ProductTypeDraft',
         attributeDefinitions: fields.attributes!.map((attribute) =>
           buildField(attribute, 'graphql')
-        ) as Array<TAttributeDefinitionDraftGraphql>,
+        ) as unknown as Array<TAttributeDefinitionDraftGraphql>,
       };
     },
     removeFields: ['attributes'],

--- a/models/product-type/src/types.ts
+++ b/models/product-type/src/types.ts
@@ -17,8 +17,7 @@ export type TProductTypeGraphql = TProductType & {
 
 export type TProductTypeDraft = ProductTypeDraft;
 
-export type TProductTypeDraftGraphql = TProductTypeDraft & {
-  __typename: 'ProductTypeDraft';
+export type TProductTypeDraftGraphql = Omit<TProductTypeDraft, 'attributes'> & {
   attributeDefinitions: Array<TAttributeDefinitionDraftGraphql>;
 };
 

--- a/models/product-variant/src/attribute/attribute-draft/builder.spec.ts
+++ b/models/product-variant/src/attribute/attribute-draft/builder.spec.ts
@@ -34,7 +34,6 @@ describe('builder', () => {
       expect.objectContaining({
         name: expect.any(String),
         value: null,
-        __typename: 'ProductAttributeInput',
       })
     )
   );

--- a/models/product-variant/src/attribute/attribute-draft/transformers.ts
+++ b/models/product-variant/src/attribute/attribute-draft/transformers.ts
@@ -4,9 +4,7 @@ import type { TAttributeDraft, TAttributeDraftGraphql } from '../types';
 const transformers = {
   default: Transformer<TAttributeDraft, TAttributeDraft>('default', {}),
   rest: Transformer<TAttributeDraft, TAttributeDraft>('rest', {}),
-  graphql: Transformer<TAttributeDraft, TAttributeDraftGraphql>('graphql', {
-    addFields: () => ({ __typename: 'ProductAttributeInput' }),
-  }),
+  graphql: Transformer<TAttributeDraft, TAttributeDraftGraphql>('graphql', {}),
 };
 
 export default transformers;

--- a/models/product-variant/src/attribute/types.ts
+++ b/models/product-variant/src/attribute/types.ts
@@ -22,9 +22,7 @@ export type TAttributeGraphql = TAttribute & {
   __typename: 'RawProductAttribute';
 };
 
-export type TAttributeDraftGraphql = TAttributeDraft & {
-  __typename: 'ProductAttributeInput';
-};
+export type TAttributeDraftGraphql = TAttributeDraft;
 
 export type TAttributeBuilder = TBuilder<TAttribute>;
 export type TAttributeDraftBuilder = TBuilder<TAttributeDraft>;

--- a/models/product-variant/src/image/image-draft/builder.spec.ts
+++ b/models/product-variant/src/image/image-draft/builder.spec.ts
@@ -15,9 +15,7 @@ describe('builder', () => {
         dimensions: expect.objectContaining({
           w: expect.any(Number),
           h: expect.any(Number),
-          __typename: 'DimensionsInput',
         }),
-        __typename: 'ImageInput',
       })
     )
   );

--- a/models/product-variant/src/image/image-draft/transformers.ts
+++ b/models/product-variant/src/image/image-draft/transformers.ts
@@ -9,9 +9,7 @@ const transformers = {
         ...fields,
         dimensions: {
           ...fields.dimensions,
-          __typename: 'DimensionsInput',
         },
-        __typename: 'ImageInput',
       };
     },
   }),

--- a/models/product-variant/src/image/types.ts
+++ b/models/product-variant/src/image/types.ts
@@ -9,9 +9,7 @@ export type TImageGraphql = TImage & {
 };
 
 //Graphql draft representation
-export type TImageDraftGraphql = TImage & {
-  __typename: 'ImageInput';
-};
+export type TImageDraftGraphql = TImage;
 
 export type TImageBuilder = TBuilder<TImage>;
 export type TCreateImageBuilder = () => TImageBuilder;

--- a/models/product-variant/src/product-variant/product-variant-draft/builder.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/builder.spec.ts
@@ -72,7 +72,6 @@ describe('builder', () => {
         prices: expect.arrayContaining([
           expect.objectContaining({
             value: expect.any(Object),
-            __typename: 'ProductPriceDataInput',
           }),
         ]),
         images: expect.arrayContaining([
@@ -82,19 +81,15 @@ describe('builder', () => {
             dimensions: expect.objectContaining({
               w: expect.any(Number),
               h: expect.any(Number),
-              __typename: 'DimensionsInput',
             }),
-            __typename: 'ImageInput',
           }),
         ]),
         attributes: expect.arrayContaining([
           expect.objectContaining({
             name: expect.any(String),
-            __typename: 'ProductAttributeInput',
           }),
         ]),
         assets: expect.arrayContaining([]),
-        __typename: 'ProductVariantInput',
       })
     )
   );

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-01.spec.ts
@@ -30,11 +30,9 @@ describe(`with anniversaryShirtVariant01 preset`, () => {
       anniversaryShirtVariant01().buildGraphql<TProductVariantDraft>();
     expect(anniversaryShirtVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Small",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-02.spec.ts
@@ -30,11 +30,9 @@ describe(`with anniversaryShirtVariant02 preset`, () => {
       anniversaryShirtVariant02().buildGraphql<TProductVariantDraft>();
     expect(anniversaryShirtVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Medium",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-03.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/anniversary-shirt-variant-03.spec.ts
@@ -30,11 +30,9 @@ describe(`with anniversaryShirtVariant03 preset`, () => {
       anniversaryShirtVariant03().buildGraphql<TProductVariantDraft>();
     expect(anniversaryShirtVariant03PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Large",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-01.spec.ts
@@ -78,11 +78,9 @@ describe(`with denimJacketVariant01 preset`, () => {
       denimJacketVariant01().buildGraphql<TProductVariantDraft>();
     expect(denimJacketVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "sleeve_length",
             "value": {
               "key": "Normal",
@@ -90,7 +88,6 @@ describe(`with denimJacketVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "cotton",
             "value": false,
           },
@@ -109,7 +106,6 @@ describe(`with denimJacketVariant01 preset`, () => {
         "key": "996024",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -120,7 +116,6 @@ describe(`with denimJacketVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 10000,
               "currencyCode": "EUR",
               "fractionDigits": 2,
@@ -128,7 +123,6 @@ describe(`with denimJacketVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "ES",
             "custom": undefined,
@@ -139,7 +133,6 @@ describe(`with denimJacketVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 10000,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/denim-jacket-variant-02.spec.ts
@@ -78,11 +78,9 @@ describe(`with denimJacketVariant02 preset`, () => {
       denimJacketVariant02().buildGraphql<TProductVariantDraft>();
     expect(denimJacketVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "sleeve_length",
             "value": {
               "key": "Extra Long",
@@ -90,7 +88,6 @@ describe(`with denimJacketVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "cotton",
             "value": false,
           },
@@ -109,7 +106,6 @@ describe(`with denimJacketVariant02 preset`, () => {
         "key": "996025",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -120,7 +116,6 @@ describe(`with denimJacketVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 10000,
               "currencyCode": "EUR",
               "fractionDigits": 2,
@@ -128,7 +123,6 @@ describe(`with denimJacketVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "ES",
             "custom": undefined,
@@ -139,7 +133,6 @@ describe(`with denimJacketVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 10000,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-01.spec.ts
@@ -51,11 +51,9 @@ describe(`with flairJeansVariant01 preset`, () => {
       flairJeansVariant01().buildGraphql<TProductVariantDraft>();
     expect(flairJeansVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Large",
@@ -63,7 +61,6 @@ describe(`with flairJeansVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "fit",
             "value": {
               "key": "Flair",
@@ -71,7 +68,6 @@ describe(`with flairJeansVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "Blue",
@@ -79,7 +75,6 @@ describe(`with flairJeansVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "length",
             "value": {
               "key": "Crop",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/flair-jeans-variant-02.spec.ts
@@ -51,11 +51,9 @@ describe(`with flairJeansVariant02 preset`, () => {
       flairJeansVariant02().buildGraphql<TProductVariantDraft>();
     expect(flairJeansVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Medium",
@@ -63,7 +61,6 @@ describe(`with flairJeansVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "fit",
             "value": {
               "key": "Flair",
@@ -71,7 +68,6 @@ describe(`with flairJeansVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "Black",
@@ -79,7 +75,6 @@ describe(`with flairJeansVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "length",
             "value": {
               "key": "Extra Long",

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-01.spec.ts
@@ -98,11 +98,9 @@ describe(`with halloweenTopVariant01 preset`, () => {
       halloweenTopVariant01().buildGraphql<TProductVariantDraft>();
     expect(halloweenTopVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Medium",
@@ -110,7 +108,6 @@ describe(`with halloweenTopVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "Purple",
@@ -132,7 +129,6 @@ describe(`with halloweenTopVariant01 preset`, () => {
         "key": "888035",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -143,7 +139,6 @@ describe(`with halloweenTopVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 2500,
               "currencyCode": "EUR",
               "fractionDigits": 2,
@@ -151,7 +146,6 @@ describe(`with halloweenTopVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -162,7 +156,6 @@ describe(`with halloweenTopVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 2500,
               "currencyCode": "USD",
               "fractionDigits": 2,
@@ -170,7 +163,6 @@ describe(`with halloweenTopVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "ES",
             "custom": undefined,
@@ -181,7 +173,6 @@ describe(`with halloweenTopVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 2500,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/halloween-top-variant-02.spec.ts
@@ -98,11 +98,9 @@ describe(`with halloweenTopVariant02 preset`, () => {
       halloweenTopVariant02().buildGraphql<TProductVariantDraft>();
     expect(halloweenTopVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Large",
@@ -110,7 +108,6 @@ describe(`with halloweenTopVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "Multi-Color",
@@ -132,7 +129,6 @@ describe(`with halloweenTopVariant02 preset`, () => {
         "key": "828329",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -143,7 +139,6 @@ describe(`with halloweenTopVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 3000,
               "currencyCode": "EUR",
               "fractionDigits": 2,
@@ -151,7 +146,6 @@ describe(`with halloweenTopVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -162,7 +156,6 @@ describe(`with halloweenTopVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 3000,
               "currencyCode": "USD",
               "fractionDigits": 2,
@@ -170,7 +163,6 @@ describe(`with halloweenTopVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "ES",
             "custom": undefined,
@@ -181,7 +173,6 @@ describe(`with halloweenTopVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 3300,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-01.spec.ts
@@ -64,11 +64,9 @@ describe(`with maternityTopVariant01 preset`, () => {
       maternityTopVariant01().buildGraphql<TProductVariantDraft>();
     expect(maternityTopVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Small",
@@ -76,7 +74,6 @@ describe(`with maternityTopVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "Green",
@@ -98,7 +95,6 @@ describe(`with maternityTopVariant01 preset`, () => {
         "key": "118716",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -109,7 +105,6 @@ describe(`with maternityTopVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 2695,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-02.spec.ts
@@ -64,11 +64,9 @@ describe(`with maternityTopVariant02 preset`, () => {
       maternityTopVariant02().buildGraphql<TProductVariantDraft>();
     expect(maternityTopVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Medium",
@@ -76,7 +74,6 @@ describe(`with maternityTopVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "Green",
@@ -98,7 +95,6 @@ describe(`with maternityTopVariant02 preset`, () => {
         "key": "118717",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -109,7 +105,6 @@ describe(`with maternityTopVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 2695,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-03.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/maternity-top-variant-03.spec.ts
@@ -64,11 +64,9 @@ describe(`with maternityTopVariant03 preset`, () => {
       maternityTopVariant03().buildGraphql<TProductVariantDraft>();
     expect(maternityTopVariant03PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Large",
@@ -76,7 +74,6 @@ describe(`with maternityTopVariant03 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "Green",
@@ -98,7 +95,6 @@ describe(`with maternityTopVariant03 preset`, () => {
         "key": "118718",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -109,7 +105,6 @@ describe(`with maternityTopVariant03 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 2695,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-01.spec.ts
@@ -95,11 +95,9 @@ describe(`with necklace variant preset`, () => {
       necklaceVariant01().buildGraphql<TProductVariantDraft>();
     expect(necklaceVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "type",
             "value": {
               "key": "Jewelry",
@@ -107,7 +105,6 @@ describe(`with necklace variant preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "engraving",
             "value": "Happy Anniversary",
           },
@@ -126,7 +123,6 @@ describe(`with necklace variant preset`, () => {
         "key": "752502",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -137,7 +133,6 @@ describe(`with necklace variant preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 5000,
               "currencyCode": "EUR",
               "fractionDigits": 2,
@@ -145,7 +140,6 @@ describe(`with necklace variant preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -156,7 +150,6 @@ describe(`with necklace variant preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 5000,
               "currencyCode": "USD",
               "fractionDigits": 2,
@@ -164,7 +157,6 @@ describe(`with necklace variant preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "ES",
             "custom": undefined,
@@ -175,7 +167,6 @@ describe(`with necklace variant preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 5000,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/necklace-variant-02.spec.ts
@@ -57,11 +57,9 @@ describe(`with necklace variant preset`, () => {
       necklaceVariant02().buildGraphql<TProductVariantDraft>();
     expect(necklaceVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "type",
             "value": {
               "key": "Jewelry",
@@ -83,7 +81,6 @@ describe(`with necklace variant preset`, () => {
         "key": "42610",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "AU",
             "custom": undefined,
@@ -94,7 +91,6 @@ describe(`with necklace variant preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 1575,
               "currencyCode": "AUD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-01.spec.ts
@@ -74,11 +74,9 @@ describe(`with promDressVariant01 preset`, () => {
       promDressVariant01().buildGraphql<TProductVariantDraft>();
     expect(promDressVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "Floral",
@@ -100,7 +98,6 @@ describe(`with promDressVariant01 preset`, () => {
         "key": "711595",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -111,7 +108,6 @@ describe(`with promDressVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 24795,
               "currencyCode": "EUR",
               "fractionDigits": 2,
@@ -119,7 +115,6 @@ describe(`with promDressVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -130,7 +125,6 @@ describe(`with promDressVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 17500,
               "currencyCode": "USD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/prom-dress-variant-02.spec.ts
@@ -74,11 +74,9 @@ describe(`with promDressVariant02 preset`, () => {
       promDressVariant02().buildGraphql<TProductVariantDraft>();
     expect(promDressVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "Pink",
@@ -100,7 +98,6 @@ describe(`with promDressVariant02 preset`, () => {
         "key": "214452",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "ES",
             "custom": undefined,
@@ -111,7 +108,6 @@ describe(`with promDressVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 12500,
               "currencyCode": "EUR",
               "fractionDigits": 2,
@@ -119,7 +115,6 @@ describe(`with promDressVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "AU",
             "custom": undefined,
@@ -130,7 +125,6 @@ describe(`with promDressVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 15000,
               "currencyCode": "AUD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-01.spec.ts
@@ -108,11 +108,9 @@ describe(`with sandals variant preset`, () => {
       sandalsVariant01().buildGraphql<TProductVariantDraft>();
     expect(sandalsVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "type",
             "value": {
               "key": "Shoes",
@@ -134,7 +132,6 @@ describe(`with sandals variant preset`, () => {
         "key": "148096",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "AU",
             "custom": undefined,
@@ -145,7 +142,6 @@ describe(`with sandals variant preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 2500,
               "currencyCode": "AUD",
               "fractionDigits": 2,
@@ -153,7 +149,6 @@ describe(`with sandals variant preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -164,7 +159,6 @@ describe(`with sandals variant preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 3000,
               "currencyCode": "EUR",
               "fractionDigits": 2,
@@ -172,7 +166,6 @@ describe(`with sandals variant preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -183,7 +176,6 @@ describe(`with sandals variant preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 2799,
               "currencyCode": "USD",
               "fractionDigits": 2,
@@ -191,7 +183,6 @@ describe(`with sandals variant preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "ES",
             "custom": undefined,
@@ -202,7 +193,6 @@ describe(`with sandals variant preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 3000,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sandals-variant-02.spec.ts
@@ -74,11 +74,9 @@ describe(`with sandalsAU variant preset`, () => {
       sandalsVariant02().buildGraphql<TProductVariantDraft>();
     expect(sandalsVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "type",
             "value": {
               "key": "Shoes",
@@ -100,7 +98,6 @@ describe(`with sandalsAU variant preset`, () => {
         "key": "148097",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "AU",
             "custom": undefined,
@@ -111,7 +108,6 @@ describe(`with sandalsAU variant preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 1199,
               "currencyCode": "AUD",
               "fractionDigits": 2,
@@ -119,7 +115,6 @@ describe(`with sandalsAU variant preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -130,7 +125,6 @@ describe(`with sandalsAU variant preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 1000,
               "currencyCode": "USD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-01.spec.ts
@@ -64,11 +64,9 @@ describe(`with skinnyJeansVariant01 preset`, () => {
       skinnyJeansVariant01().buildGraphql<TProductVariantDraft>();
     expect(skinnyJeansVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "fit",
             "value": {
               "key": "Slim",
@@ -76,7 +74,6 @@ describe(`with skinnyJeansVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Medium",
@@ -98,7 +95,6 @@ describe(`with skinnyJeansVariant01 preset`, () => {
         "key": "396594",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -109,7 +105,6 @@ describe(`with skinnyJeansVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 4999,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/skinny-jeans-variant-02.spec.ts
@@ -64,11 +64,9 @@ describe(`with skinnyJeansVariant02 preset`, () => {
       skinnyJeansVariant02().buildGraphql<TProductVariantDraft>();
     expect(skinnyJeansVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Large",
@@ -76,7 +74,6 @@ describe(`with skinnyJeansVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "fit",
             "value": {
               "key": "Slim",
@@ -98,7 +95,6 @@ describe(`with skinnyJeansVariant02 preset`, () => {
         "key": "349700",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -109,7 +105,6 @@ describe(`with skinnyJeansVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 4999,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-01.spec.ts
@@ -57,11 +57,9 @@ describe(`with sportCoatVariant01 preset`, () => {
       sportCoatVariant01().buildGraphql<TProductVariantDraft>();
     expect(sportCoatVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "sleeve_length",
             "value": {
               "key": "Crop",
@@ -83,7 +81,6 @@ describe(`with sportCoatVariant01 preset`, () => {
         "key": "692457",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "AU",
             "custom": undefined,
@@ -94,7 +91,6 @@ describe(`with sportCoatVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 20000,
               "currencyCode": "AUD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/sport-coat-variant-02.spec.ts
@@ -57,11 +57,9 @@ describe(`with sportCoatVariant02 preset`, () => {
       sportCoatVariant02().buildGraphql<TProductVariantDraft>();
     expect(sportCoatVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "sleeve_length",
             "value": {
               "key": "Normal",
@@ -83,7 +81,6 @@ describe(`with sportCoatVariant02 preset`, () => {
         "key": "692458",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "AU",
             "custom": undefined,
@@ -94,7 +91,6 @@ describe(`with sportCoatVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 20000,
               "currencyCode": "AUD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-01.spec.ts
@@ -74,11 +74,9 @@ describe(`with summerDressVariant01 preset`, () => {
       summerDressVariant01().buildGraphql<TProductVariantDraft>();
     expect(summerDressVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "White",
@@ -100,7 +98,6 @@ describe(`with summerDressVariant01 preset`, () => {
         "key": "791840",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "DE",
             "custom": undefined,
@@ -111,7 +108,6 @@ describe(`with summerDressVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 7500,
               "currencyCode": "EUR",
               "fractionDigits": 2,
@@ -119,7 +115,6 @@ describe(`with summerDressVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "ES",
             "custom": undefined,
@@ -130,7 +125,6 @@ describe(`with summerDressVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 8000,
               "currencyCode": "EUR",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/summer-dress-variant-02.spec.ts
@@ -57,11 +57,9 @@ describe(`with summerDressVariant02 preset`, () => {
       summerDressVariant02().buildGraphql<TProductVariantDraft>();
     expect(summerDressVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "Pink",
@@ -83,7 +81,6 @@ describe(`with summerDressVariant02 preset`, () => {
         "key": "439502",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -94,7 +91,6 @@ describe(`with summerDressVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 7500,
               "currencyCode": "USD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-01.spec.ts
@@ -78,11 +78,9 @@ describe(`with toddlerTrousersVariant01 preset`, () => {
       toddlerTrousersVariant01().buildGraphql<TProductVariantDraft>();
     expect(toddlerTrousersVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Medium",
@@ -90,7 +88,6 @@ describe(`with toddlerTrousersVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "fit",
             "value": {
               "key": "Straight",
@@ -98,7 +95,6 @@ describe(`with toddlerTrousersVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "White",
@@ -106,7 +102,6 @@ describe(`with toddlerTrousersVariant01 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "length",
             "value": {
               "key": "Ankle",
@@ -128,7 +123,6 @@ describe(`with toddlerTrousersVariant01 preset`, () => {
         "key": "855485",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -139,7 +133,6 @@ describe(`with toddlerTrousersVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 2599,
               "currencyCode": "USD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-02.spec.ts
@@ -78,11 +78,9 @@ describe(`with toddlerTrousersVariant02 preset`, () => {
       toddlerTrousersVariant02().buildGraphql<TProductVariantDraft>();
     expect(toddlerTrousersVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Medium",
@@ -90,7 +88,6 @@ describe(`with toddlerTrousersVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "fit",
             "value": {
               "key": "Straight",
@@ -98,7 +95,6 @@ describe(`with toddlerTrousersVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "White",
@@ -106,7 +102,6 @@ describe(`with toddlerTrousersVariant02 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "length",
             "value": {
               "key": "Ankle",
@@ -128,7 +123,6 @@ describe(`with toddlerTrousersVariant02 preset`, () => {
         "key": "855485",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -139,7 +133,6 @@ describe(`with toddlerTrousersVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 2599,
               "currencyCode": "USD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-03.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/toddler-trousers-variant-03.spec.ts
@@ -78,11 +78,9 @@ describe(`with toddlerTrousersVariant03 preset`, () => {
       toddlerTrousersVariant03().buildGraphql<TProductVariantDraft>();
     expect(toddlerTrousersVariant03PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "size",
             "value": {
               "key": "Large",
@@ -90,7 +88,6 @@ describe(`with toddlerTrousersVariant03 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "fit",
             "value": {
               "key": "Straight",
@@ -98,7 +95,6 @@ describe(`with toddlerTrousersVariant03 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "color",
             "value": {
               "key": "White",
@@ -106,7 +102,6 @@ describe(`with toddlerTrousersVariant03 preset`, () => {
             },
           },
           {
-            "__typename": "ProductAttributeInput",
             "name": "length",
             "value": {
               "key": "Ankle",
@@ -128,7 +123,6 @@ describe(`with toddlerTrousersVariant03 preset`, () => {
         "key": "855486",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -139,7 +133,6 @@ describe(`with toddlerTrousersVariant03 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 2599,
               "currencyCode": "USD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-01.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-01.spec.ts
@@ -57,11 +57,9 @@ describe(`with toteBagVariant01 preset`, () => {
       toteBagVariant01().buildGraphql<TProductVariantDraft>();
     expect(toteBagVariant01PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "type",
             "value": {
               "key": "Bag",
@@ -83,7 +81,6 @@ describe(`with toteBagVariant01 preset`, () => {
         "key": "718289",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -94,7 +91,6 @@ describe(`with toteBagVariant01 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 13999,
               "currencyCode": "USD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-02.spec.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/presets/sample-data-fashion/tote-bag-variant-02.spec.ts
@@ -57,11 +57,9 @@ describe(`with toteBagVariant02 preset`, () => {
       toteBagVariant02().buildGraphql<TProductVariantDraft>();
     expect(toteBagVariant02PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductVariantInput",
         "assets": undefined,
         "attributes": [
           {
-            "__typename": "ProductAttributeInput",
             "name": "type",
             "value": {
               "key": "Bag",
@@ -83,7 +81,6 @@ describe(`with toteBagVariant02 preset`, () => {
         "key": "124965",
         "prices": [
           {
-            "__typename": "ProductPriceDataInput",
             "channel": undefined,
             "country": "US",
             "custom": undefined,
@@ -94,7 +91,6 @@ describe(`with toteBagVariant02 preset`, () => {
             "validFrom": undefined,
             "validUntil": undefined,
             "value": {
-              "__typename": "MoneyInput",
               "centAmount": 17500,
               "currencyCode": "USD",
               "fractionDigits": 2,

--- a/models/product-variant/src/product-variant/product-variant-draft/transformers.ts
+++ b/models/product-variant/src/product-variant/product-variant-draft/transformers.ts
@@ -15,7 +15,6 @@ const transformers = {
     'graphql',
     {
       buildFields: ['prices', 'images', 'attributes'],
-      addFields: () => ({ __typename: 'ProductVariantInput' }),
     }
   ),
 };

--- a/models/product-variant/src/product-variant/types.ts
+++ b/models/product-variant/src/product-variant/types.ts
@@ -20,7 +20,6 @@ export type TProductVariantDraftGraphql = Omit<
   'attributes'
 > & {
   attributes: Array<TAttributeDraftGraphql>;
-  __typename: 'ProductVariantInput';
 };
 
 export type TProductVariantBuilder = TBuilder<TProductVariant>;

--- a/models/product/src/product/product-draft/builder.spec.ts
+++ b/models/product/src/product/product-draft/builder.spec.ts
@@ -218,7 +218,6 @@ describe('builder', () => {
             }),
           ]),
           assets: expect.arrayContaining([]),
-          __typename: 'ProductVariantInput',
         }),
         variants: expect.arrayContaining([
           expect.objectContaining({
@@ -254,7 +253,6 @@ describe('builder', () => {
         metaKeywords: null,
         publish: expect.any(Boolean),
         key: expect.any(String),
-        __typename: 'ProductDraft',
       })
     )
   );

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.spec.ts
@@ -96,17 +96,14 @@ describe(`with anniversaryShirt preset`, () => {
       anniversaryShirt().buildGraphql<TProductDraft>();
     expect(anniversaryShirtPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "anniversary_shirt",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "size",
               "value": {
                 "key": "Small",
@@ -152,11 +149,9 @@ describe(`with anniversaryShirt preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "size",
                 "value": {
                   "key": "Medium",
@@ -170,11 +165,9 @@ describe(`with anniversaryShirt preset`, () => {
             "sku": undefined,
           },
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "size",
                 "value": {
                   "key": "Large",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.spec.ts
@@ -176,17 +176,14 @@ describe(`with denimJacket preset`, () => {
       denimJacket().buildGraphql<TProductDraft>();
     expect(denimJacketPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "denim_jacket",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "sleeve_length",
               "value": {
                 "key": "Normal",
@@ -194,7 +191,6 @@ describe(`with denimJacket preset`, () => {
               },
             },
             {
-              "__typename": "ProductAttributeInput",
               "name": "cotton",
               "value": false,
             },
@@ -213,7 +209,6 @@ describe(`with denimJacket preset`, () => {
           "key": "996024",
           "prices": [
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "DE",
               "custom": undefined,
@@ -224,7 +219,6 @@ describe(`with denimJacket preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 10000,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -232,7 +226,6 @@ describe(`with denimJacket preset`, () => {
               },
             },
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "ES",
               "custom": undefined,
@@ -243,7 +236,6 @@ describe(`with denimJacket preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 10000,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -286,11 +278,9 @@ describe(`with denimJacket preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "sleeve_length",
                 "value": {
                   "key": "Extra Long",
@@ -298,7 +288,6 @@ describe(`with denimJacket preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "cotton",
                 "value": false,
               },
@@ -317,7 +306,6 @@ describe(`with denimJacket preset`, () => {
             "key": "996025",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "DE",
                 "custom": undefined,
@@ -328,7 +316,6 @@ describe(`with denimJacket preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 10000,
                   "currencyCode": "EUR",
                   "fractionDigits": 2,
@@ -336,7 +323,6 @@ describe(`with denimJacket preset`, () => {
                 },
               },
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "ES",
                 "custom": undefined,
@@ -347,7 +333,6 @@ describe(`with denimJacket preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 10000,
                   "currencyCode": "EUR",
                   "fractionDigits": 2,

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.spec.ts
@@ -121,17 +121,14 @@ describe(`with flairJeans preset`, () => {
     const flairJeansPresetGraphql = flairJeans().buildGraphql<TProductDraft>();
     expect(flairJeansPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "flair_jeans",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "size",
               "value": {
                 "key": "Large",
@@ -139,7 +136,6 @@ describe(`with flairJeans preset`, () => {
               },
             },
             {
-              "__typename": "ProductAttributeInput",
               "name": "fit",
               "value": {
                 "key": "Flair",
@@ -147,7 +143,6 @@ describe(`with flairJeans preset`, () => {
               },
             },
             {
-              "__typename": "ProductAttributeInput",
               "name": "color",
               "value": {
                 "key": "Blue",
@@ -155,7 +150,6 @@ describe(`with flairJeans preset`, () => {
               },
             },
             {
-              "__typename": "ProductAttributeInput",
               "name": "length",
               "value": {
                 "key": "Crop",
@@ -201,11 +195,9 @@ describe(`with flairJeans preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "size",
                 "value": {
                   "key": "Medium",
@@ -213,7 +205,6 @@ describe(`with flairJeans preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "fit",
                 "value": {
                   "key": "Flair",
@@ -221,7 +212,6 @@ describe(`with flairJeans preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "color",
                 "value": {
                   "key": "Black",
@@ -229,7 +219,6 @@ describe(`with flairJeans preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "length",
                 "value": {
                   "key": "Extra Long",

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.spec.ts
@@ -216,17 +216,14 @@ describe(`with halloweenTop preset`, () => {
       halloweenTop().buildGraphql<TProductDraft>();
     expect(halloweenTopPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "Halloween Top",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "size",
               "value": {
                 "key": "Medium",
@@ -234,7 +231,6 @@ describe(`with halloweenTop preset`, () => {
               },
             },
             {
-              "__typename": "ProductAttributeInput",
               "name": "color",
               "value": {
                 "key": "Purple",
@@ -256,7 +252,6 @@ describe(`with halloweenTop preset`, () => {
           "key": "888035",
           "prices": [
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "DE",
               "custom": undefined,
@@ -267,7 +262,6 @@ describe(`with halloweenTop preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 2500,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -275,7 +269,6 @@ describe(`with halloweenTop preset`, () => {
               },
             },
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "US",
               "custom": undefined,
@@ -286,7 +279,6 @@ describe(`with halloweenTop preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 2500,
                 "currencyCode": "USD",
                 "fractionDigits": 2,
@@ -294,7 +286,6 @@ describe(`with halloweenTop preset`, () => {
               },
             },
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "ES",
               "custom": undefined,
@@ -305,7 +296,6 @@ describe(`with halloweenTop preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 2500,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -348,11 +338,9 @@ describe(`with halloweenTop preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "size",
                 "value": {
                   "key": "Large",
@@ -360,7 +348,6 @@ describe(`with halloweenTop preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "color",
                 "value": {
                   "key": "Multi-Color",
@@ -382,7 +369,6 @@ describe(`with halloweenTop preset`, () => {
             "key": "828329",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "DE",
                 "custom": undefined,
@@ -393,7 +379,6 @@ describe(`with halloweenTop preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 3000,
                   "currencyCode": "EUR",
                   "fractionDigits": 2,
@@ -401,7 +386,6 @@ describe(`with halloweenTop preset`, () => {
                 },
               },
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "US",
                 "custom": undefined,
@@ -412,7 +396,6 @@ describe(`with halloweenTop preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 3000,
                   "currencyCode": "USD",
                   "fractionDigits": 2,
@@ -420,7 +403,6 @@ describe(`with halloweenTop preset`, () => {
                 },
               },
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "ES",
                 "custom": undefined,
@@ -431,7 +413,6 @@ describe(`with halloweenTop preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 3300,
                   "currencyCode": "EUR",
                   "fractionDigits": 2,

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.spec.ts
@@ -198,17 +198,14 @@ describe(`with maternityTop preset`, () => {
       maternityTop().buildGraphql<TProductDraft>();
     expect(maternityTopPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "maternity_top",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "size",
               "value": {
                 "key": "Small",
@@ -216,7 +213,6 @@ describe(`with maternityTop preset`, () => {
               },
             },
             {
-              "__typename": "ProductAttributeInput",
               "name": "color",
               "value": {
                 "key": "Green",
@@ -238,7 +234,6 @@ describe(`with maternityTop preset`, () => {
           "key": "118716",
           "prices": [
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "DE",
               "custom": undefined,
@@ -249,7 +244,6 @@ describe(`with maternityTop preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 2695,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -292,11 +286,9 @@ describe(`with maternityTop preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "size",
                 "value": {
                   "key": "Medium",
@@ -304,7 +296,6 @@ describe(`with maternityTop preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "color",
                 "value": {
                   "key": "Green",
@@ -326,7 +317,6 @@ describe(`with maternityTop preset`, () => {
             "key": "118717",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "DE",
                 "custom": undefined,
@@ -337,7 +327,6 @@ describe(`with maternityTop preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 2695,
                   "currencyCode": "EUR",
                   "fractionDigits": 2,
@@ -348,11 +337,9 @@ describe(`with maternityTop preset`, () => {
             "sku": "118717",
           },
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "size",
                 "value": {
                   "key": "Large",
@@ -360,7 +347,6 @@ describe(`with maternityTop preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "color",
                 "value": {
                   "key": "Green",
@@ -382,7 +368,6 @@ describe(`with maternityTop preset`, () => {
             "key": "118718",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "DE",
                 "custom": undefined,
@@ -393,7 +378,6 @@ describe(`with maternityTop preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 2695,
                   "currencyCode": "EUR",
                   "fractionDigits": 2,

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.spec.ts
@@ -171,17 +171,14 @@ describe(`with necklace preset`, () => {
     const necklacePresetGraphql = necklace().buildGraphql<TProductDraft>();
     expect(necklacePresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "necklace",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "type",
               "value": {
                 "key": "Jewelry",
@@ -189,7 +186,6 @@ describe(`with necklace preset`, () => {
               },
             },
             {
-              "__typename": "ProductAttributeInput",
               "name": "engraving",
               "value": "Happy Anniversary",
             },
@@ -208,7 +204,6 @@ describe(`with necklace preset`, () => {
           "key": "752502",
           "prices": [
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "DE",
               "custom": undefined,
@@ -219,7 +214,6 @@ describe(`with necklace preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 5000,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -227,7 +221,6 @@ describe(`with necklace preset`, () => {
               },
             },
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "US",
               "custom": undefined,
@@ -238,7 +231,6 @@ describe(`with necklace preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 5000,
                 "currencyCode": "USD",
                 "fractionDigits": 2,
@@ -246,7 +238,6 @@ describe(`with necklace preset`, () => {
               },
             },
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "ES",
               "custom": undefined,
@@ -257,7 +248,6 @@ describe(`with necklace preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 5000,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -300,11 +290,9 @@ describe(`with necklace preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "type",
                 "value": {
                   "key": "Jewelry",
@@ -326,7 +314,6 @@ describe(`with necklace preset`, () => {
             "key": "42610",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "AU",
                 "custom": undefined,
@@ -337,7 +324,6 @@ describe(`with necklace preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 1575,
                   "currencyCode": "AUD",
                   "fractionDigits": 2,

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.spec.ts
@@ -167,17 +167,14 @@ describe(`with promDress preset`, () => {
     const promDressPresetGraphql = promDress().buildGraphql<TProductDraft>();
     expect(promDressPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "prom_dress",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "color",
               "value": {
                 "key": "Floral",
@@ -199,7 +196,6 @@ describe(`with promDress preset`, () => {
           "key": "711595",
           "prices": [
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "DE",
               "custom": undefined,
@@ -210,7 +206,6 @@ describe(`with promDress preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 24795,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -218,7 +213,6 @@ describe(`with promDress preset`, () => {
               },
             },
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "US",
               "custom": undefined,
@@ -229,7 +223,6 @@ describe(`with promDress preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 17500,
                 "currencyCode": "USD",
                 "fractionDigits": 2,
@@ -272,11 +265,9 @@ describe(`with promDress preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "color",
                 "value": {
                   "key": "Pink",
@@ -298,7 +289,6 @@ describe(`with promDress preset`, () => {
             "key": "214452",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "ES",
                 "custom": undefined,
@@ -309,7 +299,6 @@ describe(`with promDress preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 12500,
                   "currencyCode": "EUR",
                   "fractionDigits": 2,
@@ -317,7 +306,6 @@ describe(`with promDress preset`, () => {
                 },
               },
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "AU",
                 "custom": undefined,
@@ -328,7 +316,6 @@ describe(`with promDress preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 15000,
                   "currencyCode": "AUD",
                   "fractionDigits": 2,

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.spec.ts
@@ -202,17 +202,14 @@ describe(`with sampleSandals preset`, () => {
       sampleSandals().buildGraphql<TProductDraft>();
     expect(sampleSandalsPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "sandals",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "type",
               "value": {
                 "key": "Shoes",
@@ -234,7 +231,6 @@ describe(`with sampleSandals preset`, () => {
           "key": "148096",
           "prices": [
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "AU",
               "custom": undefined,
@@ -245,7 +241,6 @@ describe(`with sampleSandals preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 2500,
                 "currencyCode": "AUD",
                 "fractionDigits": 2,
@@ -253,7 +248,6 @@ describe(`with sampleSandals preset`, () => {
               },
             },
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "DE",
               "custom": undefined,
@@ -264,7 +258,6 @@ describe(`with sampleSandals preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 3000,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -272,7 +265,6 @@ describe(`with sampleSandals preset`, () => {
               },
             },
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "US",
               "custom": undefined,
@@ -283,7 +275,6 @@ describe(`with sampleSandals preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 2799,
                 "currencyCode": "USD",
                 "fractionDigits": 2,
@@ -291,7 +282,6 @@ describe(`with sampleSandals preset`, () => {
               },
             },
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "ES",
               "custom": undefined,
@@ -302,7 +292,6 @@ describe(`with sampleSandals preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 3000,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -345,11 +334,9 @@ describe(`with sampleSandals preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "type",
                 "value": {
                   "key": "Shoes",
@@ -371,7 +358,6 @@ describe(`with sampleSandals preset`, () => {
             "key": "148097",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "AU",
                 "custom": undefined,
@@ -382,7 +368,6 @@ describe(`with sampleSandals preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 1199,
                   "currencyCode": "AUD",
                   "fractionDigits": 2,
@@ -390,7 +375,6 @@ describe(`with sampleSandals preset`, () => {
                 },
               },
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "US",
                 "custom": undefined,
@@ -401,7 +385,6 @@ describe(`with sampleSandals preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 1000,
                   "currencyCode": "USD",
                   "fractionDigits": 2,

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.spec.ts
@@ -148,17 +148,14 @@ describe(`with skinnyJeans preset`, () => {
       skinnyJeans().buildGraphql<TProductDraft>();
     expect(skinnyJeansPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "skinny_jeans",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "fit",
               "value": {
                 "key": "Slim",
@@ -166,7 +163,6 @@ describe(`with skinnyJeans preset`, () => {
               },
             },
             {
-              "__typename": "ProductAttributeInput",
               "name": "size",
               "value": {
                 "key": "Medium",
@@ -188,7 +184,6 @@ describe(`with skinnyJeans preset`, () => {
           "key": "396594",
           "prices": [
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "DE",
               "custom": undefined,
@@ -199,7 +194,6 @@ describe(`with skinnyJeans preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 4999,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -242,11 +236,9 @@ describe(`with skinnyJeans preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "size",
                 "value": {
                   "key": "Large",
@@ -254,7 +246,6 @@ describe(`with skinnyJeans preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "fit",
                 "value": {
                   "key": "Slim",
@@ -276,7 +267,6 @@ describe(`with skinnyJeans preset`, () => {
             "key": "349700",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "DE",
                 "custom": undefined,
@@ -287,7 +277,6 @@ describe(`with skinnyJeans preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 4999,
                   "currencyCode": "EUR",
                   "fractionDigits": 2,

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.spec.ts
@@ -133,17 +133,14 @@ describe(`with sportCoat preset`, () => {
     const sportCoatPresetGraphql = sportCoat().buildGraphql<TProductDraft>();
     expect(sportCoatPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "sport_coat",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "sleeve_length",
               "value": {
                 "key": "Crop",
@@ -165,7 +162,6 @@ describe(`with sportCoat preset`, () => {
           "key": "692457",
           "prices": [
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "AU",
               "custom": undefined,
@@ -176,7 +172,6 @@ describe(`with sportCoat preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 20000,
                 "currencyCode": "AUD",
                 "fractionDigits": 2,
@@ -219,11 +214,9 @@ describe(`with sportCoat preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "sleeve_length",
                 "value": {
                   "key": "Normal",
@@ -245,7 +238,6 @@ describe(`with sportCoat preset`, () => {
             "key": "692458",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "AU",
                 "custom": undefined,
@@ -256,7 +248,6 @@ describe(`with sportCoat preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 20000,
                   "currencyCode": "AUD",
                   "fractionDigits": 2,

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
@@ -151,17 +151,14 @@ describe(`with summerDress preset`, () => {
       summerDress().buildGraphql<TProductDraft>();
     expect(summerDressPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "summer_dress",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "color",
               "value": {
                 "key": "White",
@@ -183,7 +180,6 @@ describe(`with summerDress preset`, () => {
           "key": "791840",
           "prices": [
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "DE",
               "custom": undefined,
@@ -194,7 +190,6 @@ describe(`with summerDress preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 7500,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -202,7 +197,6 @@ describe(`with summerDress preset`, () => {
               },
             },
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "ES",
               "custom": undefined,
@@ -213,7 +207,6 @@ describe(`with summerDress preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 8000,
                 "currencyCode": "EUR",
                 "fractionDigits": 2,
@@ -256,11 +249,9 @@ describe(`with summerDress preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "color",
                 "value": {
                   "key": "Pink",
@@ -282,7 +273,6 @@ describe(`with summerDress preset`, () => {
             "key": "439502",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "US",
                 "custom": undefined,
@@ -293,7 +283,6 @@ describe(`with summerDress preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 7500,
                   "currencyCode": "USD",
                   "fractionDigits": 2,

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.spec.ts
@@ -240,17 +240,14 @@ describe(`with toddlerTrousers preset`, () => {
       toddlerTrousers().buildGraphql<TProductDraft>();
     expect(toddlerTrousersPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "toddler_trousers",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "size",
               "value": {
                 "key": "Small",
@@ -258,7 +255,6 @@ describe(`with toddlerTrousers preset`, () => {
               },
             },
             {
-              "__typename": "ProductAttributeInput",
               "name": "fit",
               "value": {
                 "key": "Straight",
@@ -266,7 +262,6 @@ describe(`with toddlerTrousers preset`, () => {
               },
             },
             {
-              "__typename": "ProductAttributeInput",
               "name": "color",
               "value": {
                 "key": "White",
@@ -274,7 +269,6 @@ describe(`with toddlerTrousers preset`, () => {
               },
             },
             {
-              "__typename": "ProductAttributeInput",
               "name": "length",
               "value": {
                 "key": "Ankle",
@@ -296,7 +290,6 @@ describe(`with toddlerTrousers preset`, () => {
           "key": "855484",
           "prices": [
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "US",
               "custom": undefined,
@@ -307,7 +300,6 @@ describe(`with toddlerTrousers preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 2599,
                 "currencyCode": "USD",
                 "fractionDigits": 2,
@@ -350,11 +342,9 @@ describe(`with toddlerTrousers preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "size",
                 "value": {
                   "key": "Medium",
@@ -362,7 +352,6 @@ describe(`with toddlerTrousers preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "fit",
                 "value": {
                   "key": "Straight",
@@ -370,7 +359,6 @@ describe(`with toddlerTrousers preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "color",
                 "value": {
                   "key": "White",
@@ -378,7 +366,6 @@ describe(`with toddlerTrousers preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "length",
                 "value": {
                   "key": "Ankle",
@@ -400,7 +387,6 @@ describe(`with toddlerTrousers preset`, () => {
             "key": "855485",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "US",
                 "custom": undefined,
@@ -411,7 +397,6 @@ describe(`with toddlerTrousers preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 2599,
                   "currencyCode": "USD",
                   "fractionDigits": 2,
@@ -422,11 +407,9 @@ describe(`with toddlerTrousers preset`, () => {
             "sku": "855485",
           },
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "size",
                 "value": {
                   "key": "Large",
@@ -434,7 +417,6 @@ describe(`with toddlerTrousers preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "fit",
                 "value": {
                   "key": "Straight",
@@ -442,7 +424,6 @@ describe(`with toddlerTrousers preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "color",
                 "value": {
                   "key": "White",
@@ -450,7 +431,6 @@ describe(`with toddlerTrousers preset`, () => {
                 },
               },
               {
-                "__typename": "ProductAttributeInput",
                 "name": "length",
                 "value": {
                   "key": "Ankle",
@@ -472,7 +452,6 @@ describe(`with toddlerTrousers preset`, () => {
             "key": "855486",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "US",
                 "custom": undefined,
@@ -483,7 +462,6 @@ describe(`with toddlerTrousers preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 2599,
                   "currencyCode": "USD",
                   "fractionDigits": 2,

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.spec.ts
@@ -133,17 +133,14 @@ describe(`with toteBag preset`, () => {
     const toteBagPresetGraphql = toteBag().buildGraphql<TProductDraft>();
     expect(toteBagPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ProductDraft",
         "categories": undefined,
         "categoryOrderHints": undefined,
         "description": undefined,
         "key": "tote_bag",
         "masterVariant": {
-          "__typename": "ProductVariantInput",
           "assets": undefined,
           "attributes": [
             {
-              "__typename": "ProductAttributeInput",
               "name": "type",
               "value": {
                 "key": "Bag",
@@ -165,7 +162,6 @@ describe(`with toteBag preset`, () => {
           "key": "718289",
           "prices": [
             {
-              "__typename": "ProductPriceDataInput",
               "channel": undefined,
               "country": "US",
               "custom": undefined,
@@ -176,7 +172,6 @@ describe(`with toteBag preset`, () => {
               "validFrom": undefined,
               "validUntil": undefined,
               "value": {
-                "__typename": "MoneyInput",
                 "centAmount": 13999,
                 "currencyCode": "USD",
                 "fractionDigits": 2,
@@ -219,11 +214,9 @@ describe(`with toteBag preset`, () => {
         },
         "variants": [
           {
-            "__typename": "ProductVariantInput",
             "assets": undefined,
             "attributes": [
               {
-                "__typename": "ProductAttributeInput",
                 "name": "type",
                 "value": {
                   "key": "Bag",
@@ -245,7 +238,6 @@ describe(`with toteBag preset`, () => {
             "key": "124965",
             "prices": [
               {
-                "__typename": "ProductPriceDataInput",
                 "channel": undefined,
                 "country": "US",
                 "custom": undefined,
@@ -256,7 +248,6 @@ describe(`with toteBag preset`, () => {
                 "validFrom": undefined,
                 "validUntil": undefined,
                 "value": {
-                  "__typename": "MoneyInput",
                   "centAmount": 17500,
                   "currencyCode": "USD",
                   "fractionDigits": 2,

--- a/models/product/src/product/product-draft/transformers.ts
+++ b/models/product/src/product/product-draft/transformers.ts
@@ -1,3 +1,4 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type { TProductDraft, TProductDraftGraphql } from '../types';
 

--- a/models/product/src/product/product-draft/transformers.ts
+++ b/models/product/src/product/product-draft/transformers.ts
@@ -41,7 +41,6 @@ const transformers = {
       'taxCategory',
       'state',
     ],
-    addFields: () => ({ __typename: 'ProductDraft' }),
   }),
 };
 

--- a/models/product/src/product/types.ts
+++ b/models/product/src/product/types.ts
@@ -1,5 +1,8 @@
 import { Product, ProductDraft } from '@commercetools/platform-sdk';
-import { TReferenceGraphql } from '@commercetools-test-data/commons';
+import {
+  TLocalizedStringGraphql,
+  TReferenceGraphql,
+} from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TProduct = Product & {
@@ -17,7 +20,12 @@ export type TProductGraphql = TProduct & {
 };
 
 export type TProductDraft = ProductDraft;
-export type TProductDraftGraphql = TProductDraft & {
+export type TProductDraftGraphql = Omit<
+  TProductDraft,
+  'name' | 'description'
+> & {
+  name: TLocalizedStringGraphql;
+  description?: TLocalizedStringGraphql | null;
   __typename: 'ProductDraft';
 };
 

--- a/models/product/src/product/types.ts
+++ b/models/product/src/product/types.ts
@@ -22,11 +22,19 @@ export type TProductGraphql = TProduct & {
 export type TProductDraft = ProductDraft;
 export type TProductDraftGraphql = Omit<
   TProductDraft,
-  'name' | 'description'
+  | 'name'
+  | 'description'
+  | 'slug'
+  | 'metaTitle'
+  | 'metaDescription'
+  | 'metaKeywords'
 > & {
   name: TLocalizedStringGraphql;
+  slug: TLocalizedStringGraphql;
   description?: TLocalizedStringGraphql | null;
-  __typename: 'ProductDraft';
+  metaTitle?: TLocalizedStringGraphql | null;
+  metaDescription?: TLocalizedStringGraphql | null;
+  metaKeywords?: TLocalizedStringGraphql | null;
 };
 
 export type TProductBuilder = TBuilder<TProduct>;

--- a/models/review/src/review-draft/builder.spec.ts
+++ b/models/review/src/review-draft/builder.spec.ts
@@ -51,7 +51,6 @@ describe('builder', () => {
       'graphql',
       ReviewDraft.random(),
       expect.objectContaining({
-        __typename: 'ReviewDraft',
         key: expect.any(String),
         uniquenessValue: null,
         locale: expect.any(String),

--- a/models/review/src/review-draft/transformers.ts
+++ b/models/review/src/review-draft/transformers.ts
@@ -10,9 +10,6 @@ const transformers = {
   }),
   graphql: Transformer<TReviewDraft, TReviewDraftGraphql>('graphql', {
     buildFields: [],
-    addFields: () => ({
-      __typename: 'ReviewDraft',
-    }),
   }),
 };
 

--- a/models/review/src/types.ts
+++ b/models/review/src/types.ts
@@ -7,9 +7,7 @@ export type TReviewDraft = ReviewDraft;
 export type TReviewGraphql = TReview & {
   __typename: 'Review';
 };
-export type TReviewDraftGraphql = TReviewDraft & {
-  __typename: 'ReviewDraft';
-};
+export type TReviewDraftGraphql = TReviewDraft;
 
 export type TReviewBuilder = TBuilder<TReview>;
 export type TReviewDraftBuilder = TBuilder<TReviewDraft>;

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/builder.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/builder.spec.ts
@@ -62,7 +62,6 @@ describe('builder', () => {
       'graphql',
       ShippingMethodDraft.random(),
       expect.objectContaining({
-        __typename: 'ShippingMethodDraft',
         key: expect.any(String),
         name: expect.any(String),
         localizedName: expect.arrayContaining([

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/dhl.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/dhl.spec.ts
@@ -56,7 +56,6 @@ describe('with dhlShippingMethod preset', () => {
       dhlShippingMethod().buildGraphql<TShippingMethodDraftGraphql>();
     expect(dhlShippingMethodPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ShippingMethodDraft",
         "custom": undefined,
         "isDefault": true,
         "key": "dhl",
@@ -77,17 +76,13 @@ describe('with dhlShippingMethod preset', () => {
         },
         "zoneRates": [
           {
-            "__typename": "ZoneRateDraft",
             "shippingRates": [
               {
-                "__typename": "ShippingRateDraft",
                 "freeAbove": {
-                  "__typename": "BaseMoneyInput",
                   "centAmount": 15000,
                   "currencyCode": "EUR",
                 },
                 "price": {
-                  "__typename": "BaseMoneyInput",
                   "centAmount": 1299,
                   "currencyCode": "EUR",
                 },

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/ups.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/ups.spec.ts
@@ -73,7 +73,6 @@ describe('with upsShippingMethod preset', () => {
     const upsPresetGraphql = ups().buildGraphql<TShippingMethodDraftGraphql>();
     expect(upsPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ShippingMethodDraft",
         "custom": undefined,
         "isDefault": false,
         "key": "ups",
@@ -94,17 +93,13 @@ describe('with upsShippingMethod preset', () => {
         },
         "zoneRates": [
           {
-            "__typename": "ZoneRateDraft",
             "shippingRates": [
               {
-                "__typename": "ShippingRateDraft",
                 "freeAbove": {
-                  "__typename": "BaseMoneyInput",
                   "centAmount": 10000,
                   "currencyCode": "USD",
                 },
                 "price": {
-                  "__typename": "BaseMoneyInput",
                   "centAmount": 1299,
                   "currencyCode": "USD",
                 },
@@ -118,17 +113,13 @@ describe('with upsShippingMethod preset', () => {
             },
           },
           {
-            "__typename": "ZoneRateDraft",
             "shippingRates": [
               {
-                "__typename": "ShippingRateDraft",
                 "freeAbove": {
-                  "__typename": "BaseMoneyInput",
                   "centAmount": 20000,
                   "currencyCode": "AUD",
                 },
                 "price": {
-                  "__typename": "BaseMoneyInput",
                   "centAmount": 2000,
                   "currencyCode": "AUD",
                 },

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/transformers.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/transformers.ts
@@ -33,9 +33,6 @@ const transformers = {
         'zoneRates',
         'custom',
       ],
-      addFields: () => ({
-        __typename: 'ShippingMethodDraft',
-      }),
     }
   ),
 };

--- a/models/shipping-method/src/shipping-method/types.ts
+++ b/models/shipping-method/src/shipping-method/types.ts
@@ -19,9 +19,7 @@ export type TShippingMethodGraphql = TShippingMethod & {
 };
 
 export type TShippingMethodDraft = ShippingMethodDraft;
-export type TShippingMethodDraftGraphql = TShippingMethodDraft & {
-  __typename: 'ShippingMethodDraft';
-};
+export type TShippingMethodDraftGraphql = TShippingMethodDraft;
 
 export type TShippingMethodBuilder = TBuilder<TShippingMethod>;
 export type TShippingMethodDraftBuilder = TBuilder<TShippingMethodDraft>;

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/builder.spec.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/builder.spec.ts
@@ -46,7 +46,6 @@ describe('builder', () => {
       'graphql',
       ShippingRateDraft.random(),
       expect.objectContaining({
-        __typename: 'ShippingRateDraft',
         price: expect.objectContaining({
           centAmount: expect.any(Number),
           currencyCode: expect.any(String),

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-fashion/aud-2000.spec.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-fashion/aud-2000.spec.ts
@@ -27,14 +27,11 @@ describe('with aud2000 preset', () => {
       aud2000().buildGraphql<TShippingRateDraftGraphql>();
     expect(aud2000PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ShippingRateDraft",
         "freeAbove": {
-          "__typename": "BaseMoneyInput",
           "centAmount": 20000,
           "currencyCode": "AUD",
         },
         "price": {
-          "__typename": "BaseMoneyInput",
           "centAmount": 2000,
           "currencyCode": "AUD",
         },

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-fashion/eur-1299.spec.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-fashion/eur-1299.spec.ts
@@ -27,14 +27,11 @@ describe('with eur1299 preset', () => {
       eur1299().buildGraphql<TShippingRateDraftGraphql>();
     expect(eur1299PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ShippingRateDraft",
         "freeAbove": {
-          "__typename": "BaseMoneyInput",
           "centAmount": 15000,
           "currencyCode": "EUR",
         },
         "price": {
-          "__typename": "BaseMoneyInput",
           "centAmount": 1299,
           "currencyCode": "EUR",
         },

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-fashion/usd-1299.spec.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-fashion/usd-1299.spec.ts
@@ -27,14 +27,11 @@ describe('with usd1299 preset', () => {
       usd1299().buildGraphql<TShippingRateDraftGraphql>();
     expect(usd1299PresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ShippingRateDraft",
         "freeAbove": {
-          "__typename": "BaseMoneyInput",
           "centAmount": 10000,
           "currencyCode": "USD",
         },
         "price": {
-          "__typename": "BaseMoneyInput",
           "centAmount": 1299,
           "currencyCode": "USD",
         },

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/transformers.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/transformers.ts
@@ -12,7 +12,6 @@ const transformers = {
     'graphql',
     {
       buildFields: ['price', 'freeAbove', 'tiers'],
-      addFields: () => ({ __typename: 'ShippingRateDraft' }),
     }
   ),
 };

--- a/models/shipping-method/src/shipping-rate/types.ts
+++ b/models/shipping-method/src/shipping-rate/types.ts
@@ -7,9 +7,7 @@ export type TShippingRateDraft = ShippingRateDraft;
 export type TShippingRateGraphql = TShippingRate & {
   __typename: 'ShippingRate';
 };
-export type TShippingRateDraftGraphql = TShippingRateDraft & {
-  __typename: 'ShippingRateDraft';
-};
+export type TShippingRateDraftGraphql = TShippingRateDraft;
 
 export type TShippingRateBuilder = TBuilder<TShippingRate>;
 export type TShippingRateDraftBuilder = TBuilder<TShippingRateDraft>;

--- a/models/shipping-method/src/zone-rate/types.ts
+++ b/models/shipping-method/src/zone-rate/types.ts
@@ -10,9 +10,7 @@ export type TZoneRateGraphql = ZoneRate & {
 };
 
 export type TZoneRateDraft = ZoneRateDraft;
-export type TZoneRateDraftGraphql = TZoneRateDraft & {
-  __typename: 'ZoneRateDraft';
-};
+export type TZoneRateDraftGraphql = TZoneRateDraft;
 
 export type TZoneRateBuilder = TBuilder<TZoneRate>;
 export type TZoneRateDraftBuilder = TBuilder<TZoneRateDraft>;

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/builder.spec.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/builder.spec.ts
@@ -36,7 +36,6 @@ describe('builder', () => {
       'graphql',
       ZoneRateDraft.random(),
       expect.objectContaining({
-        __typename: 'ZoneRateDraft',
         zone: expect.objectContaining({
           __typename: 'Reference',
           typeId: 'zone',

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-fashion/australia.spec.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-fashion/australia.spec.ts
@@ -32,17 +32,13 @@ describe('with australia preset', () => {
       australia().buildGraphql<TZoneRateDraftGraphql>();
     expect(australiaPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ZoneRateDraft",
         "shippingRates": [
           {
-            "__typename": "ShippingRateDraft",
             "freeAbove": {
-              "__typename": "BaseMoneyInput",
               "centAmount": 20000,
               "currencyCode": "AUD",
             },
             "price": {
-              "__typename": "BaseMoneyInput",
               "centAmount": 2000,
               "currencyCode": "AUD",
             },

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-fashion/europe.spec.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-fashion/europe.spec.ts
@@ -31,17 +31,13 @@ describe('with europe preset', () => {
     const europePresetGraphql = europe().buildGraphql<TZoneRateDraftGraphql>();
     expect(europePresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ZoneRateDraft",
         "shippingRates": [
           {
-            "__typename": "ShippingRateDraft",
             "freeAbove": {
-              "__typename": "BaseMoneyInput",
               "centAmount": 15000,
               "currencyCode": "EUR",
             },
             "price": {
-              "__typename": "BaseMoneyInput",
               "centAmount": 1299,
               "currencyCode": "EUR",
             },

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-fashion/usa.spec.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-fashion/usa.spec.ts
@@ -31,17 +31,13 @@ describe('with usa preset', () => {
     const usaPresetGraphql = usa().buildGraphql<TZoneRateDraftGraphql>();
     expect(usaPresetGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ZoneRateDraft",
         "shippingRates": [
           {
-            "__typename": "ShippingRateDraft",
             "freeAbove": {
-              "__typename": "BaseMoneyInput",
               "centAmount": 10000,
               "currencyCode": "USD",
             },
             "price": {
-              "__typename": "BaseMoneyInput",
               "centAmount": 1299,
               "currencyCode": "USD",
             },

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/transformers.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/transformers.ts
@@ -10,7 +10,6 @@ const transformers = {
   }),
   graphql: Transformer<TZoneRateDraft, TZoneRateDraftGraphql>('graphql', {
     buildFields: ['zone', 'shippingRates'],
-    addFields: () => ({ __typename: 'ZoneRateDraft' }),
   }),
 };
 

--- a/models/tax-category/src/tax-category/tax-category-draft/builder.spec.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/builder.spec.ts
@@ -36,7 +36,6 @@ describe('builder', () => {
       'graphql',
       TaxCategoryDraft.random(),
       expect.objectContaining({
-        __typename: 'TaxCategoryDraft',
         key: expect.any(String),
         name: expect.any(String),
         description: expect.any(String),

--- a/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-fashion/standard-tax-category.spec.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-fashion/standard-tax-category.spec.ts
@@ -72,13 +72,11 @@ describe('with a tax rate preset `standard tax category`', () => {
       standardTaxCategory().buildGraphql<TTaxCategoryDraftGraphql>();
     expect(taxCategoryGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "TaxCategoryDraft",
         "description": "",
         "key": "standard-tax",
         "name": "Standard Tax Category",
         "rates": [
           {
-            "__typename": "TaxRateDraft",
             "amount": 0.19,
             "country": "DE",
             "includedInPrice": true,
@@ -87,7 +85,6 @@ describe('with a tax rate preset `standard tax category`', () => {
             "subRates": [],
           },
           {
-            "__typename": "TaxRateDraft",
             "amount": 0.1,
             "country": "AU",
             "includedInPrice": true,
@@ -96,7 +93,6 @@ describe('with a tax rate preset `standard tax category`', () => {
             "subRates": [],
           },
           {
-            "__typename": "TaxRateDraft",
             "amount": 0.21,
             "country": "ES",
             "includedInPrice": true,
@@ -105,7 +101,6 @@ describe('with a tax rate preset `standard tax category`', () => {
             "subRates": [],
           },
           {
-            "__typename": "TaxRateDraft",
             "amount": 0.0625,
             "country": "US",
             "includedInPrice": false,
@@ -114,7 +109,6 @@ describe('with a tax rate preset `standard tax category`', () => {
             "subRates": [],
           },
           {
-            "__typename": "TaxRateDraft",
             "amount": 0.0663,
             "country": "US",
             "includedInPrice": false,
@@ -123,7 +117,6 @@ describe('with a tax rate preset `standard tax category`', () => {
             "subRates": [],
           },
           {
-            "__typename": "TaxRateDraft",
             "amount": 0.07,
             "country": "US",
             "includedInPrice": false,

--- a/models/tax-category/src/tax-category/tax-category-draft/transformers.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/transformers.ts
@@ -10,9 +10,6 @@ const transformers = {
   }),
   graphql: Transformer<TTaxCategoryDraft, TTaxCategoryDraftGraphql>('graphql', {
     buildFields: ['rates'],
-    addFields: () => ({
-      __typename: 'TaxCategoryDraft',
-    }),
   }),
 };
 

--- a/models/tax-category/src/tax-category/types.ts
+++ b/models/tax-category/src/tax-category/types.ts
@@ -10,9 +10,7 @@ export type TTaxCategoryDraft = TaxCategoryDraft;
 export type TTaxCategoryGraphql = TTaxCategory & {
   __typename: 'TaxCategory';
 };
-export type TTaxCategoryDraftGraphql = TTaxCategoryDraft & {
-  __typename: 'TaxCategoryDraft';
-};
+export type TTaxCategoryDraftGraphql = TTaxCategoryDraft;
 
 export type TTaxCategoryBuilder = TBuilder<TTaxCategory>;
 export type TTaxCategoryDraftBuilder = TBuilder<TTaxCategoryDraft>;

--- a/models/tax-category/src/tax-rate/tax-rate-draft/builder.spec.ts
+++ b/models/tax-category/src/tax-rate/tax-rate-draft/builder.spec.ts
@@ -40,7 +40,6 @@ describe('builder', () => {
       'graphql',
       TaxRateDraft.random(),
       expect.objectContaining({
-        __typename: 'TaxRateDraft',
         name: expect.any(String),
         amount: expect.any(Number),
         includedInPrice: expect.any(Boolean),

--- a/models/tax-category/src/tax-rate/tax-rate-draft/transformers.ts
+++ b/models/tax-category/src/tax-rate/tax-rate-draft/transformers.ts
@@ -10,9 +10,6 @@ const transformers = {
   }),
   graphql: Transformer<TTaxRateDraft, TTaxRateDraftGraphql>('graphql', {
     buildFields: [],
-    addFields: () => ({
-      __typename: 'TaxRateDraft',
-    }),
   }),
 };
 

--- a/models/tax-category/src/tax-rate/types.ts
+++ b/models/tax-category/src/tax-rate/types.ts
@@ -7,9 +7,7 @@ export type TTaxRateDraft = TaxRateDraft;
 export type TTaxRateGraphql = TTaxRate & {
   __typename: 'TaxRate';
 };
-export type TTaxRateDraftGraphql = TTaxRateDraft & {
-  __typename: 'TaxRateDraft';
-};
+export type TTaxRateDraftGraphql = TTaxRateDraft;
 
 export type TTaxRateBuilder = TBuilder<TTaxRate>;
 export type TTaxRateDraftBuilder = TBuilder<TTaxRateDraft>;

--- a/models/zone/src/types.ts
+++ b/models/zone/src/types.ts
@@ -7,9 +7,7 @@ export type TZoneDraft = ZoneDraft;
 export type TZoneGraphql = TZone & {
   __typename: 'Zone';
 };
-export type TZoneDraftGraphql = TZoneDraft & {
-  __typename: 'ZoneDraft';
-};
+export type TZoneDraftGraphql = TZoneDraft;
 
 export type TZoneBuilder = TBuilder<TZone>;
 export type TZoneDraftBuilder = TBuilder<TZoneDraft>;

--- a/models/zone/src/zone-draft/builder.spec.ts
+++ b/models/zone/src/zone-draft/builder.spec.ts
@@ -36,7 +36,6 @@ describe('builder', () => {
       'graphql',
       ZoneDraft.random(),
       expect.objectContaining({
-        __typename: 'ZoneDraft',
         name: expect.any(String),
         key: expect.any(String),
         description: expect.any(String),

--- a/models/zone/src/zone-draft/presets/sample-data-fashion/country-australia.spec.ts
+++ b/models/zone/src/zone-draft/presets/sample-data-fashion/country-australia.spec.ts
@@ -24,7 +24,6 @@ describe('with the preset `country australia`', () => {
 
     expect(zoneGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ZoneDraft",
         "description": undefined,
         "key": "australia",
         "locations": [

--- a/models/zone/src/zone-draft/presets/sample-data-fashion/country-spain-and-germany.spec.ts
+++ b/models/zone/src/zone-draft/presets/sample-data-fashion/country-spain-and-germany.spec.ts
@@ -28,7 +28,6 @@ describe('with the preset `country spain and germany`', () => {
 
     expect(zoneGraphql).toMatchInlineSnapshot(`
       {
-        "__typename": "ZoneDraft",
         "description": undefined,
         "key": "europe",
         "locations": [

--- a/models/zone/src/zone-draft/presets/sample-data-fashion/country-usa.spec.ts
+++ b/models/zone/src/zone-draft/presets/sample-data-fashion/country-usa.spec.ts
@@ -24,7 +24,6 @@ describe('with the preset `country usa`', () => {
 
     expect(zone).toMatchInlineSnapshot(`
       {
-        "__typename": "ZoneDraft",
         "description": undefined,
         "key": "usa",
         "locations": [

--- a/models/zone/src/zone-draft/transformers.ts
+++ b/models/zone/src/zone-draft/transformers.ts
@@ -10,9 +10,6 @@ const transformers = {
   }),
   graphql: Transformer<TZoneDraft, TZoneDraftGraphql>('graphql', {
     buildFields: [],
-    addFields: () => ({
-      __typename: 'ZoneDraft',
-    }),
   }),
 };
 


### PR DESCRIPTION
## Summary

In building the resolver for test data imports, we discovered additional type inconsistencies when type casting, mostly surrounding the GraphQL conversion from strings, to arrays of localized input types.

I've resolved the types where necessary by consulting the Impex schema, and regenerated snapshots where appropriate.