### PR TITLE
fix(test-data): correct graphql transforms for Product and Cart discounts

### DIFF
--- a/.changeset/great-boats-rhyme.md
+++ b/.changeset/great-boats-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/product-discount': patch
+'@commercetools-test-data/cart-discount': patch
+---
+
+correct graphql transformations, minor data fixes

--- a/models/cart-discount/src/cart-discount-line-items-target/cart-discount-line-items-target-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-line-items-target/cart-discount-line-items-target-draft/builder.spec.ts
@@ -31,7 +31,6 @@ describe('builder', () => {
       CartDiscountLineItemsTargetDraft.random(),
       expect.objectContaining({
         lineItems: {
-          type: 'lineItems',
           predicate: expect.any(String),
         },
       })

--- a/models/cart-discount/src/cart-discount-line-items-target/cart-discount-line-items-target-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-line-items-target/cart-discount-line-items-target-draft/transformers.ts
@@ -13,11 +13,15 @@ const transformers = {
     TCartDiscountLineItemsTargetDraft,
     TCartDiscountLineItemsTargetDraftGraphql
   >('graphql', {
-    replaceFields: ({ fields }) => ({
-      lineItems: {
-        ...fields,
-      },
-    }),
+    replaceFields: ({ fields }) => {
+      const { type, ...rest } = fields;
+
+      return {
+        [type]: {
+          ...rest,
+        },
+      };
+    },
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-line-items-target/types.ts
+++ b/models/cart-discount/src/cart-discount-line-items-target/types.ts
@@ -10,7 +10,7 @@ export type TCartDiscountLineItemsTargetGraphql =
   };
 
 export type TCartDiscountLineItemsTargetDraftGraphql = {
-  lineItems: TCartDiscountLineItemsTarget;
+  lineItems: Omit<TCartDiscountLineItemsTarget, 'type'>;
 };
 
 export type TCartDiscountLineItemsTargetBuilder =

--- a/models/cart-discount/src/cart-discount-multi-buy-line-items-target/cart-discount-multi-buy-line-items-target-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-multi-buy-line-items-target/cart-discount-multi-buy-line-items-target-draft/builder.spec.ts
@@ -35,7 +35,6 @@ describe('builder', () => {
       CartDiscountMultiBuyLineItemsTargetDraft.random(),
       expect.objectContaining({
         multiBuyLineItems: {
-          type: 'multiBuyLineItems',
           predicate: expect.any(String),
           triggerQuantity: expect.any(Number),
           discountedQuantity: expect.any(Number),

--- a/models/cart-discount/src/cart-discount-multi-buy-line-items-target/cart-discount-multi-buy-line-items-target-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-multi-buy-line-items-target/cart-discount-multi-buy-line-items-target-draft/transformers.ts
@@ -13,11 +13,15 @@ const transformers = {
     TCartDiscountMultiBuyLineItemsTargetDraft,
     TCartDiscountMultiBuyLineItemsTargetDraftGraphql
   >('graphql', {
-    replaceFields: ({ fields }) => ({
-      multiBuyLineItems: {
-        ...fields,
-      },
-    }),
+    replaceFields: ({ fields }) => {
+      const { type, ...rest } = fields;
+
+      return {
+        [type]: {
+          ...rest,
+        },
+      };
+    },
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-multi-buy-line-items-target/types.ts
+++ b/models/cart-discount/src/cart-discount-multi-buy-line-items-target/types.ts
@@ -1,10 +1,8 @@
-import { MultiBuyCustomLineItemsTarget } from '@commercetools/platform-sdk';
+import { MultiBuyLineItemsTarget } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
 
-export type TCartDiscountMultiBuyLineItemsTarget =
-  MultiBuyCustomLineItemsTarget;
-export type TCartDiscountMultiBuyLineItemsTargetDraft =
-  MultiBuyCustomLineItemsTarget;
+export type TCartDiscountMultiBuyLineItemsTarget = MultiBuyLineItemsTarget;
+export type TCartDiscountMultiBuyLineItemsTargetDraft = MultiBuyLineItemsTarget;
 
 export type TCartDiscountMultiBuyLineItemsTargetGraphql =
   TCartDiscountMultiBuyLineItemsTarget & {
@@ -12,7 +10,7 @@ export type TCartDiscountMultiBuyLineItemsTargetGraphql =
   };
 
 export type TCartDiscountMultiBuyLineItemsTargetDraftGraphql = {
-  multiBuyLineItems: TCartDiscountMultiBuyLineItemsTarget;
+  multiBuyLineItems: Omit<TCartDiscountMultiBuyLineItemsTarget, 'type'>;
 };
 
 export type TCartDiscountMultiBuyLineItemsTargetBuilder =

--- a/models/cart-discount/src/cart-discount-shipping-cost-target/cart-discount-shipping-cost-target-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-shipping-cost-target/cart-discount-shipping-cost-target-draft/builder.spec.ts
@@ -29,9 +29,7 @@ describe('builder', () => {
       'graphql',
       CartDiscountShippingCostTargetDraft.random(),
       expect.objectContaining({
-        shipping: {
-          type: 'shipping',
-        },
+        shipping: {},
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-shipping-cost-target/cart-discount-shipping-cost-target-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-shipping-cost-target/cart-discount-shipping-cost-target-draft/transformers.ts
@@ -13,11 +13,15 @@ const transformers = {
     TCartDiscountShippingCostTargetDraft,
     TCartDiscountShippingCostTargetDraftGraphql
   >('graphql', {
-    replaceFields: ({ fields }) => ({
-      shipping: {
-        ...fields,
-      },
-    }),
+    replaceFields: ({ fields }) => {
+      const { type, ...rest } = fields;
+
+      return {
+        [type]: {
+          ...rest,
+        },
+      };
+    },
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-shipping-cost-target/types.ts
+++ b/models/cart-discount/src/cart-discount-shipping-cost-target/types.ts
@@ -11,7 +11,7 @@ export type TCartDiscountShippingCostTargetGraphql =
   };
 
 export type TCartDiscountShippingCostTargetDraftGraphql = {
-  shipping: TCartDiscountShippingCostTarget;
+  shipping: Omit<TCartDiscountShippingCostTarget, 'type'>;
 };
 
 export type TCartDiscountShippingCostTargetBuilder =

--- a/models/cart-discount/src/cart-discount-value-absolute/cart-discount-value-absolute-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-absolute/cart-discount-value-absolute-draft/builder.spec.ts
@@ -52,12 +52,13 @@ describe('builder', () => {
       'graphql',
       CartDiscountValueAbsoluteDraft.random(),
       expect.objectContaining({
-        type: 'absolute',
-        money: expect.arrayContaining([
-          expect.objectContaining({
-            centAmount: expect.any(Number),
-          }),
-        ]),
+        absolute: {
+          money: expect.arrayContaining([
+            expect.objectContaining({
+              centAmount: expect.any(Number),
+            }),
+          ]),
+        },
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-value-absolute/cart-discount-value-absolute-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-absolute/cart-discount-value-absolute-draft/transformers.ts
@@ -22,6 +22,15 @@ const transformers = {
     TCartDiscountValueAbsoluteDraftGraphql
   >('graphql', {
     buildFields: ['money'],
+    replaceFields: ({ fields }) => {
+      const { type, ...rest } = fields;
+
+      return {
+        [type]: {
+          ...rest,
+        },
+      };
+    },
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-value-absolute/types.ts
+++ b/models/cart-discount/src/cart-discount-value-absolute/types.ts
@@ -10,8 +10,10 @@ export type TCartDiscountValueAbsoluteDraft = CartDiscountValueAbsoluteDraft;
 export type TCartDiscountValueAbsoluteGraphql = TCartDiscountValueAbsolute & {
   __typename: 'CartDiscountValueAbsolute';
 };
-export type TCartDiscountValueAbsoluteDraftGraphql =
-  TCartDiscountValueAbsoluteDraft;
+
+export type TCartDiscountValueAbsoluteDraftGraphql = {
+  absolute: Omit<TCartDiscountValueAbsoluteDraft, 'type'>;
+};
 
 export type TCartDiscountValueAbsoluteBuilder =
   TBuilder<TCartDiscountValueAbsolute>;

--- a/models/cart-discount/src/cart-discount-value-fixed/cart-discount-value-fixed-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-fixed/cart-discount-value-fixed-draft/builder.spec.ts
@@ -52,12 +52,13 @@ describe('builder', () => {
       'graphql',
       CartDiscountValueFixedDraft.random(),
       expect.objectContaining({
-        type: 'fixed',
-        money: expect.arrayContaining([
-          expect.objectContaining({
-            centAmount: expect.any(Number),
-          }),
-        ]),
+        fixed: {
+          money: expect.arrayContaining([
+            expect.objectContaining({
+              centAmount: expect.any(Number),
+            }),
+          ]),
+        },
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-value-fixed/cart-discount-value-fixed-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-fixed/cart-discount-value-fixed-draft/transformers.ts
@@ -22,6 +22,15 @@ const transformers = {
     TCartDiscountValueFixedDraftGraphql
   >('graphql', {
     buildFields: ['money'],
+    replaceFields: ({ fields }) => {
+      const { type, ...rest } = fields;
+
+      return {
+        [type]: {
+          ...rest,
+        },
+      };
+    },
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-value-fixed/types.ts
+++ b/models/cart-discount/src/cart-discount-value-fixed/types.ts
@@ -10,7 +10,9 @@ export type TCartDiscountValueFixedDraft = CartDiscountValueFixedDraft;
 export type TCartDiscountValueFixedGraphql = TCartDiscountValueFixed & {
   __typename: 'CartDiscountValueFixed';
 };
-export type TCartDiscountValueFixedDraftGraphql = TCartDiscountValueFixedDraft;
+export type TCartDiscountValueFixedDraftGraphql = {
+  fixed: Omit<TCartDiscountValueFixedDraft, 'type'>;
+};
 
 export type TCartDiscountValueFixedBuilder = TBuilder<TCartDiscountValueFixed>;
 export type TCartDiscountValueFixedDraftBuilder =

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/cart-discount-value-gift-line-item-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/cart-discount-value-gift-line-item-draft/builder.spec.ts
@@ -68,20 +68,21 @@ describe('builder', () => {
       'graphql',
       CartDiscountValueGiftLineItemDraft.random(),
       expect.objectContaining({
-        type: 'giftLineItem',
-        product: expect.objectContaining({
-          id: expect.any(String),
-          typeId: 'product',
-        }),
-        variantId: expect.any(Number),
-        supplyChannel: expect.objectContaining({
-          id: expect.any(String),
-          typeId: 'channel',
-        }),
-        distributionChannel: expect.objectContaining({
-          id: expect.any(String),
-          typeId: 'channel',
-        }),
+        giftLineItem: {
+          product: expect.objectContaining({
+            id: expect.any(String),
+            typeId: 'product',
+          }),
+          variantId: expect.any(Number),
+          supplyChannel: expect.objectContaining({
+            id: expect.any(String),
+            typeId: 'channel',
+          }),
+          distributionChannel: expect.objectContaining({
+            id: expect.any(String),
+            typeId: 'channel',
+          }),
+        },
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/cart-discount-value-gift-line-item-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/cart-discount-value-gift-line-item-draft/transformers.ts
@@ -22,6 +22,15 @@ const transformers = {
     TCartDiscountValueGiftLineItemDraftGraphql
   >('graphql', {
     buildFields: ['product', 'supplyChannel', 'distributionChannel'],
+    replaceFields: ({ fields }) => {
+      const { type, ...rest } = fields;
+
+      return {
+        [type]: {
+          ...rest,
+        },
+      };
+    },
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
@@ -12,8 +12,9 @@ export type TCartDiscountValueGiftLineItemGraphql =
   TCartDiscountValueGiftLineItem & {
     __typename: 'CartDiscountValueGiftLineItem';
   };
-export type TCartDiscountValueGiftLineItemDraftGraphql =
-  TCartDiscountValueGiftLineItemDraft;
+export type TCartDiscountValueGiftLineItemDraftGraphql = {
+  giftLineItem: Omit<TCartDiscountValueGiftLineItemDraft, 'type'>;
+};
 
 export type TCartDiscountValueGiftLineItemBuilder =
   TBuilder<TCartDiscountValueGiftLineItem>;

--- a/models/cart-discount/src/cart-discount-value-relative/cart-discount-value-relative-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-relative/cart-discount-value-relative-draft/builder.spec.ts
@@ -44,8 +44,9 @@ describe('builder', () => {
       'graphql',
       CartDiscountValueRelativeDraft.random(),
       expect.objectContaining({
-        type: 'relative',
-        permyriad: expect.any(Number),
+        relative: {
+          permyriad: expect.any(Number),
+        },
       })
     )
   );

--- a/models/cart-discount/src/cart-discount-value-relative/cart-discount-value-relative-draft/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-relative/cart-discount-value-relative-draft/transformers.ts
@@ -22,6 +22,15 @@ const transformers = {
     TCartDiscountValueRelativeDraftGraphql
   >('graphql', {
     buildFields: [],
+    replaceFields: ({ fields }) => {
+      const { type, ...rest } = fields;
+
+      return {
+        [type]: {
+          ...rest,
+        },
+      };
+    },
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-value-relative/types.ts
+++ b/models/cart-discount/src/cart-discount-value-relative/types.ts
@@ -10,8 +10,9 @@ export type TCartDiscountValueRelativeDraft = CartDiscountValueRelativeDraft;
 export type TCartDiscountValueRelativeGraphql = TCartDiscountValueRelative & {
   __typename: 'CartDiscountValueRelative';
 };
-export type TCartDiscountValueRelativeDraftGraphql =
-  TCartDiscountValueRelativeDraft;
+export type TCartDiscountValueRelativeDraftGraphql = {
+  relative: Omit<TCartDiscountValueRelativeDraft, 'type'>;
+};
 
 export type TCartDiscountValueRelativeBuilder =
   TBuilder<TCartDiscountValueRelative>;

--- a/models/cart-discount/src/cart-discount/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount/builder.spec.ts
@@ -103,9 +103,7 @@ describe('builder', () => {
             __typename: 'LocalizedString',
           }),
         ]),
-        value: expect.objectContaining({
-          type: expect.any(String),
-        }),
+        value: expect.any(Object),
         cartPredicate: '1=1',
         sortOrder: expect.any(String),
         isActive: expect.any(Boolean),

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/builder.spec.ts
@@ -77,9 +77,7 @@ describe('builder', () => {
             value: expect.any(String),
           }),
         ]),
-        value: expect.objectContaining({
-          type: expect.any(String),
-        }),
+        value: expect.any(Object),
         cartPredicate: '1=1',
         sortOrder: expect.any(String),
         isActive: expect.any(Boolean),

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/employee-sale.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/employee-sale.spec.ts
@@ -73,7 +73,6 @@ describe('with the preset `employeeSale`', () => {
         "target": {
           "lineItems": {
             "predicate": "customer.customerGroup.key = "employee"",
-            "type": "lineItems",
           },
         },
         "validFrom": undefined,

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/employee-sale.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/employee-sale.spec.ts
@@ -30,7 +30,7 @@ describe('with the preset `employeeSale`', () => {
         "sortOrder": "0.8",
         "stackingMode": "Stacking",
         "target": {
-          "predicate": "customer.customerGroup.key = "employee"",
+          "predicate": "1=1",
           "type": "lineItems",
         },
         "validFrom": undefined,
@@ -72,14 +72,15 @@ describe('with the preset `employeeSale`', () => {
         "stackingMode": "Stacking",
         "target": {
           "lineItems": {
-            "predicate": "customer.customerGroup.key = "employee"",
+            "predicate": "1=1",
           },
         },
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "permyriad": 1500,
-          "type": "relative",
+          "relative": {
+            "permyriad": 1500,
+          },
         },
       }
     `);

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/employee-sale.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/employee-sale.ts
@@ -20,11 +20,7 @@ const employeeSale = (): TCartDiscountDraftBuilder =>
     .empty()
     .value(CartDiscountValueRelativeDraft.random().permyriad(1500))
     .cartPredicate(`customer.customerGroup.key = "${customerGroupDraft.key}"`)
-    .target(
-      CartDiscountLineItemsTargetDraft.random().predicate(
-        `customer.customerGroup.key = "${customerGroupDraft.key}"`
-      )
-    )
+    .target(CartDiscountLineItemsTargetDraft.random().predicate(`1=1`))
     .name(LocalizedString.presets.empty()['en-US']('Employee Sale'))
     .description(LocalizedString.presets.empty()['en-US']('employee_sale'))
     .stackingMode(stackingMode.Stacking)

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/free-shipping.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/free-shipping.spec.ts
@@ -70,9 +70,7 @@ describe('with the preset `freeShipping`', () => {
         "sortOrder": "0.222",
         "stackingMode": "Stacking",
         "target": {
-          "shipping": {
-            "type": "shipping",
-          },
+          "shipping": {},
         },
         "validFrom": undefined,
         "validUntil": undefined,

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/free-shipping.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/free-shipping.spec.ts
@@ -75,8 +75,9 @@ describe('with the preset `freeShipping`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "permyriad": 10000,
-          "type": "relative",
+          "relative": {
+            "permyriad": 10000,
+          },
         },
       }
     `);

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.spec.ts
@@ -78,7 +78,6 @@ describe('with the preset `luxeSpend`', () => {
         "target": {
           "lineItems": {
             "predicate": "1=1",
-            "type": "lineItems",
           },
         },
         "validFrom": undefined,

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.spec.ts
@@ -39,8 +39,6 @@ describe('with the preset `luxeSpend`', () => {
           "money": {
             "centAmount": 3000,
             "currencyCode": "EUR",
-            "fractionDigits": 2,
-            "type": "centPrecision",
           },
           "type": "absolute",
         },
@@ -83,13 +81,12 @@ describe('with the preset `luxeSpend`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "money": {
-            "centAmount": 3000,
-            "currencyCode": "EUR",
-            "fractionDigits": 2,
-            "type": "centPrecision",
+          "absolute": {
+            "money": {
+              "centAmount": 3000,
+              "currencyCode": "EUR",
+            },
           },
-          "type": "absolute",
         },
       }
     `);

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.spec.ts
@@ -36,10 +36,12 @@ describe('with the preset `luxeSpend`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "money": {
-            "centAmount": 3000,
-            "currencyCode": "EUR",
-          },
+          "money": [
+            {
+              "centAmount": 3000,
+              "currencyCode": "EUR",
+            },
+          ],
           "type": "absolute",
         },
       }
@@ -82,10 +84,12 @@ describe('with the preset `luxeSpend`', () => {
         "validUntil": undefined,
         "value": {
           "absolute": {
-            "money": {
-              "centAmount": 3000,
-              "currencyCode": "EUR",
-            },
+            "money": [
+              {
+                "centAmount": 3000,
+                "currencyCode": "EUR",
+              },
+            ],
           },
         },
       }

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.ts
@@ -19,9 +19,9 @@ const luxeSpend = (): TCartDiscountDraftBuilder =>
   CartDiscountDraft.presets
     .empty()
     .value(
-      CartDiscountValueAbsoluteDraft.random().money(
-        Money.random().currencyCode('EUR').centAmount(3000)
-      )
+      CartDiscountValueAbsoluteDraft.random().money([
+        Money.random().currencyCode('EUR').centAmount(3000),
+      ])
     )
     .cartPredicate(
       `totalPrice = "500.00 EUR" and customer.customerGroup.key = "${customerGroupDraft.key}"`

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/luxe-spend.ts
@@ -1,7 +1,4 @@
-import {
-  CentPrecisionMoneyDraft,
-  LocalizedString,
-} from '@commercetools-test-data/commons';
+import { LocalizedString, Money } from '@commercetools-test-data/commons';
 import {
   CustomerGroupDraft,
   TCustomerGroupDraft,
@@ -23,10 +20,7 @@ const luxeSpend = (): TCartDiscountDraftBuilder =>
     .empty()
     .value(
       CartDiscountValueAbsoluteDraft.random().money(
-        CentPrecisionMoneyDraft.random()
-          .currencyCode('EUR')
-          .centAmount(3000)
-          .fractionDigits(2)
+        Money.random().currencyCode('EUR').centAmount(3000)
       )
     )
     .cartPredicate(

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/percent-off-womens-wear.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/percent-off-womens-wear.spec.ts
@@ -74,7 +74,6 @@ describe('with the preset `percentOffWomensWear`', () => {
         "target": {
           "lineItems": {
             "predicate": "categories.key contains "bottoms-women" and price.discount.id is not defined",
-            "type": "lineItems",
           },
         },
         "validFrom": undefined,

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/percent-off-womens-wear.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/percent-off-womens-wear.spec.ts
@@ -79,8 +79,9 @@ describe('with the preset `percentOffWomensWear`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "permyriad": 1500,
-          "type": "relative",
+          "relative": {
+            "permyriad": 1500,
+          },
         },
       }
     `);

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
@@ -81,7 +81,6 @@ describe('with the preset `shirtsBogo`', () => {
             "predicate": "productType.key = "shirts"",
             "selectionMode": "Cheapest",
             "triggerQuantity": 2,
-            "type": "multiBuyLineItems",
           },
         },
         "validFrom": undefined,

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
@@ -86,8 +86,9 @@ describe('with the preset `shirtsBogo`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "permyriad": 10000,
-          "type": "relative",
+          "relative": {
+            "permyriad": 10000,
+          },
         },
       }
     `);

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.spec.ts
@@ -36,10 +36,12 @@ describe('with the preset `skinnyFixed`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "money": {
-            "centAmount": 2500,
-            "currencyCode": "EUR",
-          },
+          "money": [
+            {
+              "centAmount": 2500,
+              "currencyCode": "EUR",
+            },
+          ],
           "type": "fixed",
         },
       }
@@ -82,10 +84,12 @@ describe('with the preset `skinnyFixed`', () => {
         "validUntil": undefined,
         "value": {
           "fixed": {
-            "money": {
-              "centAmount": 2500,
-              "currencyCode": "EUR",
-            },
+            "money": [
+              {
+                "centAmount": 2500,
+                "currencyCode": "EUR",
+              },
+            ],
           },
         },
       }

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.spec.ts
@@ -39,8 +39,6 @@ describe('with the preset `skinnyFixed`', () => {
           "money": {
             "centAmount": 2500,
             "currencyCode": "EUR",
-            "fractionDigits": 2,
-            "type": "centPrecision",
           },
           "type": "fixed",
         },
@@ -83,13 +81,12 @@ describe('with the preset `skinnyFixed`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "money": {
-            "centAmount": 2500,
-            "currencyCode": "EUR",
-            "fractionDigits": 2,
-            "type": "centPrecision",
+          "fixed": {
+            "money": {
+              "centAmount": 2500,
+              "currencyCode": "EUR",
+            },
           },
-          "type": "fixed",
         },
       }
     `);

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.spec.ts
@@ -78,7 +78,6 @@ describe('with the preset `skinnyFixed`', () => {
         "target": {
           "lineItems": {
             "predicate": "product.key = "skinny_jeans"",
-            "type": "lineItems",
           },
         },
         "validFrom": undefined,

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.ts
@@ -11,9 +11,9 @@ const skinnyFixed = (): TCartDiscountDraftBuilder =>
   CartDiscountDraft.presets
     .empty()
     .value(
-      CartDiscountValueFixedDraft.random().money(
-        Money.random().currencyCode('EUR').centAmount(2500)
-      )
+      CartDiscountValueFixedDraft.random().money([
+        Money.random().currencyCode('EUR').centAmount(2500),
+      ])
     )
     .cartPredicate('1 = 1')
     .target(

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/skinny-fixed.ts
@@ -1,7 +1,4 @@
-import {
-  CentPrecisionMoneyDraft,
-  LocalizedString,
-} from '@commercetools-test-data/commons';
+import { Money, LocalizedString } from '@commercetools-test-data/commons';
 import {
   CartDiscountLineItemsTargetDraft,
   CartDiscountValueFixedDraft,
@@ -15,10 +12,7 @@ const skinnyFixed = (): TCartDiscountDraftBuilder =>
     .empty()
     .value(
       CartDiscountValueFixedDraft.random().money(
-        CentPrecisionMoneyDraft.random()
-          .currencyCode('EUR')
-          .centAmount(2500)
-          .fractionDigits(2)
+        Money.random().currencyCode('EUR').centAmount(2500)
       )
     )
     .cartPredicate('1 = 1')

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/spend-save-ten-percent.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/spend-save-ten-percent.spec.ts
@@ -78,8 +78,9 @@ describe('with the preset `spendSaveTenPercent`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "permyriad": 1000,
-          "type": "relative",
+          "relative": {
+            "permyriad": 1000,
+          },
         },
       }
     `);

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/spend-save-ten-percent.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/spend-save-ten-percent.spec.ts
@@ -73,7 +73,6 @@ describe('with the preset `spendSaveTenPercent`', () => {
         "target": {
           "lineItems": {
             "predicate": "1=1",
-            "type": "lineItems",
           },
         },
         "validFrom": undefined,

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/summer-flips.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/summer-flips.spec.ts
@@ -77,15 +77,16 @@ describe('with the preset `summerFlips`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "distributionChannel": undefined,
-          "product": {
-            "__typename": "Reference",
-            "key": "summer_dress",
-            "typeId": "product",
+          "giftLineItem": {
+            "distributionChannel": undefined,
+            "product": {
+              "__typename": "Reference",
+              "key": "summer_dress",
+              "typeId": "product",
+            },
+            "supplyChannel": undefined,
+            "variantId": 1,
           },
-          "supplyChannel": undefined,
-          "type": "giftLineItem",
-          "variantId": 1,
         },
       }
     `);

--- a/models/cart-discount/src/cart-discount/types.ts
+++ b/models/cart-discount/src/cart-discount/types.ts
@@ -1,4 +1,9 @@
-import { CartDiscount, CartDiscountDraft } from '@commercetools/platform-sdk';
+import {
+  CartDiscount,
+  CartDiscountDraft,
+  CartDiscountTarget,
+  CartDiscountValueDraft,
+} from '@commercetools/platform-sdk';
 import {
   TClientLoggingGraphql,
   TLocalizedStringGraphql,
@@ -17,10 +22,16 @@ export type TCartDiscountGraphql = TCartDiscount & {
 };
 export type TCartDiscountDraftGraphql = Omit<
   TCartDiscountDraft,
-  'name' | 'description'
+  'name' | 'description' | 'value' | 'target'
 > & {
   name: TLocalizedStringGraphql;
   description?: TLocalizedStringGraphql | null;
+  value: {
+    [key: string]: Omit<CartDiscountValueDraft, 'type'>;
+  };
+  target: {
+    [key: string]: Omit<CartDiscountTarget, 'type'>;
+  };
 };
 
 export type TCartDiscountBuilder = TBuilder<TCartDiscount>;

--- a/models/product-discount/src/product-discount-value-absolute/product-discount-value-absolute-draft/builder.spec.ts
+++ b/models/product-discount/src/product-discount-value-absolute/product-discount-value-absolute-draft/builder.spec.ts
@@ -52,12 +52,13 @@ describe('builder', () => {
       'graphql',
       ProductDiscountValueAbsoluteDraft.random(),
       expect.objectContaining({
-        type: 'absolute',
-        money: expect.arrayContaining([
-          expect.objectContaining({
-            centAmount: expect.any(Number),
-          }),
-        ]),
+        absolute: {
+          money: expect.arrayContaining([
+            expect.objectContaining({
+              centAmount: expect.any(Number),
+            }),
+          ]),
+        },
       })
     )
   );

--- a/models/product-discount/src/product-discount-value-absolute/product-discount-value-absolute-draft/transformers.ts
+++ b/models/product-discount/src/product-discount-value-absolute/product-discount-value-absolute-draft/transformers.ts
@@ -22,6 +22,15 @@ const transformers = {
     TProductDiscountValueAbsoluteDraftGraphql
   >('graphql', {
     buildFields: ['money'],
+    replaceFields: ({ fields }) => {
+      const { type, ...rest } = fields;
+
+      return {
+        [type]: {
+          ...rest,
+        },
+      };
+    },
   }),
 };
 

--- a/models/product-discount/src/product-discount-value-absolute/types.ts
+++ b/models/product-discount/src/product-discount-value-absolute/types.ts
@@ -12,8 +12,9 @@ export type TProductDiscountValueAbsoluteGraphql =
   TProductDiscountValueAbsolute & {
     __typename: 'ProductDiscountValueAbsolute';
   };
-export type TProductDiscountValueAbsoluteDraftGraphql =
-  TProductDiscountValueAbsoluteDraft & {};
+export type TProductDiscountValueAbsoluteDraftGraphql = {
+  absolute: Omit<TProductDiscountValueAbsoluteDraft, 'type'>;
+};
 
 export type TProductDiscountValueAbsoluteBuilder =
   TBuilder<TProductDiscountValueAbsolute>;

--- a/models/product-discount/src/product-discount-value-external/product-discount-value-external-draft/builder.spec.ts
+++ b/models/product-discount/src/product-discount-value-external/product-discount-value-external-draft/builder.spec.ts
@@ -41,9 +41,7 @@ describe('builder', () => {
     >(
       'graphql',
       ProductDiscountValueExternalDraft.random(),
-      expect.objectContaining({
-        type: 'external',
-      })
+      expect.objectContaining({ external: {} })
     )
   );
 });

--- a/models/product-discount/src/product-discount-value-external/product-discount-value-external-draft/transformers.ts
+++ b/models/product-discount/src/product-discount-value-external/product-discount-value-external-draft/transformers.ts
@@ -22,6 +22,15 @@ const transformers = {
     TProductDiscountValueExternalDraftGraphql
   >('graphql', {
     buildFields: [],
+    replaceFields: ({ fields }) => {
+      const { type, ...rest } = fields;
+
+      return {
+        [type]: {
+          ...rest,
+        },
+      };
+    },
   }),
 };
 

--- a/models/product-discount/src/product-discount-value-external/types.ts
+++ b/models/product-discount/src/product-discount-value-external/types.ts
@@ -12,8 +12,9 @@ export type TProductDiscountValueExternalGraphql =
   TProductDiscountValueExternal & {
     __typename: 'ProductDiscountValueExternal';
   };
-export type TProductDiscountValueExternalDraftGraphql =
-  TProductDiscountValueExternalDraft;
+export type TProductDiscountValueExternalDraftGraphql = {
+  external: Omit<TProductDiscountValueExternalDraft, 'type'>;
+};
 
 export type TProductDiscountValueExternalBuilder =
   TBuilder<TProductDiscountValueExternal>;

--- a/models/product-discount/src/product-discount-value-relative/product-discount-value-relative-draft/builder.spec.ts
+++ b/models/product-discount/src/product-discount-value-relative/product-discount-value-relative-draft/builder.spec.ts
@@ -44,8 +44,9 @@ describe('builder', () => {
       'graphql',
       ProductDiscountValueRelativeDraft.random(),
       expect.objectContaining({
-        type: 'relative',
-        permyriad: expect.any(Number),
+        relative: {
+          permyriad: expect.any(Number),
+        },
       })
     )
   );

--- a/models/product-discount/src/product-discount-value-relative/product-discount-value-relative-draft/transformers.ts
+++ b/models/product-discount/src/product-discount-value-relative/product-discount-value-relative-draft/transformers.ts
@@ -22,6 +22,15 @@ const transformers = {
     TProductDiscountValueRelativeDraftGraphql
   >('graphql', {
     buildFields: [],
+    replaceFields: ({ fields }) => {
+      const { type, ...rest } = fields;
+
+      return {
+        [type]: {
+          ...rest,
+        },
+      };
+    },
   }),
 };
 

--- a/models/product-discount/src/product-discount-value-relative/types.ts
+++ b/models/product-discount/src/product-discount-value-relative/types.ts
@@ -12,8 +12,9 @@ export type TProductDiscountValueRelativeGraphql =
   TProductDiscountValueRelative & {
     __typename: 'ProductDiscountValueRelative';
   };
-export type TProductDiscountValueRelativeDraftGraphql =
-  TProductDiscountValueRelativeDraft;
+export type TProductDiscountValueRelativeDraftGraphql = {
+  relative: Omit<TProductDiscountValueRelativeDraft, 'type'>;
+};
 
 export type TProductDiscountValueRelativeBuilder =
   TBuilder<TProductDiscountValueRelative>;

--- a/models/product-discount/src/product-discount/product-discount-draft/builder.spec.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/builder.spec.ts
@@ -71,9 +71,7 @@ describe('builder', () => {
             value: expect.any(String),
           }),
         ]),
-        value: expect.objectContaining({
-          type: expect.any(String),
-        }),
+        value: expect.any(Object),
         predicate: '1=1',
         sortOrder: expect.any(String),
         isActive: expect.any(Boolean),

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-dresses.spec.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-dresses.spec.ts
@@ -30,12 +30,12 @@ describe('with the preset `discountDresses`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "money": {
-            "centAmount": 500,
-            "currencyCode": "EUR",
-            "fractionDigits": 2,
-            "type": "centPrecision",
-          },
+          "money": [
+            {
+              "centAmount": 500,
+              "currencyCode": "EUR",
+            },
+          ],
           "type": "absolute",
         },
       }
@@ -69,13 +69,14 @@ describe('with the preset `discountDresses`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "money": {
-            "centAmount": 500,
-            "currencyCode": "EUR",
-            "fractionDigits": 2,
-            "type": "centPrecision",
+          "absolute": {
+            "money": [
+              {
+                "centAmount": 500,
+                "currencyCode": "EUR",
+              },
+            ],
           },
-          "type": "absolute",
         },
       }
     `);

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-dresses.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-dresses.ts
@@ -1,7 +1,4 @@
-import {
-  CentPrecisionMoneyDraft,
-  LocalizedString,
-} from '@commercetools-test-data/commons';
+import { LocalizedString, Money } from '@commercetools-test-data/commons';
 import { ProductDiscountValueAbsoluteDraft } from '../../../../index';
 import type { TProductDiscountDraftBuilder } from '../../../types';
 import * as ProductDiscountDraft from '../../index';
@@ -10,12 +7,9 @@ const discountDresses = (): TProductDiscountDraftBuilder =>
   ProductDiscountDraft.presets
     .empty()
     .value(
-      ProductDiscountValueAbsoluteDraft.random().money(
-        CentPrecisionMoneyDraft.random()
-          .currencyCode('EUR')
-          .centAmount(500)
-          .fractionDigits(2)
-      )
+      ProductDiscountValueAbsoluteDraft.random().money([
+        Money.random().currencyCode('EUR').centAmount(500),
+      ])
     )
     // TODO: integrate product type keys
     .predicate('productType.key = "dresses"')

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-kids.spec.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-kids.spec.ts
@@ -63,8 +63,9 @@ describe('with the preset `discountKids`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "permyriad": 2000,
-          "type": "relative",
+          "relative": {
+            "permyriad": 2000,
+          },
         },
       }
     `);

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-pants.spec.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-fashion/discount-pants.spec.ts
@@ -63,8 +63,9 @@ describe('with the preset `discountPants`', () => {
         "validFrom": undefined,
         "validUntil": undefined,
         "value": {
-          "permyriad": 1000,
-          "type": "relative",
+          "relative": {
+            "permyriad": 1000,
+          },
         },
       }
     `);

--- a/models/product-discount/src/product-discount/product-discount-draft/transformers.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/transformers.ts
@@ -1,4 +1,5 @@
-import { Transformer } from '@commercetools-test-data/core';
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { buildField, Transformer } from '@commercetools-test-data/core';
 import type {
   TProductDiscountDraft,
   TProductDiscountDraftGraphql,
@@ -15,7 +16,18 @@ const transformers = {
   graphql: Transformer<TProductDiscountDraft, TProductDiscountDraftGraphql>(
     'graphql',
     {
-      buildFields: ['value', 'name', 'description'],
+      replaceFields: ({ fields }) => {
+        const { type, ...rest } = buildField(fields.value, 'graphql');
+
+        return {
+          ...fields,
+          name: LocalizedString.toLocalizedField(fields.name)!,
+          description: LocalizedString.toLocalizedField(fields.description),
+          value: {
+            [type]: { ...rest },
+          },
+        };
+      },
     }
   ),
 };

--- a/models/product-discount/src/product-discount/product-discount-draft/transformers.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/transformers.ts
@@ -1,5 +1,4 @@
-import { LocalizedString } from '@commercetools-test-data/commons';
-import { buildField, Transformer } from '@commercetools-test-data/core';
+import { Transformer } from '@commercetools-test-data/core';
 import type {
   TProductDiscountDraft,
   TProductDiscountDraftGraphql,
@@ -16,18 +15,7 @@ const transformers = {
   graphql: Transformer<TProductDiscountDraft, TProductDiscountDraftGraphql>(
     'graphql',
     {
-      replaceFields: ({ fields }) => {
-        const { type, ...rest } = buildField(fields.value, 'graphql');
-
-        return {
-          ...fields,
-          name: LocalizedString.toLocalizedField(fields.name)!,
-          description: LocalizedString.toLocalizedField(fields.description),
-          value: {
-            [type]: { ...rest },
-          },
-        };
-      },
+      buildFields: ['value', 'name', 'description'],
     }
   ),
 };

--- a/models/product-discount/src/product-discount/types.ts
+++ b/models/product-discount/src/product-discount/types.ts
@@ -1,6 +1,7 @@
 import {
   ProductDiscount,
   ProductDiscountDraft,
+  ProductDiscountValueDraft,
 } from '@commercetools/platform-sdk';
 import {
   TClientLoggingGraphql,
@@ -20,10 +21,13 @@ export type TProductDiscountGraphql = TProductDiscount & {
 };
 export type TProductDiscountDraftGraphql = Omit<
   TProductDiscountDraft,
-  'name' | 'description'
+  'name' | 'description' | 'value'
 > & {
   name: TLocalizedStringGraphql;
   description?: TLocalizedStringGraphql | null;
+  value: {
+    [key: string]: Omit<ProductDiscountValueDraft, 'type'>;
+  };
 };
 
 export type TProductDiscountBuilder = TBuilder<TProductDiscount>;


### PR DESCRIPTION
## Summary

This PR corrects some of the errors encountered when attempting to create cart and product discounts via the GraphQL API.

I've copy and pasted each Product and Cart Discount preset graphql snapshot into Impex and confirmed they do indeed successfully create entities.

I'm commenting on these inline as it's easier to discuss in the code ✨ 

## Considerations

I have not addressed discount codes as we're still waiting to hear back from TeamQL on expected functionality. That will be a separate PR.