### PR TITLE
fix(test-data): prefer `id` resource identifiers in discount code presets

### DIFF
--- a/.changeset/hip-tomatoes-train.md
+++ b/.changeset/hip-tomatoes-train.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/discount-code': patch
+---
+
+prefer id resource identifiers for discount code draft presets

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-02.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/john-doe-02.ts
@@ -17,7 +17,8 @@ const johnDoe = CustomerDraft.presets.sampleDataFashion
   .build<TCustomerDraft>();
 const address = AddressDraft.presets.sampleDataFashion.johnDoe();
 const employeeSale = DiscountCodeDraft.presets.sampleDataFashion
-  .employeeSale()
+  // cartDiscountId is not used, we can pass an empty string
+  .employeeSale('')
   .build<TDiscountCodeDraft>();
 
 const johnDoe01 = (): TCartDraftBuilder =>

--- a/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-02.ts
+++ b/models/cart/src/cart-draft/presets/sample-data-fashion/mary-smith-02.ts
@@ -17,7 +17,8 @@ const marySmith = CustomerDraft.presets.sampleDataFashion
   .build<TCustomerDraft>();
 const address = AddressDraft.presets.sampleDataFashion.marySmith();
 const shirtsBogo = DiscountCodeDraft.presets.sampleDataFashion
