### PR TITLE
chore(test-data): fix free-shipping preset

### DIFF
--- a/.changeset/kind-insects-exist.md
+++ b/.changeset/kind-insects-exist.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart-discount': patch
+---
+
+correct cart discount predicate on free-shipping preset

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/free-shipping.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/free-shipping.spec.ts
@@ -10,7 +10,7 @@ describe('with the preset `freeShipping`', () => {
 
     expect(cartDiscountDraft).toMatchInlineSnapshot(`
       {
-        "cartPredicate": "1 = 1",
+        "cartPredicate": "totalPrice >= "100 EUR"",
         "custom": undefined,
         "description": {
           "de": undefined,
@@ -48,7 +48,7 @@ describe('with the preset `freeShipping`', () => {
 
     expect(cartDiscountDraft).toMatchInlineSnapshot(`
       {
-        "cartPredicate": "1 = 1",
+        "cartPredicate": "totalPrice >= "100 EUR"",
         "custom": undefined,
         "description": [
           {

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/free-shipping.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-fashion/free-shipping.ts
@@ -11,7 +11,7 @@ const freeShipping = (): TCartDiscountDraftBuilder =>
   CartDiscountDraft.presets
     .empty()
     .value(CartDiscountValueRelativeDraft.random().permyriad(10000))
-    .cartPredicate('1 = 1')
+    .cartPredicate('totalPrice >= "100 EUR"')
     .target(CartDiscountShippingCostTargetDraft.random())
     .name(
       LocalizedString.presets


### PR DESCRIPTION
## Summary

This PR fixes the cart discount predicate for the preset so it can select discounts correctly, rather than be applied to all carts.