### PR TITLE
feat(store): added store presets for goodstore data

### DIFF
--- a/.changeset/shaggy-rings-suffer.md
+++ b/.changeset/shaggy-rings-suffer.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/store': minor
+---
+
+Added store presets to Good Store data

--- a/models/store/src/store/store-draft/generator.ts
+++ b/models/store/src/store/store-draft/generator.ts
@@ -8,7 +8,7 @@ const generator = Generator<TStoreDraft>({
   fields: {
     key: fake((f) => f.lorem.slug()),
     name: fake(() => LocalizedString.random()),
-    languages: [oneOf('en-US', 'de-DE', 'es-ES')],
+    languages: [oneOf('en-US', 'de-DE', 'es-ES', 'en-GB')],
     countries: [fake((f) => f.location.countryCode())],
     distributionChannels: null,
     supplyChannels: null,

--- a/models/store/src/store/store-draft/presets/index.ts
+++ b/models/store/src/store/store-draft/presets/index.ts
@@ -1,6 +1,7 @@
 import empty from './empty';
 import sampleDataFashion from './sample-data-fashion';
+import sampleDataGoodStore from './sample-data-goodstore';
 
-const presets = { empty, sampleDataFashion };
+const presets = { empty, sampleDataFashion, sampleDataGoodStore };
 
 export default presets;

--- a/models/store/src/store/store-draft/presets/sample-data-goodstore/index.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-goodstore/index.ts
@@ -1,5 +1,5 @@
-import the_good_store from './the-good-store';
+import theGoodStore from './the-good-store';
 
-const presets = { the_good_store };
+const presets = { theGoodStore };
 
 export default presets;

--- a/models/store/src/store/store-draft/presets/sample-data-goodstore/index.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-goodstore/index.ts
@@ -1,0 +1,5 @@
+import the_good_store from './the-good-store';
+
+const presets = { the_good_store };
+
+export default presets;

--- a/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.spec.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.spec.ts
@@ -1,9 +1,9 @@
 import { TStoreDraft } from '../../../types';
-import the_good_store from './the-good-store';
+import theGoodStore from './the-good-store';
 
 describe('with `the_good_store` preset', () => {
   it('should return a store draft preset', () => {
-    const storeDraft = the_good_store().build<TStoreDraft>();
+    const storeDraft = theGoodStore().build<TStoreDraft>();
     expect(storeDraft).toMatchInlineSnapshot(`
       {
         "countries": undefined,
@@ -25,7 +25,7 @@ describe('with `the_good_store` preset', () => {
   });
 
   it('should return a store draft preset preset when built for graphql', () => {
-    const storeDraft = the_good_store().buildGraphql<TStoreDraft>();
+    const storeDraft = theGoodStore().buildGraphql<TStoreDraft>();
     expect(storeDraft).toMatchInlineSnapshot(`
       {
         "__typename": "StoreDraft",

--- a/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.spec.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.spec.ts
@@ -1,0 +1,48 @@
+import { TStoreDraft } from '../../../types';
+import the_good_store from './the-good-store';
+
+describe('with `the_good_store` preset', () => {
+  it('should return a store draft preset', () => {
+    const storeDraft = the_good_store().build<TStoreDraft>();
+    expect(storeDraft).toMatchInlineSnapshot(`
+      {
+        "countries": undefined,
+        "custom": undefined,
+        "distributionChannels": undefined,
+        "key": "the-good-store",
+        "languages": undefined,
+        "name": {
+          "de": undefined,
+          "en": undefined,
+          "en-GB": "The Good Store",
+          "fr": undefined,
+        },
+        "productSelections": undefined,
+        "supplyChannels": undefined,
+      }
+    `);
+  });
+
+  it('should return a store draft preset preset when built for graphql', () => {
+    const storeDraft = the_good_store().buildGraphql<TStoreDraft>();
+    expect(storeDraft).toMatchInlineSnapshot(`
+      {
+        "__typename": "StoreDraft",
+        "countries": undefined,
+        "custom": undefined,
+        "distributionChannels": undefined,
+        "key": "the-good-store",
+        "languages": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-GB",
+            "value": "The Good Store",
+          },
+        ],
+        "productSelections": undefined,
+        "supplyChannels": undefined,
+      }
+    `);
+  });
+});

--- a/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.spec.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.spec.ts
@@ -15,6 +15,7 @@ describe('with `the_good_store` preset', () => {
           "de": undefined,
           "en": undefined,
           "en-GB": "The Good Store",
+          "en-US": "The Good Store",
           "fr": undefined,
         },
         "productSelections": undefined,
@@ -34,6 +35,11 @@ describe('with `the_good_store` preset', () => {
         "key": "the-good-store",
         "languages": undefined,
         "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-US",
+            "value": "The Good Store",
+          },
           {
             "__typename": "LocalizedString",
             "locale": "en-GB",

--- a/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.ts
@@ -6,6 +6,5 @@ const the_good_store = (): TStoreDraftBuilder =>
   StoreDraft.presets
     .empty()
     .key('the-good-store')
-    .name(LocalizedString.presets.empty()['en-US']('The Good Store'))
-    .name(LocalizedString.presets.empty()['en-GB']('The Good Store'));
+    .name(LocalizedString.presets.empty()['en-US']('The Good Store')['en-GB']('The Good Store'));
 export default the_good_store;

--- a/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.ts
@@ -6,5 +6,10 @@ const the_good_store = (): TStoreDraftBuilder =>
   StoreDraft.presets
     .empty()
     .key('the-good-store')
-    .name(LocalizedString.presets.empty()['en-US']('The Good Store')['en-GB']('The Good Store'));
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-US']('The Good Store')
+        ['en-GB']('The Good Store')
+    );
 export default the_good_store;

--- a/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.ts
@@ -2,7 +2,7 @@ import { LocalizedString } from '@commercetools-test-data/commons';
 import type { TStoreDraftBuilder } from '../../../types';
 import * as StoreDraft from '../../index';
 
-const the_good_store = (): TStoreDraftBuilder =>
+const theGoodStore = (): TStoreDraftBuilder =>
   StoreDraft.presets
     .empty()
     .key('the-good-store')
@@ -12,4 +12,4 @@ const the_good_store = (): TStoreDraftBuilder =>
         ['en-US']('The Good Store')
         ['en-GB']('The Good Store')
     );
-export default the_good_store;
+export default theGoodStore;

--- a/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-goodstore/the-good-store.ts
@@ -1,0 +1,11 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
+import type { TStoreDraftBuilder } from '../../../types';
+import * as StoreDraft from '../../index';
+
+const the_good_store = (): TStoreDraftBuilder =>
+  StoreDraft.presets
+    .empty()
+    .key('the-good-store')
+    .name(LocalizedString.presets.empty()['en-US']('The Good Store'))
+    .name(LocalizedString.presets.empty()['en-GB']('The Good Store'));
+export default the_good_store;


### PR DESCRIPTION
Added store presets to the good store data. Did not include the countries as the project only supports those two countries. Info seemed redundant. 

Mirrors orginal Good Store data. https://github.com/frontastic-developers/customer-thegoodstore/blob/master/getting-started/data/stores.json