### PR TITLE
fix(renovate): disable lockfileMaintenance PR in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,26 +1,22 @@
 {
-  "extends": [
-    "config:base",
-    ":pinOnlyDevDependencies",
-    "schedule:monthly"
-  ],
+  "extends": ["config:base", ":pinOnlyDevDependencies", "schedule:monthly"],
   "separateMajorMinor": true,
   "packageRules": [
     {
-      "sourceUrlPrefixes": ["https://github.com/commercetools/merchant-center-application-kit"],
+      "sourceUrlPrefixes": [
+        "https://github.com/commercetools/merchant-center-application-kit"
+      ],
       "groupName": "all application-kit packages"
     },
     {
-      "packagePatterns": [
-        "*"
-      ],
+      "packagePatterns": ["*"],
       "updateTypes": ["minor", "patch"],
       "groupName": "all dependencies",
       "groupSlug": "all"
     }
   ],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": false
   },
   "labels": ["🤖 Type: Dependencies"],
   "ignoreDeps": []


### PR DESCRIPTION
Disables the renovate `lockfileMaintenance` PR due to some inconsistencies in version numbers that we have seen recently in that PR.

See [this slack thread](https://commercetools.slack.com/archives/C04NE7LQXV3/p1691155743054109?thread_ts=1691087263.446609&cid=C04NE7LQXV3) for more context