### PR TITLE
feat(models/product-type): add `AttributeSetType` and `AttributeSetTpeDraft` models

### DIFF
--- a/.changeset/big-garlics-cheat.md
+++ b/.changeset/big-garlics-cheat.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product-type': patch
+---
+
+Add `AttributeSetType` and `AttributeSetTypeDraft` models.

--- a/models/product-type/README.md
+++ b/models/product-type/README.md
@@ -18,6 +18,7 @@ $ pnpm add -D @commercetools-test-data/product-type
 - [AttributeLocalizedEnumValue](#attributelocalizedenumvalue)<br>
 - [attributeLocalizableTextType](#attributelocalizabletexttype)<br>
 - [AttributePlainEnumValue](#attributeplainenumvalue)<br>
+- [AttributeSetType](#attributesettype)<br>
 - [AttributeTextType](#attributetexttype)<br><br>
 - [ProductType](#producttype)<br>
 
@@ -103,6 +104,17 @@ import {
 
 const attributePlainEnumValue =
   AttributePlainEnumValue.random().build<TAttributePlainEnumValue>();
+```
+
+## `AttributeSetType`
+
+```ts
+import {
+  AttributeSetType,
+  type TAttributeSetType,
+} from '@commercetools-test-data/product-type';
+
+const attributeSetType = AttributeSetType.random().build<TAttributeSetType>();
 ```
 
 ## `AttributeTextType`

--- a/models/product-type/src/attribute-enum-type/builder.spec.ts
+++ b/models/product-type/src/attribute-enum-type/builder.spec.ts
@@ -34,7 +34,7 @@ describe('builder', () => {
       expect.objectContaining({
         name: 'enum',
         values: [],
-        __typename: 'AttributeEnumDefinitionType',
+        __typename: 'EnumAttributionDefinitionType',
       })
     )
   );

--- a/models/product-type/src/attribute-enum-type/transformers.ts
+++ b/models/product-type/src/attribute-enum-type/transformers.ts
@@ -13,7 +13,7 @@ const transformers = {
     {
       buildFields: [],
       addFields: ({ fields }) => ({
-        __typename: 'AttributeEnumDefinitionType',
+        __typename: 'EnumAttributionDefinitionType',
       }),
     }
   ),

--- a/models/product-type/src/attribute-enum-type/types.ts
+++ b/models/product-type/src/attribute-enum-type/types.ts
@@ -8,7 +8,7 @@ export type TAttributeEnumType = AttributeEnumType;
 export type TAttributeEnumTypeDraft = AttributeEnumType;
 
 export type TAttributeEnumTypeGraphql = AttributeEnumType & {
-  __typename: 'AttributeEnumDefinitionType';
+  __typename: 'EnumAttributionDefinitionType';
 };
 export type TAttributeEnumTypeDraftGraphql = {
   enum: { values: Array<AttributePlainEnumValue> };

--- a/models/product-type/src/attribute-localizable-text-type/builder.spec.ts
+++ b/models/product-type/src/attribute-localizable-text-type/builder.spec.ts
@@ -1,7 +1,10 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import { type TAttributeLocalizableTextType } from './types';
+import {
+  type TAttributeLocalizableTextType,
+  TAttributeLocalizableTextTypeGraphql,
+} from './types';
 import * as AttributeLocalizableTextType from './index';
 
 describe('builder', () => {
@@ -30,5 +33,18 @@ describe('builder', () => {
       })
     )
   );
-  //There are no graphql tests at this time
+
+  it(
+    ...createBuilderSpec<
+      TAttributeLocalizableTextType,
+      TAttributeLocalizableTextTypeGraphql
+    >(
+      'graphql',
+      AttributeLocalizableTextType.random(),
+      expect.objectContaining({
+        name: 'ltext',
+        __typename: 'LocalizableTextAttributeDefinitionType',
+      })
+    )
+  );
 });

--- a/models/product-type/src/attribute-localizable-text-type/transformers.ts
+++ b/models/product-type/src/attribute-localizable-text-type/transformers.ts
@@ -20,7 +20,7 @@ const transformers = {
   >('graphql', {
     buildFields: [],
     addFields: () => ({
-      __typename: 'AttributeLocalizableTextType',
+      __typename: 'LocalizableTextAttributeDefinitionType',
     }),
   }),
 };

--- a/models/product-type/src/attribute-localizable-text-type/types.ts
+++ b/models/product-type/src/attribute-localizable-text-type/types.ts
@@ -5,7 +5,7 @@ export type TAttributeLocalizableTextType = AttributeLocalizableTextType;
 
 export type TAttributeLocalizableTextTypeGraphql =
   TAttributeLocalizableTextType & {
-    __typename: 'AttributeLocalizableTextType';
+    __typename: 'LocalizableTextAttributeDefinitionType';
   };
 
 export type TAttributeLocalizableTextTypeBuilder =

--- a/models/product-type/src/attribute-set-type/attribute-set-type-draft/builder.spec.ts
+++ b/models/product-type/src/attribute-set-type/attribute-set-type-draft/builder.spec.ts
@@ -2,7 +2,6 @@
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import {
-  TAttributeSetType,
   TAttributeSetTypeDraft,
   TAttributeSetTypeDraftGraphql,
 } from '../types';
@@ -10,11 +9,10 @@ import * as AttributeEnumTypeDraft from './index';
 
 describe('builder', () => {
   it(
-    ...createBuilderSpec<TAttributeSetType, TAttributeSetTypeDraft>(
+    ...createBuilderSpec<TAttributeSetTypeDraft, TAttributeSetTypeDraft>(
       'default',
       AttributeEnumTypeDraft.random(),
       expect.objectContaining({
-        name: 'set',
         elementType: {
           name: 'boolean',
         },
@@ -23,7 +21,7 @@ describe('builder', () => {
   );
 
   it(
-    ...createBuilderSpec<TAttributeSetType, TAttributeSetTypeDraftGraphql>(
+    ...createBuilderSpec<TAttributeSetTypeDraft, TAttributeSetTypeDraftGraphql>(
       'graphql',
       AttributeEnumTypeDraft.random(),
       expect.objectContaining({

--- a/models/product-type/src/attribute-set-type/attribute-set-type-draft/builder.spec.ts
+++ b/models/product-type/src/attribute-set-type/attribute-set-type-draft/builder.spec.ts
@@ -1,0 +1,38 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import {
+  TAttributeSetType,
+  TAttributeSetTypeDraft,
+  TAttributeSetTypeDraftGraphql,
+} from '../types';
+import * as AttributeEnumTypeDraft from './index';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TAttributeSetType, TAttributeSetTypeDraft>(
+      'default',
+      AttributeEnumTypeDraft.random(),
+      expect.objectContaining({
+        name: 'set',
+        elementType: {
+          name: 'boolean',
+        },
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TAttributeSetType, TAttributeSetTypeDraftGraphql>(
+      'graphql',
+      AttributeEnumTypeDraft.random(),
+      expect.objectContaining({
+        elementType: {
+          boolean: {
+            dummy: null,
+          },
+        },
+      })
+    )
+  );
+});

--- a/models/product-type/src/attribute-set-type/attribute-set-type-draft/builder.ts
+++ b/models/product-type/src/attribute-set-type/attribute-set-type-draft/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import {
+  TAttributeSetTypeDraft,
+  TCreateAttributeSetTypeDraftBuilder,
+} from '../types';
+import { generator } from './generator';
+import transformers from './transformers';
+
+const Model: TCreateAttributeSetTypeDraftBuilder = () =>
+  Builder<TAttributeSetTypeDraft>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/product-type/src/attribute-set-type/attribute-set-type-draft/generator.ts
+++ b/models/product-type/src/attribute-set-type/attribute-set-type-draft/generator.ts
@@ -6,7 +6,6 @@ import { TAttributeSetTypeDraft } from '../types';
 
 export const generator = Generator<TAttributeSetTypeDraft>({
   fields: {
-    name: 'set',
     elementType: fake(() => AttributeBooleanTypeDraft.random()),
   },
 });

--- a/models/product-type/src/attribute-set-type/attribute-set-type-draft/generator.ts
+++ b/models/product-type/src/attribute-set-type/attribute-set-type-draft/generator.ts
@@ -1,0 +1,12 @@
+import { fake, Generator } from '@commercetools-test-data/core';
+import * as AttributeBooleanTypeDraft from '../../attribute-boolean-type/attribute-boolean-type-draft';
+import { TAttributeSetTypeDraft } from '../types';
+
+// https://docs.commercetools.com/api/projects/productTypes#attributesettype
+
+export const generator = Generator<TAttributeSetTypeDraft>({
+  fields: {
+    name: 'set',
+    elementType: fake(() => AttributeBooleanTypeDraft.random()),
+  },
+});

--- a/models/product-type/src/attribute-set-type/attribute-set-type-draft/index.ts
+++ b/models/product-type/src/attribute-set-type/attribute-set-type-draft/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/product-type/src/attribute-set-type/attribute-set-type-draft/presets/index.ts
+++ b/models/product-type/src/attribute-set-type/attribute-set-type-draft/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/product-type/src/attribute-set-type/attribute-set-type-draft/transformers.ts
+++ b/models/product-type/src/attribute-set-type/attribute-set-type-draft/transformers.ts
@@ -1,0 +1,22 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TAttributeSetTypeDraft,
+  TAttributeSetTypeDraftGraphql,
+} from '../types';
+
+const transformers = {
+  default: Transformer<TAttributeSetTypeDraft, TAttributeSetTypeDraft>(
+    'default',
+    {
+      buildFields: ['elementType'],
+    }
+  ),
+  graphql: Transformer<TAttributeSetTypeDraft, TAttributeSetTypeDraftGraphql>(
+    'graphql',
+    {
+      buildFields: ['elementType'],
+    }
+  ),
+};
+
+export default transformers;

--- a/models/product-type/src/attribute-set-type/builder.spec.ts
+++ b/models/product-type/src/attribute-set-type/builder.spec.ts
@@ -1,0 +1,48 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { type TAttributeSetType, TAttributeSetTypeGraphql } from './types';
+import * as AttributeSetType from './index';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TAttributeSetType, TAttributeSetType>(
+      'default',
+      AttributeSetType.random(),
+      expect.objectContaining({
+        name: 'set',
+        elementType: {
+          name: 'boolean',
+        },
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TAttributeSetType, TAttributeSetType>(
+      'rest',
+      AttributeSetType.random(),
+      expect.objectContaining({
+        name: 'set',
+        elementType: {
+          name: 'boolean',
+        },
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TAttributeSetType, TAttributeSetTypeGraphql>(
+      'graphql',
+      AttributeSetType.random(),
+      expect.objectContaining({
+        name: 'set',
+        elementType: {
+          name: 'boolean',
+          __typename: 'BooleanAttributeDefinitionType',
+        },
+        __typename: 'SetAttributeDefinitionType',
+      })
+    )
+  );
+});

--- a/models/product-type/src/attribute-set-type/builder.ts
+++ b/models/product-type/src/attribute-set-type/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import { TAttributeSetType, TCreateAttributeSetTypeBuilder } from './types';
+
+const Model: TCreateAttributeSetTypeBuilder = () =>
+  Builder<TAttributeSetType>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/product-type/src/attribute-set-type/generator.ts
+++ b/models/product-type/src/attribute-set-type/generator.ts
@@ -1,0 +1,14 @@
+import { fake, Generator } from '@commercetools-test-data/core';
+import * as AttributeBooleanType from '../attribute-boolean-type';
+import { TAttributeSetType } from './types';
+
+// https://docs.commercetools.com/api/projects/productTypes#attributesettype
+
+const generator = Generator<TAttributeSetType>({
+  fields: {
+    name: 'set',
+    elementType: fake(() => AttributeBooleanType.random()),
+  },
+});
+
+export default generator;

--- a/models/product-type/src/attribute-set-type/index.ts
+++ b/models/product-type/src/attribute-set-type/index.ts
@@ -1,0 +1,3 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+export * from './types';

--- a/models/product-type/src/attribute-set-type/presets/index.ts
+++ b/models/product-type/src/attribute-set-type/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/product-type/src/attribute-set-type/transformers.ts
+++ b/models/product-type/src/attribute-set-type/transformers.ts
@@ -1,0 +1,20 @@
+import { Transformer } from '@commercetools-test-data/core';
+import { type TAttributeSetType, type TAttributeSetTypeGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TAttributeSetType, TAttributeSetType>('default', {
+    buildFields: ['elementType'],
+  }),
+
+  rest: Transformer<TAttributeSetType, TAttributeSetType>('rest', {
+    buildFields: ['elementType'],
+  }),
+  graphql: Transformer<TAttributeSetType, TAttributeSetTypeGraphql>('graphql', {
+    buildFields: ['elementType'],
+    addFields: () => ({
+      __typename: 'SetAttributeDefinitionType',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/product-type/src/attribute-set-type/types.ts
+++ b/models/product-type/src/attribute-set-type/types.ts
@@ -1,0 +1,19 @@
+import { AttributeSetType, AttributeType } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@commercetools-test-data/core';
+
+export type TAttributeSetType = AttributeSetType;
+export type TAttributeSetTypeDraft = AttributeSetType;
+
+export type TAttributeSetTypeGraphql = TAttributeSetType & {
+  __typename: 'SetAttributeDefinitionType';
+};
+export type TAttributeSetTypeDraftGraphql = {
+  elementType: AttributeType;
+};
+
+export type TAttributeSetTypeBuilder = TBuilder<TAttributeSetType>;
+export type TAttributeSetTypeDraftBuilder = TBuilder<TAttributeSetType>;
+
+export type TCreateAttributeSetTypeBuilder = () => TAttributeSetTypeBuilder;
+export type TCreateAttributeSetTypeDraftBuilder =
+  () => TAttributeSetTypeDraftBuilder;

--- a/models/product-type/src/attribute-set-type/types.ts
+++ b/models/product-type/src/attribute-set-type/types.ts
@@ -1,18 +1,16 @@
-import { AttributeSetType, AttributeType } from '@commercetools/platform-sdk';
+import { AttributeSetType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TAttributeSetType = AttributeSetType;
-export type TAttributeSetTypeDraft = AttributeSetType;
+export type TAttributeSetTypeDraft = Omit<AttributeSetType, 'name'>;
 
 export type TAttributeSetTypeGraphql = TAttributeSetType & {
   __typename: 'SetAttributeDefinitionType';
 };
-export type TAttributeSetTypeDraftGraphql = {
-  elementType: AttributeType;
-};
+export type TAttributeSetTypeDraftGraphql = TAttributeSetTypeDraft;
 
 export type TAttributeSetTypeBuilder = TBuilder<TAttributeSetType>;
-export type TAttributeSetTypeDraftBuilder = TBuilder<TAttributeSetType>;
+export type TAttributeSetTypeDraftBuilder = TBuilder<TAttributeSetTypeDraft>;
 
 export type TCreateAttributeSetTypeBuilder = () => TAttributeSetTypeBuilder;
 export type TCreateAttributeSetTypeDraftBuilder =

--- a/models/product-type/src/index.ts
+++ b/models/product-type/src/index.ts
@@ -5,6 +5,7 @@ export * from './attribute-enum-type/types';
 export * from './attribute-localized-enum-value/types';
 export * from './attribute-localizable-text-type/types';
 export * from './attribute-plain-enum-value/types';
+export * from './attribute-set-type/types';
 export * from './attribute-text-type/types';
 export * from './product-type/types';
 
@@ -18,6 +19,8 @@ export * as AttributeEnumType from './attribute-enum-type';
 export * as AttributeEnumTypeDraft from './attribute-enum-type/attribute-enum-type-draft';
 export * as AttributeLocalizedEnumValue from './attribute-localized-enum-value';
 export * as AttributeLocalizableTextType from './attribute-localizable-text-type';
+export * as AttributeSetType from './attribute-set-type';
+export * as AttributeSetTypeDraft from './attribute-set-type/attribute-set-type-draft';
 export * as AttributeTextType from './attribute-text-type';
 export * as AttributeTextTypeDraft from './attribute-text-type/attribute-text-type-draft';
 export * as ProductType from './product-type';


### PR DESCRIPTION
#### Summary
- Create attribute set type and draft models
- Cleaned up GraphQL type names for various other attribute types