### PR TITLE
chore(test-data): fix `StoreDraft.name` graphql type

### DIFF
--- a/.changeset/large-worms-peel.md
+++ b/.changeset/large-worms-peel.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/store': patch
+---
+
+fix store draft `name` field type

--- a/models/store/src/store/store-draft/presets/sample-data-fashion/store-01.spec.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-fashion/store-01.spec.ts
@@ -33,12 +33,13 @@ describe('with `store01` preset', () => {
         "distributionChannels": undefined,
         "key": "sample_store_one",
         "languages": undefined,
-        "name": {
-          "de": undefined,
-          "en": undefined,
-          "en-US": "Sample Store One",
-          "fr": undefined,
-        },
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-US",
+            "value": "Sample Store One",
+          },
+        ],
         "productSelections": undefined,
         "supplyChannels": undefined,
       }

--- a/models/store/src/store/store-draft/presets/sample-data-fashion/store-02.spec.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-fashion/store-02.spec.ts
@@ -33,12 +33,13 @@ describe('with `store02` preset', () => {
         "distributionChannels": undefined,
         "key": "sample_store_one",
         "languages": undefined,
-        "name": {
-          "de": undefined,
-          "en": undefined,
-          "en-US": "Sample Store One",
-          "fr": undefined,
-        },
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-US",
+            "value": "Sample Store One",
+          },
+        ],
         "productSelections": undefined,
         "supplyChannels": undefined,
       }

--- a/models/store/src/store/store-draft/presets/sample-data-fashion/store-03.spec.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-fashion/store-03.spec.ts
@@ -33,12 +33,13 @@ describe('with `store03` preset', () => {
         "distributionChannels": undefined,
         "key": "sample_store_three",
         "languages": undefined,
-        "name": {
-          "de": undefined,
-          "en": undefined,
-          "en-US": "Sample Store Three",
-          "fr": undefined,
-        },
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-US",
+            "value": "Sample Store Three",
+          },
+        ],
         "productSelections": undefined,
         "supplyChannels": undefined,
       }

--- a/models/store/src/store/store-draft/transformers.ts
+++ b/models/store/src/store/store-draft/transformers.ts
@@ -1,3 +1,4 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type { TStoreDraft, TStoreDraftGraphql } from '../types';
 
@@ -10,8 +11,11 @@ const transformers = {
   }),
   //Note that the storeDraft graphql transformer is provided as scaffolding only and may not be complete at this time.
   graphql: Transformer<TStoreDraft, TStoreDraftGraphql>('rest', {
-    buildFields: ['name'],
-    addFields: () => ({ __typename: 'StoreDraft' }),
+    replaceFields: ({ fields }) => ({
+      ...fields,
+      name: LocalizedString.toLocalizedField(fields.name),
+      __typename: 'StoreDraft',
+    }),
   }),
 };
 

--- a/models/store/src/store/types.ts
+++ b/models/store/src/store/types.ts
@@ -6,7 +6,8 @@ import type { TBuilder } from '@commercetools-test-data/core';
 export type TStoreDraft = StoreDraft;
 export type TStoreDraftBuilder = TBuilder<TStoreDraft>;
 export type TCreateStoreDraftBuilder = () => TStoreDraftBuilder;
-export type TStoreDraftGraphql = TStore & {
+export type TStoreDraftGraphql = Omit<TStoreDraft, 'name'> & {
+  name: TLocalizedStringGraphql | null;
   __typename: 'StoreDraft';
 };
 //Store


### PR DESCRIPTION
## Summary

Local testing of the import resolver yielded errors, due to an invalid GraphQL type of the `name` field in `StoreDraft` presets. Just resolving that here 🤓 

```
  {
    "status": "rejected",
    "reason": {
      "message": "Variable '$draft' expected value of type 'CreateStore!' but got: {\"key\":\"sample_store_one\",\"name\":{\"en-US\":\"Sample Store One\"},\"__typename\":\"StoreDraft\"}. Reason: 'name[0].locale' Expected non-null value, found null.",
      "extensions": { "code": "InvalidInput" }
    }
  },
  ```