-  .shirtsBogo()
+  // cartDiscountId is not used, we can pass an empty string
+  .shirtsBogo('')
   .build<TDiscountCodeDraft>();
 
 const marySmith02 = (): TCartDraftBuilder =>

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.spec.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.spec.ts
@@ -3,13 +3,14 @@ import employeeSale from './employee-sale';
 
 describe('with the preset `employeeSale`', () => {
   it('should return a discount code draft', () => {
-    const discountCodeDraft = employeeSale().build<TDiscountCodeDraft>();
+    const discountCodeDraft =
+      employeeSale('my-cart-id').build<TDiscountCodeDraft>();
 
     expect(discountCodeDraft).toMatchInlineSnapshot(`
       {
         "cartDiscounts": [
           {
-            "key": "EmployeeSale",
+            "id": "my-cart-id",
             "typeId": "cart-discount",
           },
         ],
@@ -39,14 +40,14 @@ describe('with the preset `employeeSale`', () => {
 
   it('should return a discount code draft when built for GraphQL', () => {
     const discountCodeDraft =
-      employeeSale().buildGraphql<TDiscountCodeDraftGraphql>();
+      employeeSale('my-cart-id').buildGraphql<TDiscountCodeDraftGraphql>();
 
     expect(discountCodeDraft).toMatchInlineSnapshot(`
       {
         "cartDiscounts": [
           {
             "__typename": "Reference",
-            "key": "EmployeeSale",
+            "id": "my-cart-id",
             "typeId": "cart-discount",
           },
         ],

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.spec.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.spec.ts
@@ -3,14 +3,15 @@ import employeeSale from './employee-sale';
 
 describe('with the preset `employeeSale`', () => {
   it('should return a discount code draft', () => {
-    const discountCodeDraft =
-      employeeSale('my-cart-id').build<TDiscountCodeDraft>();
+    const discountCodeDraft = employeeSale(
+      'my-cart-discount-id'
+    ).build<TDiscountCodeDraft>();
 
     expect(discountCodeDraft).toMatchInlineSnapshot(`
       {
         "cartDiscounts": [
           {
-            "id": "my-cart-id",
+            "id": "my-cart-discount-id",
             "typeId": "cart-discount",
           },
         ],
@@ -39,15 +40,16 @@ describe('with the preset `employeeSale`', () => {
   });
 
   it('should return a discount code draft when built for GraphQL', () => {
-    const discountCodeDraft =
-      employeeSale('my-cart-id').buildGraphql<TDiscountCodeDraftGraphql>();
+    const discountCodeDraft = employeeSale(
+      'my-cart-discount-id'
+    ).buildGraphql<TDiscountCodeDraftGraphql>();
 
     expect(discountCodeDraft).toMatchInlineSnapshot(`
       {
         "cartDiscounts": [
           {
             "__typename": "Reference",
-            "id": "my-cart-id",
+            "id": "my-cart-discount-id",
             "typeId": "cart-discount",
           },
         ],

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/employee-sale.ts
@@ -1,26 +1,15 @@
-import {
-  CartDiscountDraft,
-  type TCartDiscountDraft,
-} from '@commercetools-test-data/cart-discount';
-import {
-  KeyReference,
-  LocalizedString,
-} from '@commercetools-test-data/commons';
+import { Reference, LocalizedString } from '@commercetools-test-data/commons';
 import { TDiscountCodeDraftBuilder } from '../../../types';
 import * as DiscountCodeDraft from '../../index';
 
-const cartDiscountDraft = CartDiscountDraft.presets.sampleDataFashion
-  .employeeSale()
-  .build<TCartDiscountDraft>();
-
-const employeeSale = (): TDiscountCodeDraftBuilder =>
+const employeeSale = (cartDiscountId: string): TDiscountCodeDraftBuilder =>
   DiscountCodeDraft.presets
     .empty()
     .code('emp15')
     .name(LocalizedString.presets.empty()['en-US']('Employee Sale'))
     .description(LocalizedString.presets.empty())
     .cartDiscounts([
-      KeyReference.random().key(cartDiscountDraft.key!).typeId('cart-discount'),
+      Reference.random().id(cartDiscountId).typeId('cart-discount'),
     ])
     .isActive(true)
     .groups([]);

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
@@ -3,14 +3,15 @@ import shirtsBogo from './shirts-bogo';
 
 describe('with the preset `employeeSale`', () => {
   it('should return a discount code draft', () => {
-    const discountCodeDraft =
-      shirtsBogo('my-cart-id').build<TDiscountCodeDraft>();
+    const discountCodeDraft = shirtsBogo(
+      'my-cart-discount-id'
+    ).build<TDiscountCodeDraft>();
 
     expect(discountCodeDraft).toMatchInlineSnapshot(`
       {
         "cartDiscounts": [
           {
-            "id": "my-cart-id",
+            "id": "my-cart-discount-id",
             "typeId": "cart-discount",
           },
         ],
@@ -39,15 +40,16 @@ describe('with the preset `employeeSale`', () => {
   });
 
   it('should return a discount code draft when built for GraphQL', () => {
-    const discountCodeDraft =
-      shirtsBogo('my-cart-id').buildGraphql<TDiscountCodeDraftGraphql>();
+    const discountCodeDraft = shirtsBogo(
+      'my-cart-discount-id'
+    ).buildGraphql<TDiscountCodeDraftGraphql>();
 
     expect(discountCodeDraft).toMatchInlineSnapshot(`
       {
         "cartDiscounts": [
           {
             "__typename": "Reference",
-            "id": "my-cart-id",
+            "id": "my-cart-discount-id",
             "typeId": "cart-discount",
           },
         ],

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.spec.ts
@@ -3,13 +3,14 @@ import shirtsBogo from './shirts-bogo';
 
 describe('with the preset `employeeSale`', () => {
   it('should return a discount code draft', () => {
-    const discountCodeDraft = shirtsBogo().build<TDiscountCodeDraft>();
+    const discountCodeDraft =
+      shirtsBogo('my-cart-id').build<TDiscountCodeDraft>();
 
     expect(discountCodeDraft).toMatchInlineSnapshot(`
       {
         "cartDiscounts": [
           {
-            "key": "ShirtsBOGO",
+            "id": "my-cart-id",
             "typeId": "cart-discount",
           },
         ],
@@ -39,14 +40,14 @@ describe('with the preset `employeeSale`', () => {
 
   it('should return a discount code draft when built for GraphQL', () => {
     const discountCodeDraft =
-      shirtsBogo().buildGraphql<TDiscountCodeDraftGraphql>();
+      shirtsBogo('my-cart-id').buildGraphql<TDiscountCodeDraftGraphql>();
 
     expect(discountCodeDraft).toMatchInlineSnapshot(`
       {
         "cartDiscounts": [
           {
             "__typename": "Reference",
-            "key": "ShirtsBOGO",
+            "id": "my-cart-id",
             "typeId": "cart-discount",
           },
         ],

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-fashion/shirts-bogo.ts
@@ -1,26 +1,15 @@
-import {
-  CartDiscountDraft,
-  type TCartDiscountDraft,
-} from '@commercetools-test-data/cart-discount';
-import {
-  KeyReference,
-  LocalizedString,
-} from '@commercetools-test-data/commons';
+import { LocalizedString, Reference } from '@commercetools-test-data/commons';
 import { TDiscountCodeDraftBuilder } from '../../../types';
 import * as DiscountCodeDraft from '../../index';
 
-const cartDiscountDraft = CartDiscountDraft.presets.sampleDataFashion
-  .shirtsBogo()
-  .build<TCartDiscountDraft>();
-
-const shirtsBogo = (): TDiscountCodeDraftBuilder =>
+const shirtsBogo = (cartDiscountId: string): TDiscountCodeDraftBuilder =>
   DiscountCodeDraft.presets
     .empty()
     .code('BOGO')
     .name(LocalizedString.presets.empty()['en-US']('BOGO'))
     .description(LocalizedString.presets.empty())
     .cartDiscounts([
-      KeyReference.random().key(cartDiscountDraft.key!).typeId('cart-discount'),
+      Reference.random().id(cartDiscountId).typeId('cart-discount'),
     ])
     .isActive(true)
     .maxApplications(1)


### PR DESCRIPTION
## Summary

Due to a restriction in the GraphQL CoCo API [discussed here](https://commercetools.slack.com/archives/C010MT0L58D/p1684525621747999), we must use `id` to identify cart discounts in `DiscountCodeDraft` presets.

This PR simply adds arguments to our presets and updates snapshots appropriately.