### PR TITLE
feat(zone): added presets for goodstore data

### DIFF
--- a/.changeset/lovely-jars-trade.md
+++ b/.changeset/lovely-jars-trade.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/zone': minor
+---
+
+Added zones to Good Store data presets

--- a/models/zone/src/zone/zone-draft/presets/index.ts
+++ b/models/zone/src/zone/zone-draft/presets/index.ts
@@ -1,6 +1,7 @@
 import empty from './empty';
 import sampleDataFashion from './sample-data-fashion';
+import sampleDataGoodStore from './sample-data-goodstore';
 
-const presets = { empty, sampleDataFashion };
+const presets = { empty, sampleDataFashion, sampleDataGoodStore };
 
 export default presets;

--- a/models/zone/src/zone/zone-draft/presets/sample-data-goodstore/country-germany.spec.ts
+++ b/models/zone/src/zone/zone-draft/presets/sample-data-goodstore/country-germany.spec.ts
@@ -1,0 +1,38 @@
+import { TZoneDraft, TZoneDraftGraphql } from '../../../types';
+import countryGermany from './country-germany';
+
+describe('with the preset `country germany`', () => {
+  it('should return a zone with name `Europe`', () => {
+    const zone = countryGermany().build<TZoneDraft>();
+
+    expect(zone).toMatchInlineSnapshot(`
+      {
+        "description": undefined,
+        "key": "europe",
+        "locations": [
+          {
+            "country": "DE",
+          },
+        ],
+        "name": "Europe",
+      }
+    `);
+  });
+
+  it('should return a zone with name `Europe` when built for GraphQL', () => {
+    const zoneGraphql = countryGermany().buildGraphql<TZoneDraftGraphql>();
+
+    expect(zoneGraphql).toMatchInlineSnapshot(`
+      {
+        "description": undefined,
+        "key": "europe",
+        "locations": [
+          {
+            "country": "DE",
+          },
+        ],
+        "name": "Europe",
+      }
+    `);
+  });
+});

--- a/models/zone/src/zone/zone-draft/presets/sample-data-goodstore/country-germany.ts
+++ b/models/zone/src/zone/zone-draft/presets/sample-data-goodstore/country-germany.ts
@@ -1,0 +1,10 @@
+import * as ZoneDraft from '../../index';
+
+const countryGermany = () =>
+  ZoneDraft.presets
+    .empty()
+    .name('Europe')
+    .key('europe')
+    .locations([{ country: 'DE' }]);
+
+export default countryGermany;

--- a/models/zone/src/zone/zone-draft/presets/sample-data-goodstore/country-unitedkingdom.spec.ts
+++ b/models/zone/src/zone/zone-draft/presets/sample-data-goodstore/country-unitedkingdom.spec.ts
@@ -1,0 +1,39 @@
+import { TZoneDraft, TZoneDraftGraphql } from '../../../types';
+import countryUnitedKingdom from './country-unitedkingdom';
+
+describe('with the preset `country united kingdom`', () => {
+  it('should return a zone with name `United Kingdom`', () => {
+    const zone = countryUnitedKingdom().build<TZoneDraft>();
+
+    expect(zone).toMatchInlineSnapshot(`
+      {
+        "description": undefined,
+        "key": "unitedkingdom",
+        "locations": [
+          {
+            "country": "GB",
+          },
+        ],
+        "name": "United Kingdom",
+      }
+    `);
+  });
+
+  it('should return a zone with name `United Kingdom` when built for GraphQL', () => {
+    const zoneGraphql =
+      countryUnitedKingdom().buildGraphql<TZoneDraftGraphql>();
+
+    expect(zoneGraphql).toMatchInlineSnapshot(`
+      {
+        "description": undefined,
+        "key": "unitedkingdom",
+        "locations": [
+          {
+            "country": "GB",
+          },
+        ],
+        "name": "United Kingdom",
+      }
+    `);
+  });
+});

--- a/models/zone/src/zone/zone-draft/presets/sample-data-goodstore/country-unitedkingdom.ts
+++ b/models/zone/src/zone/zone-draft/presets/sample-data-goodstore/country-unitedkingdom.ts
@@ -1,0 +1,10 @@
+import * as ZoneDraft from '../../index';
+
+const countryUnitedKingdom = () =>
+  ZoneDraft.presets
+    .empty()
+    .name('United Kingdom')
+    .key('unitedkingdom')
+    .locations([{ country: 'GB' }]);
+
+export default countryUnitedKingdom;

--- a/models/zone/src/zone/zone-draft/presets/sample-data-goodstore/index.ts
+++ b/models/zone/src/zone/zone-draft/presets/sample-data-goodstore/index.ts
@@ -1,0 +1,9 @@
+import countryGermany from './country-germany';
+import countryUnitedKingdom from './country-unitedkingdom';
+
+const presets = {
+  countryGermany,
+  countryUnitedKingdom,
+};
+
+export default presets;


### PR DESCRIPTION
The original zone PR got a tad overwhelming with the failed test and attempted updates. Hoping this one is cleaner.