### PR TITLE
FCT-451: add payment presets to orders

### DIFF
--- a/.changeset/modern-parrots-attack.md
+++ b/.changeset/modern-parrots-attack.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/commons': minor
+'@commercetools-test-data/payment': minor
+---
+
+Adds payment sample data presets, empty preset for payment-draft, empty presets for transaction-draft and payment-status-draft.

--- a/models/commons/src/key-reference/presets/customer-reference.spec.ts
+++ b/models/commons/src/key-reference/presets/customer-reference.spec.ts
@@ -1,7 +1,7 @@
 import type { TKeyReference } from '../types';
 import customer from './customer-reference';
 
-it('should build customer group reference', () => {
+it('should build customer reference', () => {
   const built = customer().build<TKeyReference>();
   expect(built).toEqual({
     key: expect.any(String),

--- a/models/commons/src/key-reference/presets/customer-reference.spec.ts
+++ b/models/commons/src/key-reference/presets/customer-reference.spec.ts
@@ -1,0 +1,10 @@
+import type { TKeyReference } from '../types';
+import customer from './customer-reference';
+
+it('should build customer group reference', () => {
+  const built = customer().build<TKeyReference>();
+  expect(built).toEqual({
+    key: expect.any(String),
+    typeId: 'customer',
+  });
+});

--- a/models/commons/src/key-reference/presets/customer-reference.ts
+++ b/models/commons/src/key-reference/presets/customer-reference.ts
@@ -1,0 +1,6 @@
+import KeyReference from '../builder';
+import type { TKeyReferenceBuilder } from '../types';
+
+const customer = (): TKeyReferenceBuilder => KeyReference().typeId('customer');
+
+export default customer;

--- a/models/commons/src/key-reference/presets/index.ts
+++ b/models/commons/src/key-reference/presets/index.ts
@@ -1,5 +1,6 @@
 import category from './category-reference';
 import customerGroup from './customer-group-reference';
+import customer from './customer-reference';
 import productType from './product-type-reference';
 import shippingMethod from './shipping-method-reference';
 import taxCategory from './tax-category-reference';
@@ -7,6 +8,7 @@ import zone from './zone-reference';
 
 const presets = {
   category,
+  customer,
   customerGroup,
   productType,
   taxCategory,

--- a/models/payment/src/payment-method-info/payment-method-info-draft/presets/empty.spec.ts
+++ b/models/payment/src/payment-method-info/payment-method-info-draft/presets/empty.spec.ts
@@ -1,0 +1,11 @@
+import { TPaymentMethodInfoDraft } from '../../types';
+import empty from './empty';
+
+it(`should set all specified fields to undefined`, () => {
+  const emptyPaymentMethodInfoDraft = empty().build<TPaymentMethodInfoDraft>();
+  expect(emptyPaymentMethodInfoDraft.paymentInterface).toMatchInlineSnapshot(
+    `undefined`
+  );
+  expect(emptyPaymentMethodInfoDraft.method).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPaymentMethodInfoDraft.name).toMatchInlineSnapshot(`undefined`);
+});

--- a/models/payment/src/payment-method-info/payment-method-info-draft/presets/empty.ts
+++ b/models/payment/src/payment-method-info/payment-method-info-draft/presets/empty.ts
@@ -1,0 +1,10 @@
+import type { TPaymentMethodInfoDraftBuilder } from '../../types';
+import PaymentMethodInfoDraft from '../builder';
+
+const empty = (): TPaymentMethodInfoDraftBuilder =>
+  PaymentMethodInfoDraft()
+    .paymentInterface(undefined)
+    .method(undefined)
+    .name(undefined);
+
+export default empty;

--- a/models/payment/src/payment-method-info/payment-method-info-draft/presets/index.ts
+++ b/models/payment/src/payment-method-info/payment-method-info-draft/presets/index.ts
@@ -1,3 +1,5 @@
-const presets = {};
+import empty from './empty';
+
+const presets = { empty };
 
 export default presets;

--- a/models/payment/src/payment-status/payment-status-draft/presets/empty.spec.ts
+++ b/models/payment/src/payment-status/payment-status-draft/presets/empty.spec.ts
@@ -1,0 +1,13 @@
+import { TPaymentStatusDraft } from '../../types';
+import empty from './empty';
+
+it(`should set all specified fields to undefined`, () => {
+  const emptyPaymentStatusDraft = empty().build<TPaymentStatusDraft>();
+  expect(emptyPaymentStatusDraft.interfaceCode).toMatchInlineSnapshot(
+    `undefined`
+  );
+  expect(emptyPaymentStatusDraft.interfaceText).toMatchInlineSnapshot(
+    `undefined`
+  );
+  expect(emptyPaymentStatusDraft.state).toMatchInlineSnapshot(`undefined`);
+});

--- a/models/payment/src/payment-status/payment-status-draft/presets/empty.ts
+++ b/models/payment/src/payment-status/payment-status-draft/presets/empty.ts
@@ -1,0 +1,10 @@
+import type { TPaymentStatusDraftBuilder } from '../../types';
+import PaymentStatusDraft from '../builder';
+
+const empty = (): TPaymentStatusDraftBuilder =>
+  PaymentStatusDraft()
+    .interfaceCode(undefined)
+    .interfaceText(undefined)
+    .state(undefined);
+
+export default empty;

--- a/models/payment/src/payment-status/payment-status-draft/presets/index.ts
+++ b/models/payment/src/payment-status/payment-status-draft/presets/index.ts
@@ -1,3 +1,5 @@
-const presets = {};
+import empty from './empty';
+
+const presets = { empty };
 
 export default presets;

--- a/models/payment/src/payment/payment-draft/presets/empty.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/empty.spec.ts
@@ -1,0 +1,19 @@
+import { TPaymentDraft } from '../../types';
+import empty from './empty';
+
+it(`should set all specified fields to undefined`, () => {
+  const emptyPaymentDraft = empty().build<TPaymentDraft>();
+  expect(emptyPaymentDraft.key).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPaymentDraft.anonymousId).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPaymentDraft.interfaceId).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPaymentDraft.customer).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPaymentDraft.paymentMethodInfo).toMatchInlineSnapshot(
+    `undefined`
+  );
+  expect(emptyPaymentDraft.paymentStatus).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPaymentDraft.transactions).toMatchInlineSnapshot(`undefined`);
+  expect(emptyPaymentDraft.interfaceInteractions).toMatchInlineSnapshot(
+    `undefined`
+  );
+  expect(emptyPaymentDraft.custom).toMatchInlineSnapshot(`undefined`);
+});

--- a/models/payment/src/payment/payment-draft/presets/empty.ts
+++ b/models/payment/src/payment/payment-draft/presets/empty.ts
@@ -1,0 +1,16 @@
+import type { TPaymentDraftBuilder } from '../../types';
+import PaymentDraft from '../builder';
+
+const empty = (): TPaymentDraftBuilder =>
+  PaymentDraft()
+    .key(undefined)
+    .interfaceId(undefined)
+    .anonymousId(undefined)
+    .customer(undefined)
+    .paymentMethodInfo(undefined)
+    .paymentStatus(undefined)
+    .transactions(undefined)
+    .interfaceInteractions(undefined)
+    .custom(undefined);
+
+export default empty;

--- a/models/payment/src/payment/payment-draft/presets/index.ts
+++ b/models/payment/src/payment/payment-draft/presets/index.ts
@@ -1,3 +1,6 @@
-const presets = {};
+import empty from './empty';
+import sampleDataFashion from './sample-data-fashion';
+
+const presets = { empty, sampleDataFashion };
 
 export default presets;

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/index.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/index.ts
@@ -1,0 +1,11 @@
+import paymentAUS1 from './payment-aus1';
+import paymentAUS2 from './payment-aus2';
+import paymentUSA from './payment-usa';
+
+const presets = {
+  paymentAUS1,
+  paymentAUS2,
+  paymentUSA,
+};
+
+export default presets;

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.spec.ts
@@ -8,7 +8,7 @@ it(`should set all fields to specified values`, () => {
   expect(paymentDraftAUS2.interfaceId).toMatchInlineSnapshot(`undefined`);
   expect(paymentDraftAUS2.customer).toMatchInlineSnapshot(`
     {
-      "key": "12345",
+      "key": "1234",
       "typeId": "customer",
     }
   `);
@@ -20,7 +20,7 @@ it(`should set all fields to specified values`, () => {
         "en": "Debit Card",
         "fr": undefined,
       },
-      "paymentInterface": null,
+      "paymentInterface": undefined,
     }
   `);
   expect(paymentDraftAUS2.paymentStatus).toMatchInlineSnapshot(`

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.spec.ts
@@ -1,0 +1,52 @@
+import type { TPaymentDraft } from '../../../types';
+import paymentAUS1 from './payment-aus1';
+
+it(`should set all fields to specified values`, () => {
+  const paymentDraftAUS2 = paymentAUS1().build<TPaymentDraft>();
+  expect(paymentDraftAUS2.key).toMatchInlineSnapshot(`undefined`);
+  expect(paymentDraftAUS2.anonymousId).toMatchInlineSnapshot(`undefined`);
+  expect(paymentDraftAUS2.interfaceId).toMatchInlineSnapshot(`undefined`);
+  expect(paymentDraftAUS2.customer).toMatchInlineSnapshot(`
+    {
+      "key": "12345",
+      "typeId": "customer",
+    }
+  `);
+  expect(paymentDraftAUS2.paymentMethodInfo).toMatchInlineSnapshot(`
+    {
+      "method": "Debit Card",
+      "name": {
+        "de": undefined,
+        "en": "Debit Card",
+        "fr": undefined,
+      },
+      "paymentInterface": null,
+    }
+  `);
+  expect(paymentDraftAUS2.paymentStatus).toMatchInlineSnapshot(`
+    {
+      "interfaceCode": undefined,
+      "interfaceText": "Pending",
+      "state": undefined,
+    }
+  `);
+  expect(paymentDraftAUS2.transactions).toMatchInlineSnapshot(`
+    [
+      {
+        "amount": {
+          "centAmount": 4075,
+          "currencyCode": "AUD",
+        },
+        "custom": undefined,
+        "interactionId": "147258369",
+        "state": "Pending",
+        "timestamp": "2023-07-01T13:00:00.000Z",
+        "type": "Authorization",
+      },
+    ]
+  `);
+  expect(paymentDraftAUS2.interfaceInteractions).toMatchInlineSnapshot(
+    `undefined`
+  );
+  expect(paymentDraftAUS2.custom).toMatchInlineSnapshot(`undefined`);
+});

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.ts
@@ -8,13 +8,13 @@ import {
   type TCustomerDraft,
 } from '@commercetools-test-data/customer';
 import * as PaymentDraft from '../..';
-import * as PaymentMethodInfo from '../../../../payment-method-info';
+import { PaymentMethodInfoDraft } from '../../../../payment-method-info';
 import { PaymentStatusDraft } from '../../../../payment-status';
-import { TransactionDraft } from '../../../../transaction';
+import { TransactionDraft, constants } from '../../../../transaction';
 import { TPaymentDraftBuilder } from '../../../types';
 
 const customerAUS = CustomerDraft.presets.sampleDataFashion
-  .sampleUsa()
+  .sampleAustralia()
   .build<TCustomerDraft>();
 
 const paymentAUS1 = (): TPaymentDraftBuilder =>
@@ -23,7 +23,8 @@ const paymentAUS1 = (): TPaymentDraftBuilder =>
     .customer(KeyReference.presets.customer().key(customerAUS.key!))
     .amountPlanned(Money.random().centAmount(4075).currencyCode('AUD'))
     .paymentMethodInfo(
-      PaymentMethodInfo.random()
+      PaymentMethodInfoDraft.presets
+        .empty()
         .method('Debit Card')
         .name(LocalizedString.presets.empty()['en']('Debit Card'))
     )
@@ -32,9 +33,9 @@ const paymentAUS1 = (): TPaymentDraftBuilder =>
       TransactionDraft.presets
         .empty()
         .amount(Money.random().centAmount(4075).currencyCode('AUD'))
-        .state('Pending')
+        .state(constants.TRANSACTION_STATE.PENDING)
         .timestamp('2023-07-01T13:00:00.000Z')
-        .type('Authorization')
+        .type(constants.TRANSACTION_TYPE.AUTHORIZATION)
         .interactionId('147258369'),
     ]);
 

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.ts
@@ -1,0 +1,41 @@
+import {
+  LocalizedString,
+  KeyReference,
+  Money,
+} from '@commercetools-test-data/commons';
+import {
+  CustomerDraft,
+  type TCustomerDraft,
+} from '@commercetools-test-data/customer';
+import * as PaymentDraft from '../..';
+import * as PaymentMethodInfo from '../../../../payment-method-info';
+import { PaymentStatusDraft } from '../../../../payment-status';
+import { TransactionDraft } from '../../../../transaction';
+import { TPaymentDraftBuilder } from '../../../types';
+
+const customerAUS = CustomerDraft.presets.sampleDataFashion
+  .sampleUsa()
+  .build<TCustomerDraft>();
+
+const paymentAUS1 = (): TPaymentDraftBuilder =>
+  PaymentDraft.presets
+    .empty()
+    .customer(KeyReference.presets.customer().key(customerAUS.key!))
+    .amountPlanned(Money.random().centAmount(4075).currencyCode('AUD'))
+    .paymentMethodInfo(
+      PaymentMethodInfo.random()
+        .method('Debit Card')
+        .name(LocalizedString.presets.empty()['en']('Debit Card'))
+    )
+    .paymentStatus(PaymentStatusDraft.presets.empty().interfaceText('Pending'))
+    .transactions([
+      TransactionDraft.presets
+        .empty()
+        .amount(Money.random().centAmount(4075).currencyCode('AUD'))
+        .state('Pending')
+        .timestamp('2023-07-01T13:00:00.000Z')
+        .type('Authorization')
+        .interactionId('147258369'),
+    ]);
+
+export default paymentAUS1;

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.spec.ts
@@ -8,7 +8,7 @@ it(`should set all fields to specified values`, () => {
   expect(paymentDraftAUS2.interfaceId).toMatchInlineSnapshot(`undefined`);
   expect(paymentDraftAUS2.customer).toMatchInlineSnapshot(`
     {
-      "key": "12345",
+      "key": "1234",
       "typeId": "customer",
     }
   `);
@@ -20,7 +20,7 @@ it(`should set all fields to specified values`, () => {
         "en": "Gift Card",
         "fr": undefined,
       },
-      "paymentInterface": null,
+      "paymentInterface": undefined,
     }
   `);
   expect(paymentDraftAUS2.paymentStatus).toMatchInlineSnapshot(`

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.spec.ts
@@ -1,0 +1,63 @@
+import type { TPaymentDraft } from '../../../types';
+import paymentAUS2 from './payment-aus2';
+
+it(`should set all fields to specified values`, () => {
+  const paymentDraftAUS2 = paymentAUS2().build<TPaymentDraft>();
+  expect(paymentDraftAUS2.key).toMatchInlineSnapshot(`undefined`);
+  expect(paymentDraftAUS2.anonymousId).toMatchInlineSnapshot(`undefined`);
+  expect(paymentDraftAUS2.interfaceId).toMatchInlineSnapshot(`undefined`);
+  expect(paymentDraftAUS2.customer).toMatchInlineSnapshot(`
+    {
+      "key": "12345",
+      "typeId": "customer",
+    }
+  `);
+  expect(paymentDraftAUS2.paymentMethodInfo).toMatchInlineSnapshot(`
+    {
+      "method": "Gift Card",
+      "name": {
+        "de": undefined,
+        "en": "Gift Card",
+        "fr": undefined,
+      },
+      "paymentInterface": null,
+    }
+  `);
+  expect(paymentDraftAUS2.paymentStatus).toMatchInlineSnapshot(`
+    {
+      "interfaceCode": undefined,
+      "interfaceText": "Paid",
+      "state": undefined,
+    }
+  `);
+  expect(paymentDraftAUS2.transactions).toMatchInlineSnapshot(`
+    [
+      {
+        "amount": {
+          "centAmount": 4000,
+          "currencyCode": "AUD",
+        },
+        "custom": undefined,
+        "interactionId": "741852963",
+        "state": "Pending",
+        "timestamp": "2023-07-01T13:00:00.000Z",
+        "type": "Authorization",
+      },
+      {
+        "amount": {
+          "centAmount": 4000,
+          "currencyCode": "AUD",
+        },
+        "custom": undefined,
+        "interactionId": "321654987",
+        "state": "Success",
+        "timestamp": "2023-07-01T13:05:00.000Z",
+        "type": "Charge",
+      },
+    ]
+  `);
+  expect(paymentDraftAUS2.interfaceInteractions).toMatchInlineSnapshot(
+    `undefined`
+  );
+  expect(paymentDraftAUS2.custom).toMatchInlineSnapshot(`undefined`);
+});

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.ts
@@ -1,0 +1,48 @@
+import {
+  LocalizedString,
+  KeyReference,
+  Money,
+} from '@commercetools-test-data/commons';
+import {
+  CustomerDraft,
+  type TCustomerDraft,
+} from '@commercetools-test-data/customer';
+import * as PaymentDraft from '../..';
+import * as PaymentMethodInfo from '../../../../payment-method-info';
+import { PaymentStatusDraft } from '../../../../payment-status';
+import { TransactionDraft } from '../../../../transaction';
+import { TPaymentDraftBuilder } from '../../../types';
+
+const customerAUS = CustomerDraft.presets.sampleDataFashion
+  .sampleUsa()
+  .build<TCustomerDraft>();
+
+const paymentAUS2 = (): TPaymentDraftBuilder =>
+  PaymentDraft.presets
+    .empty()
+    .customer(KeyReference.presets.customer().key(customerAUS.key!))
+    .amountPlanned(Money.random().centAmount(4000).currencyCode('AUD'))
+    .paymentMethodInfo(
+      PaymentMethodInfo.random()
+        .method('Gift Card')
+        .name(LocalizedString.presets.empty()['en']('Gift Card'))
+    )
+    .paymentStatus(PaymentStatusDraft.presets.empty().interfaceText('Paid'))
+    .transactions([
+      TransactionDraft.presets
+        .empty()
+        .amount(Money.random().centAmount(4000).currencyCode('AUD'))
+        .state('Pending')
+        .timestamp('2023-07-01T13:00:00.000Z')
+        .type('Authorization')
+        .interactionId('741852963'),
+      TransactionDraft.presets
+        .empty()
+        .amount(Money.random().centAmount(4000).currencyCode('AUD'))
+        .state('Success')
+        .timestamp('2023-07-01T13:05:00.000Z')
+        .type('Charge')
+        .interactionId('321654987'),
+    ]);
+
+export default paymentAUS2;

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.ts
@@ -8,13 +8,13 @@ import {
   type TCustomerDraft,
 } from '@commercetools-test-data/customer';
 import * as PaymentDraft from '../..';
-import * as PaymentMethodInfo from '../../../../payment-method-info';
+import { PaymentMethodInfoDraft } from '../../../../payment-method-info';
 import { PaymentStatusDraft } from '../../../../payment-status';
-import { TransactionDraft } from '../../../../transaction';
+import { TransactionDraft, constants } from '../../../../transaction';
 import { TPaymentDraftBuilder } from '../../../types';
 
 const customerAUS = CustomerDraft.presets.sampleDataFashion
-  .sampleUsa()
+  .sampleAustralia()
   .build<TCustomerDraft>();
 
 const paymentAUS2 = (): TPaymentDraftBuilder =>
@@ -23,7 +23,8 @@ const paymentAUS2 = (): TPaymentDraftBuilder =>
     .customer(KeyReference.presets.customer().key(customerAUS.key!))
     .amountPlanned(Money.random().centAmount(4000).currencyCode('AUD'))
     .paymentMethodInfo(
-      PaymentMethodInfo.random()
+      PaymentMethodInfoDraft.presets
+        .empty()
         .method('Gift Card')
         .name(LocalizedString.presets.empty()['en']('Gift Card'))
     )
@@ -32,16 +33,16 @@ const paymentAUS2 = (): TPaymentDraftBuilder =>
       TransactionDraft.presets
         .empty()
         .amount(Money.random().centAmount(4000).currencyCode('AUD'))
-        .state('Pending')
+        .state(constants.TRANSACTION_STATE.PENDING)
         .timestamp('2023-07-01T13:00:00.000Z')
-        .type('Authorization')
+        .type(constants.TRANSACTION_TYPE.AUTHORIZATION)
         .interactionId('741852963'),
       TransactionDraft.presets
         .empty()
         .amount(Money.random().centAmount(4000).currencyCode('AUD'))
-        .state('Success')
+        .state(constants.TRANSACTION_STATE.SUCCESS)
         .timestamp('2023-07-01T13:05:00.000Z')
-        .type('Charge')
+        .type(constants.TRANSACTION_TYPE.CHARGE)
         .interactionId('321654987'),
     ]);
 

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.spec.ts
@@ -1,0 +1,63 @@
+import type { TPaymentDraft } from '../../../types';
+import paymentUSA from './payment-usa';
+
+it(`should set all fields to specified values`, () => {
+  const paymentUSADraft = paymentUSA().build<TPaymentDraft>();
+  expect(paymentUSADraft.key).toMatchInlineSnapshot(`undefined`);
+  expect(paymentUSADraft.anonymousId).toMatchInlineSnapshot(`undefined`);
+  expect(paymentUSADraft.interfaceId).toMatchInlineSnapshot(`undefined`);
+  expect(paymentUSADraft.customer).toMatchInlineSnapshot(`
+    {
+      "key": "12345",
+      "typeId": "customer",
+    }
+  `);
+  expect(paymentUSADraft.paymentMethodInfo).toMatchInlineSnapshot(`
+    {
+      "method": "Credit Card",
+      "name": {
+        "de": undefined,
+        "en": "Credit Card",
+        "fr": undefined,
+      },
+      "paymentInterface": null,
+    }
+  `);
+  expect(paymentUSADraft.paymentStatus).toMatchInlineSnapshot(`
+    {
+      "interfaceCode": undefined,
+      "interfaceText": "Paid",
+      "state": undefined,
+    }
+  `);
+  expect(paymentUSADraft.transactions).toMatchInlineSnapshot(`
+    [
+      {
+        "amount": {
+          "centAmount": 32348,
+          "currencyCode": "USD",
+        },
+        "custom": undefined,
+        "interactionId": "123456789",
+        "state": "Pending",
+        "timestamp": "2023-07-01T03:15:00.000Z",
+        "type": "Authorization",
+      },
+      {
+        "amount": {
+          "centAmount": 32348,
+          "currencyCode": "USD",
+        },
+        "custom": undefined,
+        "interactionId": "345678912",
+        "state": "Success",
+        "timestamp": "2023-07-01T03:17:00.000Z",
+        "type": "Charge",
+      },
+    ]
+  `);
+  expect(paymentUSADraft.interfaceInteractions).toMatchInlineSnapshot(
+    `undefined`
+  );
+  expect(paymentUSADraft.custom).toMatchInlineSnapshot(`undefined`);
+});

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.spec.ts
@@ -20,7 +20,7 @@ it(`should set all fields to specified values`, () => {
         "en": "Credit Card",
         "fr": undefined,
       },
-      "paymentInterface": null,
+      "paymentInterface": undefined,
     }
   `);
   expect(paymentUSADraft.paymentStatus).toMatchInlineSnapshot(`

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.ts
@@ -1,0 +1,48 @@
+import {
+  LocalizedString,
+  KeyReference,
+  Money,
+} from '@commercetools-test-data/commons';
+import {
+  CustomerDraft,
+  type TCustomerDraft,
+} from '@commercetools-test-data/customer';
+import * as PaymentDraft from '../..';
+import * as PaymentMethodInfo from '../../../../payment-method-info';
+import { PaymentStatusDraft } from '../../../../payment-status';
+import { TransactionDraft } from '../../../../transaction';
+import { TPaymentDraftBuilder } from '../../../types';
+
+const customerUSA = CustomerDraft.presets.sampleDataFashion
+  .sampleUsa()
+  .build<TCustomerDraft>();
+
+const paymentUSA = (): TPaymentDraftBuilder =>
+  PaymentDraft.presets
+    .empty()
+    .customer(KeyReference.presets.customer().key(customerUSA.key!))
+    .amountPlanned(Money.random().centAmount(32348).currencyCode('USD'))
+    .paymentMethodInfo(
+      PaymentMethodInfo.random()
+        .method('Credit Card')
+        .name(LocalizedString.presets.empty()['en']('Credit Card'))
+    )
+    .paymentStatus(PaymentStatusDraft.presets.empty().interfaceText('Paid'))
+    .transactions([
+      TransactionDraft.presets
+        .empty()
+        .amount(Money.random().centAmount(32348).currencyCode('USD'))
+        .state('Pending')
+        .timestamp('2023-07-01T03:15:00.000Z')
+        .type('Authorization')
+        .interactionId('123456789'),
+      TransactionDraft.presets
+        .empty()
+        .amount(Money.random().centAmount(32348).currencyCode('USD'))
+        .state('Success')
+        .timestamp('2023-07-01T03:17:00.000Z')
+        .type('Charge')
+        .interactionId('345678912'),
+    ]);
+
+export default paymentUSA;

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.ts
@@ -8,9 +8,9 @@ import {
   type TCustomerDraft,
 } from '@commercetools-test-data/customer';
 import * as PaymentDraft from '../..';
-import * as PaymentMethodInfo from '../../../../payment-method-info';
+import { PaymentMethodInfoDraft } from '../../../../payment-method-info';
 import { PaymentStatusDraft } from '../../../../payment-status';
-import { TransactionDraft } from '../../../../transaction';
+import { TransactionDraft, constants } from '../../../../transaction';
 import { TPaymentDraftBuilder } from '../../../types';
 
 const customerUSA = CustomerDraft.presets.sampleDataFashion
@@ -23,7 +23,8 @@ const paymentUSA = (): TPaymentDraftBuilder =>
     .customer(KeyReference.presets.customer().key(customerUSA.key!))
     .amountPlanned(Money.random().centAmount(32348).currencyCode('USD'))
     .paymentMethodInfo(
-      PaymentMethodInfo.random()
+      PaymentMethodInfoDraft.presets
+        .empty()
         .method('Credit Card')
         .name(LocalizedString.presets.empty()['en']('Credit Card'))
     )
@@ -32,16 +33,16 @@ const paymentUSA = (): TPaymentDraftBuilder =>
       TransactionDraft.presets
         .empty()
         .amount(Money.random().centAmount(32348).currencyCode('USD'))
-        .state('Pending')
+        .state(constants.TRANSACTION_STATE.PENDING)
         .timestamp('2023-07-01T03:15:00.000Z')
-        .type('Authorization')
+        .type(constants.TRANSACTION_TYPE.AUTHORIZATION)
         .interactionId('123456789'),
       TransactionDraft.presets
         .empty()
         .amount(Money.random().centAmount(32348).currencyCode('USD'))
-        .state('Success')
+        .state(constants.TRANSACTION_STATE.SUCCESS)
         .timestamp('2023-07-01T03:17:00.000Z')
-        .type('Charge')
+        .type(constants.TRANSACTION_TYPE.CHARGE)
         .interactionId('345678912'),
     ]);
 

