### PR TITLE
FCT-426 update shipping method names

### DIFF
--- a/.changeset/hungry-dots-kick.md
+++ b/.changeset/hungry-dots-kick.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/shipping-method': minor
+---
+
+Update names of ShippingMethodDraft presets.

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/europe.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/europe.spec.ts
@@ -2,25 +2,25 @@ import type {
   TShippingMethodDraft,
   TShippingMethodDraftGraphql,
 } from '../../../types';
-import dhlShippingMethod from './dhl';
+import europeShippingMethod from './europe';
 
-describe('with dhlShippingMethod preset', () => {
-  it('should return a dhlShippingMethod preset', () => {
-    const dhlShippingMethodPreset =
-      dhlShippingMethod().build<TShippingMethodDraft>();
-    expect(dhlShippingMethodPreset).toMatchInlineSnapshot(`
+describe('with europeShippingMethod preset', () => {
+  it('should return a europeShippingMethod preset', () => {
+    const europeShippingMethodPreset =
+      europeShippingMethod().build<TShippingMethodDraft>();
+    expect(europeShippingMethodPreset).toMatchInlineSnapshot(`
       {
         "custom": undefined,
         "isDefault": true,
-        "key": "dhl",
+        "key": "shipping-europe",
         "localizedDescription": {
           "de": undefined,
           "en": undefined,
-          "en-US": "DHL",
+          "en-US": "Sample Shipping Method Europe",
           "fr": undefined,
         },
         "localizedName": undefined,
-        "name": "DHL",
+        "name": "Sample Shipping Method Europe",
         "predicate": undefined,
         "taxCategory": {
           "key": "standard-tax",
@@ -51,23 +51,23 @@ describe('with dhlShippingMethod preset', () => {
     `);
   });
 
-  it('should return a dhlShippingMethod preset when built for graphql', () => {
-    const dhlShippingMethodPresetGraphql =
-      dhlShippingMethod().buildGraphql<TShippingMethodDraftGraphql>();
-    expect(dhlShippingMethodPresetGraphql).toMatchInlineSnapshot(`
+  it('should return a europeShippingMethod preset when built for graphql', () => {
+    const europeShippingMethodPresetGraphql =
+      europeShippingMethod().buildGraphql<TShippingMethodDraftGraphql>();
+    expect(europeShippingMethodPresetGraphql).toMatchInlineSnapshot(`
       {
         "custom": undefined,
         "isDefault": true,
-        "key": "dhl",
+        "key": "shipping-europe",
         "localizedDescription": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",
-            "value": "DHL",
+            "value": "Sample Shipping Method Europe",
           },
         ],
         "localizedName": undefined,
-        "name": "DHL",
+        "name": "Sample Shipping Method Europe",
         "predicate": undefined,
         "taxCategory": {
           "__typename": "Reference",

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/europe.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/europe.ts
@@ -5,26 +5,23 @@ import {
 import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ZoneRateDraft from '../../../../zone-rate/zone-rate-draft';
-import * as ShippingMethodDraft from '../../../shipping-method-draft';
 import type { TShippingMethodDraftBuilder } from '../../../types';
+import * as ShippingMethodDraft from '../../index';
 
 const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
   .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
-const upsShippingMethod = (): TShippingMethodDraftBuilder =>
+const EuropeShippingMethod = (): TShippingMethodDraftBuilder =>
   ShippingMethodDraft.presets
     .empty()
-    .key('ups')
-    .name('UPS')
-    .localizedDescription(LocalizedString.presets.empty()['en-US']('UPS'))
+    .key('shipping-europe')
+    .name('Sample Shipping Method Europe')
+    .localizedDescription(LocalizedString.presets.empty()['en-US']('Sample Shipping Method Europe'))
     .taxCategory(
       KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
-    .zoneRates([
-      ZoneRateDraft.presets.sampleDataFashion.usa(),
-      ZoneRateDraft.presets.sampleDataFashion.australia(),
-    ])
-    .isDefault(false);
+    .zoneRates([ZoneRateDraft.presets.sampleDataFashion.europe()])
+    .isDefault(true);
 
-export default upsShippingMethod;
+export default EuropeShippingMethod;

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/europe.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/europe.ts
@@ -12,16 +12,18 @@ const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
   .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
-const EuropeShippingMethod = (): TShippingMethodDraftBuilder =>
+const europeShippingMethod = (): TShippingMethodDraftBuilder =>
   ShippingMethodDraft.presets
     .empty()
     .key('shipping-europe')
     .name('Sample Shipping Method Europe')
-    .localizedDescription(LocalizedString.presets.empty()['en-US']('Sample Shipping Method Europe'))
+    .localizedDescription(
+      LocalizedString.presets.empty()['en-US']('Sample Shipping Method Europe')
+    )
     .taxCategory(
       KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .zoneRates([ZoneRateDraft.presets.sampleDataFashion.europe()])
     .isDefault(true);
 
-export default EuropeShippingMethod;
+export default europeShippingMethod;

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/index.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/index.ts
@@ -1,9 +1,9 @@
-import dhl from './dhl';
-import ups from './ups';
+import europe from './europe';
+import usaAustralia from './usaAustralia';
 
 const presets = {
-  dhl,
-  ups,
+  europe,
+  usaAustralia,
 };
 
 export default presets;

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/usaAustralia.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/usaAustralia.spec.ts
@@ -2,24 +2,24 @@ import type {
   TShippingMethodDraft,
   TShippingMethodDraftGraphql,
 } from '../../../types';
-import ups from './ups';
+import usaAustralia from './usaAustralia';
 
-describe('with upsShippingMethod preset', () => {
-  it('should return a ups preset', () => {
-    const upsPreset = ups().build<TShippingMethodDraft>();
-    expect(upsPreset).toMatchInlineSnapshot(`
+describe('with usaAustraliaShippingMethod preset', () => {
+  it('should return a usaAustralia preset', () => {
+    const usaAustraliaPreset = usaAustralia().build<TShippingMethodDraft>();
+    expect(usaAustraliaPreset).toMatchInlineSnapshot(`
       {
         "custom": undefined,
         "isDefault": false,
-        "key": "ups",
+        "key": "shipping-usa-australia",
         "localizedDescription": {
           "de": undefined,
           "en": undefined,
-          "en-US": "UPS",
+          "en-US": "Sample Shipping Method USA/Australia",
           "fr": undefined,
         },
         "localizedName": undefined,
-        "name": "UPS",
+        "name": "Sample Shipping Method USA/Australia",
         "predicate": undefined,
         "taxCategory": {
           "key": "standard-tax",
@@ -69,22 +69,23 @@ describe('with upsShippingMethod preset', () => {
     `);
   });
 
-  it('should return a ups preset when built for graphql', () => {
-    const upsPresetGraphql = ups().buildGraphql<TShippingMethodDraftGraphql>();
-    expect(upsPresetGraphql).toMatchInlineSnapshot(`
+  it('should return a usaAustralia preset when built for graphql', () => {
+    const usaAustraliaPresetGraphql =
+      usaAustralia().buildGraphql<TShippingMethodDraftGraphql>();
+    expect(usaAustraliaPresetGraphql).toMatchInlineSnapshot(`
       {
         "custom": undefined,
         "isDefault": false,
-        "key": "ups",
+        "key": "shipping-usa-australia",
         "localizedDescription": [
           {
             "__typename": "LocalizedString",
             "locale": "en-US",
-            "value": "UPS",
+            "value": "Sample Shipping Method USA/Australia",
           },
         ],
         "localizedName": undefined,
-        "name": "UPS",
+        "name": "Sample Shipping Method USA/Australia",
         "predicate": undefined,
         "taxCategory": {
           "__typename": "Reference",

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/usaAustralia.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/usaAustralia.ts
@@ -17,7 +17,11 @@ const usaAustraliaShippingMethod = (): TShippingMethodDraftBuilder =>
     .empty()
     .key('shipping-usa-australia')
     .name('Sample Shipping Method USA/Australia')
-    .localizedDescription(LocalizedString.presets.empty()['en-US']('Sample Shipping Method USA/Australia'))
+    .localizedDescription(
+      LocalizedString.presets
+        .empty()
+        ['en-US']('Sample Shipping Method USA/Australia')
+    )
     .taxCategory(
       KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/usaAustralia.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-fashion/usaAustralia.ts
@@ -5,23 +5,26 @@ import {
 import { TaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import type { TTaxCategoryDraft } from '@commercetools-test-data/tax-category';
 import * as ZoneRateDraft from '../../../../zone-rate/zone-rate-draft';
-import * as ShippingMethodDraft from '../../../shipping-method-draft';
 import type { TShippingMethodDraftBuilder } from '../../../types';
+import * as ShippingMethodDraft from '../../index';
 
 const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataFashion
   .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
-const dhlShippingMethod = (): TShippingMethodDraftBuilder =>
+const usaAustraliaShippingMethod = (): TShippingMethodDraftBuilder =>
   ShippingMethodDraft.presets
     .empty()
-    .key('dhl')
-    .name('DHL')
-    .localizedDescription(LocalizedString.presets.empty()['en-US']('DHL'))
+    .key('shipping-usa-australia')
+    .name('Sample Shipping Method USA/Australia')
+    .localizedDescription(LocalizedString.presets.empty()['en-US']('Sample Shipping Method USA/Australia'))
     .taxCategory(
       KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
-    .zoneRates([ZoneRateDraft.presets.sampleDataFashion.europe()])
-    .isDefault(true);
+    .zoneRates([
+      ZoneRateDraft.presets.sampleDataFashion.usa(),
+      ZoneRateDraft.presets.sampleDataFashion.australia(),
+    ])
+    .isDefault(false);
 
-export default dhlShippingMethod;
+export default usaAustraliaShippingMethod;

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/change-history-data/with-usd-currency.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/change-history-data/with-usd-currency.ts
@@ -4,7 +4,7 @@ import * as ShippingRateDraft from '../../index';
 
 const usdCurrency = (): TShippingRateDraftBuilder =>
   ShippingRateDraft.random()
-    .price(Money.presets.changeHistoryData.withUsCurrencyCode())
-    .freeAbove(Money.presets.changeHistoryData.withUsCurrencyCode());
+    .price(Money.presets.changeHistoryData.withUsdCurrencyCode())
+    .freeAbove(Money.presets.changeHistoryData.withUsdCurrencyCode());
 
 export default usdCurrency;

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/change-history-data/with-usd-currency.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/change-history-data/with-usd-currency.ts
@@ -4,7 +4,7 @@ import * as ShippingRateDraft from '../../index';
 
 const usdCurrency = (): TShippingRateDraftBuilder =>
   ShippingRateDraft.random()
-    .price(Money.presets.changeHistoryData.withUsdCurrencyCode())
-    .freeAbove(Money.presets.changeHistoryData.withUsdCurrencyCode());
+    .price(Money.presets.changeHistoryData.withUsCurrencyCode())
+    .freeAbove(Money.presets.changeHistoryData.withUsCurrencyCode());
 
 export default usdCurrency;


### PR DESCRIPTION
This PR renames the `ShippingMethodDraft` presets. 

Note: AFAIK these drafts are not used in other models and are only built in `mc-services` when the import takes place. 