--- a/models/payment/src/transaction/index.ts
+++ b/models/payment/src/transaction/index.ts
@@ -3,4 +3,5 @@ export * as TransactionDraft from './transaction-draft';
 export { default as random } from './builder';
 export { default as presets } from './presets';
 export { default as draftPresets } from './transaction-draft/presets';
+export * as constants from './constants';
 export * from './types';

--- a/models/payment/src/transaction/index.ts
+++ b/models/payment/src/transaction/index.ts
@@ -1,3 +1,6 @@
+export * as TransactionDraft from './transaction-draft';
+
 export { default as random } from './builder';
 export { default as presets } from './presets';
+export { default as draftPresets } from './transaction-draft/presets';
 export * from './types';

--- a/models/payment/src/transaction/transaction-draft/presets/empty.spec.ts
+++ b/models/payment/src/transaction/transaction-draft/presets/empty.spec.ts
@@ -1,0 +1,12 @@
+import { TTransactionDraft } from '../../types';
+import empty from './empty';
+
+it(`should set all specified fields to undefined`, () => {
+  const emptyTransactionDraft = empty().build<TTransactionDraft>();
+  expect(emptyTransactionDraft.interactionId).toMatchInlineSnapshot(
+    `undefined`
+  );
+  expect(emptyTransactionDraft.state).toMatchInlineSnapshot(`undefined`);
+  expect(emptyTransactionDraft.timestamp).toMatchInlineSnapshot(`undefined`);
+  expect(emptyTransactionDraft.custom).toMatchInlineSnapshot(`undefined`);
+});

--- a/models/payment/src/transaction/transaction-draft/presets/empty.ts
+++ b/models/payment/src/transaction/transaction-draft/presets/empty.ts
@@ -1,0 +1,11 @@
+import type { TTransactionDraftBuilder } from '../../types';
+import TransactionDraft from '../builder';
+
+const empty = (): TTransactionDraftBuilder =>
+  TransactionDraft()
+    .interactionId(undefined)
+    .state(undefined)
+    .timestamp(undefined)
+    .custom(undefined);
+
+export default empty;

--- a/models/payment/src/transaction/transaction-draft/presets/index.ts
+++ b/models/payment/src/transaction/transaction-draft/presets/index.ts
@@ -1,3 +1,5 @@
-const presets = {};
+import empty from './empty';
+
+const presets = { empty };
 
 export default presets;


### PR DESCRIPTION
This PR adds sample data payment presets, and empty presets for `payment-draft`, `transaction-draft`, `payment-status-draft`.