### PR TITLE
feat(models/product-type): add `AttributeLocalizedEnumType`, `AttributeLocalizedEnumTypeDraft`, and `AttributeLocalizedEnumValueDraft` models

### DIFF
--- a/.changeset/light-seas-sort.md
+++ b/.changeset/light-seas-sort.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product-type': minor
+---
+
+Add `AttributeLocalizedEnumType`, `AttributeLocalizedEnumTypeDraft`, and `AttributeLocalizedEnumValueDraft` models.

--- a/models/product-type/README.md
+++ b/models/product-type/README.md
@@ -15,6 +15,7 @@ $ pnpm add -D @commercetools-test-data/product-type
 - [AttributeBooleanType](#attributebooleantype)<br>
 - [AttributeDefinition](#attributedefinition)<br>
 - [AttributeEnumType](#attributeenumtype)<br>
+- [AttributeLocalizedEnumType](#attributelocalizedenumtype)<br>
 - [AttributeLocalizedEnumValue](#attributelocalizedenumvalue)<br>
 - [attributeLocalizableTextType](#attributelocalizabletexttype)<br>
 - [AttributePlainEnumValue](#attributeplainenumvalue)<br>
@@ -65,6 +66,19 @@ import {
 
 const attributeEnumType =
   AttributeEnumType.random().build<TAttributeEnumType>();
+```
+
+## `AttributeLocalizedEnumType`
+
+```ts
+import {
+  AttributeLocalizedEnumType,
+  type TAttributeLocalizedEnumType,
+  type TAttributeLocalizedEnumValueGraphql,
+} from '@commercetools-test-data/product-type';
+
+const attributeLocalizedEnumType =
+  AttributePLocalizedEnumType.random().build<TAttributeLocalizedEnumValue>();
 ```
 
 ## `AttributeLocalizedEnumValue`

--- a/models/product-type/src/attribute-boolean-type/attribute-boolean-type-draft/generator.ts
+++ b/models/product-type/src/attribute-boolean-type/attribute-boolean-type-draft/generator.ts
@@ -1,7 +1,7 @@
 import { Generator } from '@commercetools-test-data/core';
 import { TAttributeBooleanTypeDraft } from '../types';
 
-// https://docs.commercetools.com/api/projects/productTypes#attributeenumtype
+// https://docs.commercetools.com/api/projects/productTypes#attributebooleantype
 
 export const generator = Generator<TAttributeBooleanTypeDraft>({
   fields: {

--- a/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/builder.spec.ts
+++ b/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/builder.spec.ts
@@ -1,0 +1,55 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import {
+  TAttributeLocalizedEnumTypeDraft,
+  TAttributeLocalizedEnumTypeDraftGraphql,
+} from '../types';
+import * as AttributeLocalizedEnumTypeDraft from './index';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<
+      TAttributeLocalizedEnumTypeDraft,
+      TAttributeLocalizedEnumTypeDraft
+    >(
+      'default',
+      AttributeLocalizedEnumTypeDraft.random(),
+      expect.objectContaining({
+        values: [
+          expect.objectContaining({
+            key: expect.any(String),
+            label: expect.objectContaining({
+              de: expect.any(String),
+              en: expect.any(String),
+              fr: expect.any(String),
+            }),
+          }),
+        ],
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<
+      TAttributeLocalizedEnumTypeDraft,
+      TAttributeLocalizedEnumTypeDraftGraphql
+    >(
+      'graphql',
+      AttributeLocalizedEnumTypeDraft.random(),
+      expect.objectContaining({
+        values: [
+          expect.objectContaining({
+            key: expect.any(String),
+            label: expect.arrayContaining([
+              expect.objectContaining({
+                locale: 'en',
+                value: expect.any(String),
+              }),
+            ]),
+          }),
+        ],
+      })
+    )
+  );
+});

--- a/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/builder.ts
+++ b/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import {
+  TAttributeLocalizedEnumTypeDraft,
+  TCreateAttributeLocalizedEnumTypeDraftBuilder,
+} from '../types';
+import { generator } from './generator';
+import transformers from './transformers';
+
+const Model: TCreateAttributeLocalizedEnumTypeDraftBuilder = () =>
+  Builder<TAttributeLocalizedEnumTypeDraft>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/generator.ts
+++ b/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/generator.ts
@@ -1,0 +1,11 @@
+import { fake, Generator } from '@commercetools-test-data/core';
+import * as AttributeLocalizedEnumValueDraft from '../../attribute-localized-enum-value/attribute-localized-enum-value-draft';
+import { TAttributeLocalizedEnumTypeDraft } from '../types';
+
+// https://docs.commercetools.com/api/projects/productTypes#attributelocalizedenumtype
+
+export const generator = Generator<TAttributeLocalizedEnumTypeDraft>({
+  fields: {
+    values: fake(() => [AttributeLocalizedEnumValueDraft.random()]),
+  },
+});

--- a/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/index.ts
+++ b/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/presets/index.ts
+++ b/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/transformers.ts
+++ b/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/transformers.ts
@@ -1,0 +1,22 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TAttributeLocalizedEnumTypeDraftGraphql,
+  TAttributeLocalizedEnumTypeDraft,
+} from '../types';
+
+const transformers = {
+  default: Transformer<
+    TAttributeLocalizedEnumTypeDraft,
+    TAttributeLocalizedEnumTypeDraft
+  >('default', {
+    buildFields: ['values'],
+  }),
+  graphql: Transformer<
+    TAttributeLocalizedEnumTypeDraft,
+    TAttributeLocalizedEnumTypeDraftGraphql
+  >('graphql', {
+    buildFields: ['values'],
+  }),
+};
+
+export default transformers;

--- a/models/product-type/src/attribute-localized-enum-type/builder.spec.ts
+++ b/models/product-type/src/attribute-localized-enum-type/builder.spec.ts
@@ -1,0 +1,83 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { type TAttributeLocalizedEnumType } from './types';
+import * as AttributeLocalizedEnumType from './index';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<
+      TAttributeLocalizedEnumType,
+      TAttributeLocalizedEnumType
+    >(
+      'default',
+      AttributeLocalizedEnumType.random(),
+      expect.objectContaining({
+        name: 'lenum',
+        values: [
+          expect.objectContaining({
+            key: expect.any(String),
+            label: expect.objectContaining({
+              de: expect.any(String),
+              en: expect.any(String),
+              fr: expect.any(String),
+            }),
+          }),
+        ],
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<
+      TAttributeLocalizedEnumType,
+      TAttributeLocalizedEnumType
+    >(
+      'rest',
+      AttributeLocalizedEnumType.random(),
+      expect.objectContaining({
+        name: 'lenum',
+        values: [
+          expect.objectContaining({
+            key: expect.any(String),
+            label: expect.objectContaining({
+              de: expect.any(String),
+              en: expect.any(String),
+              fr: expect.any(String),
+            }),
+          }),
+        ],
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<
+      TAttributeLocalizedEnumType,
+      TAttributeLocalizedEnumType
+    >(
+      'graphql',
+      AttributeLocalizedEnumType.random(),
+      expect.objectContaining({
+        name: 'lenum',
+        values: expect.objectContaining({
+          results: [
+            expect.objectContaining({
+              key: expect.any(String),
+              labelAllLocales: expect.arrayContaining([
+                expect.objectContaining({
+                  locale: 'en',
+                  value: expect.any(String),
+                  __typename: 'LocalizedString',
+                }),
+              ]),
+              __typename: 'LocalizableEnumValueType',
+            }),
+          ],
+          __typename: 'LocalizableEnumValueTypeResult',
+        }),
+        __typename: 'LocalizableEnumAttributeDefinitionType',
+      })
+    )
+  );
+});

--- a/models/product-type/src/attribute-localized-enum-type/builder.ts
+++ b/models/product-type/src/attribute-localized-enum-type/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TAttributeLocalizedEnumType,
+  TCreateAttributeLocalizedEnumTypeBuilder,
+} from './types';
+
+const Model: TCreateAttributeLocalizedEnumTypeBuilder = () =>
+  Builder<TAttributeLocalizedEnumType>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/product-type/src/attribute-localized-enum-type/generator.ts
+++ b/models/product-type/src/attribute-localized-enum-type/generator.ts
@@ -1,0 +1,14 @@
+import { fake, Generator } from '@commercetools-test-data/core';
+import * as AttributeLocalizedEnumValue from '../attribute-localized-enum-value';
+import { TAttributeLocalizedEnumType } from './types';
+
+// https://docs.commercetools.com/api/projects/productTypes#attributelocalizedenumtype
+
+const generator = Generator<TAttributeLocalizedEnumType>({
+  fields: {
+    name: 'lenum',
+    values: fake(() => [AttributeLocalizedEnumValue.random()]),
+  },
+});
+
+export default generator;

--- a/models/product-type/src/attribute-localized-enum-type/index.ts
+++ b/models/product-type/src/attribute-localized-enum-type/index.ts
@@ -1,0 +1,3 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+export * from './types';

--- a/models/product-type/src/attribute-localized-enum-type/presets/index.ts
+++ b/models/product-type/src/attribute-localized-enum-type/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/product-type/src/attribute-localized-enum-type/transformers.ts
+++ b/models/product-type/src/attribute-localized-enum-type/transformers.ts
@@ -1,0 +1,35 @@
+import { buildField, Transformer } from '@commercetools-test-data/core';
+import { TAttributeLocalizedEnumValueGraphql } from '../attribute-localized-enum-value';
+import {
+  type TAttributeLocalizedEnumType,
+  type TAttributeLocalizedEnumTypeGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<
+    TAttributeLocalizedEnumType,
+    TAttributeLocalizedEnumType
+  >('default', { buildFields: ['values'] }),
+  rest: Transformer<TAttributeLocalizedEnumType, TAttributeLocalizedEnumType>(
+    'rest',
+    { buildFields: ['values'] }
+  ),
+  graphql: Transformer<
+    TAttributeLocalizedEnumType,
+    TAttributeLocalizedEnumTypeGraphql
+  >('graphql', {
+    buildFields: [],
+    replaceFields: ({ fields }) => ({
+      ...fields,
+      values: {
+        results: fields.values!.map((value) =>
+          buildField(value, 'graphql')
+        ) as unknown as Array<TAttributeLocalizedEnumValueGraphql>,
+        __typename: 'LocalizableEnumValueTypeResult',
+      },
+      __typename: 'LocalizableEnumAttributeDefinitionType',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/product-type/src/attribute-localized-enum-type/types.ts
+++ b/models/product-type/src/attribute-localized-enum-type/types.ts
@@ -1,0 +1,36 @@
+import { AttributeLocalizedEnumType } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@commercetools-test-data/core';
+import {
+  TAttributeLocalizedEnumValueDraftGraphql,
+  TAttributeLocalizedEnumValueGraphql,
+} from '../attribute-localized-enum-value';
+
+export type TAttributeLocalizedEnumType = AttributeLocalizedEnumType;
+export type TAttributeLocalizedEnumTypeDraft = Omit<
+  AttributeLocalizedEnumType,
+  'name'
+>;
+
+export type TAttributeLocalizedEnumTypeGraphql = Omit<
+  TAttributeLocalizedEnumType,
+  'values'
+> & {
+  values: {
+    results: Array<TAttributeLocalizedEnumValueGraphql>;
+    __typename: 'LocalizableEnumValueTypeResult';
+  };
+  __typename: 'LocalizableEnumAttributeDefinitionType';
+};
+export type TAttributeLocalizedEnumTypeDraftGraphql = {
+  values: Array<TAttributeLocalizedEnumValueDraftGraphql>;
+};
+
+export type TAttributeLocalizedEnumTypeBuilder =
+  TBuilder<TAttributeLocalizedEnumType>;
+export type TAttributeLocalizedEnumTypeDraftBuilder =
+  TBuilder<TAttributeLocalizedEnumTypeDraft>;
+
+export type TCreateAttributeLocalizedEnumTypeBuilder =
+  () => TAttributeLocalizedEnumTypeBuilder;
+export type TCreateAttributeLocalizedEnumTypeDraftBuilder =
+  () => TAttributeLocalizedEnumTypeDraftBuilder;

--- a/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/builder.spec.ts
+++ b/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/builder.spec.ts
@@ -1,0 +1,45 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import {
+  TAttributeLocalizedEnumValue,
+  TAttributeLocalizedEnumValueDraft,
+  TAttributeLocalizedEnumValueDraftGraphql,
+} from '../types';
+import * as AttributeLocalizedEnumValueDraft from './index';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<
+      TAttributeLocalizedEnumValue,
+      TAttributeLocalizedEnumValueDraft
+    >(
+      'default',
+      AttributeLocalizedEnumValueDraft.random(),
+      expect.objectContaining({
+        key: expect.any(String),
+        label: expect.objectContaining({
+          de: expect.any(String),
+          en: expect.any(String),
+          fr: expect.any(String),
+        }),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<
+      TAttributeLocalizedEnumValue,
+      TAttributeLocalizedEnumValueDraftGraphql
+    >(
+      'graphql',
+      AttributeLocalizedEnumValueDraft.random(),
+      expect.objectContaining({
+        key: expect.any(String),
+        label: expect.arrayContaining([
+          expect.objectContaining({ locale: 'en', value: expect.any(String) }),
+        ]),
+      })
+    )
+  );
+});

--- a/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/builder.ts
+++ b/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import {
+  TAttributeLocalizedEnumValueDraft,
+  TCreateAttributeLocalizedEnumValueDraftBuilder,
+} from '../types';
+import { generator } from './generator';
+import transformers from './transformers';
+
+const Model: TCreateAttributeLocalizedEnumValueDraftBuilder = () =>
+  Builder<TAttributeLocalizedEnumValueDraft>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/generator.ts
+++ b/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/generator.ts
@@ -1,0 +1,12 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { fake, Generator } from '@commercetools-test-data/core';
+import { TAttributeLocalizedEnumValueDraft } from '../types';
+
+// https://docs.commercetools.com/api/projects/productTypes#attributelocalizedenumvalue
+
+export const generator = Generator<TAttributeLocalizedEnumValueDraft>({
+  fields: {
+    key: fake((f) => f.lorem.slug(2)),
+    label: fake(() => LocalizedString.random()),
+  },
+});

--- a/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/index.ts
+++ b/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/presets/index.ts
+++ b/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/transformers.ts
+++ b/models/product-type/src/attribute-localized-enum-value/attribute-localized-enum-value-draft/transformers.ts
@@ -1,0 +1,25 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  type TAttributeLocalizedEnumValueDraft,
+  type TAttributeLocalizedEnumValueDraftGraphql,
+} from '../types';
+
+const transformers = {
+  default: Transformer<
+    TAttributeLocalizedEnumValueDraft,
+    TAttributeLocalizedEnumValueDraft
+  >('default', { buildFields: ['label'] }),
+
+  rest: Transformer<
+    TAttributeLocalizedEnumValueDraft,
+    TAttributeLocalizedEnumValueDraft
+  >('rest', { buildFields: ['label'] }),
+  graphql: Transformer<
+    TAttributeLocalizedEnumValueDraft,
+    TAttributeLocalizedEnumValueDraftGraphql
+  >('graphql', {
+    buildFields: ['label'],
+  }),
+};
+
+export default transformers;

--- a/models/product-type/src/attribute-localized-enum-value/builder.spec.ts
+++ b/models/product-type/src/attribute-localized-enum-value/builder.spec.ts
@@ -1,7 +1,10 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import { type TAttributeLocalizedEnumValue } from './types';
+import {
+  type TAttributeLocalizedEnumValue,
+  TAttributeLocalizedEnumValueGraphql,
+} from './types';
 import * as AttributeLocalizedEnumValue from './index';
 
 describe('builder', () => {
@@ -41,5 +44,24 @@ describe('builder', () => {
     )
   );
 
-  //There are no graphql tests at this time
+  it(
+    ...createBuilderSpec<
+      TAttributeLocalizedEnumValue,
+      TAttributeLocalizedEnumValueGraphql
+    >(
+      'graphql',
+      AttributeLocalizedEnumValue.random(),
+      expect.objectContaining({
+        key: expect.any(String),
+        labelAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        __typename: 'LocalizableEnumValueType',
+      })
+    )
+  );
 });

--- a/models/product-type/src/attribute-localized-enum-value/transformers.ts
+++ b/models/product-type/src/attribute-localized-enum-value/transformers.ts
@@ -1,3 +1,4 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import {
   type TAttributeLocalizedEnumValue,
@@ -9,7 +10,6 @@ const transformers = {
     TAttributeLocalizedEnumValue,
     TAttributeLocalizedEnumValue
   >('default', { buildFields: ['label'] }),
-
   rest: Transformer<TAttributeLocalizedEnumValue, TAttributeLocalizedEnumValue>(
     'rest',
     { buildFields: ['label'] }
@@ -19,8 +19,10 @@ const transformers = {
     TAttributeLocalizedEnumValueGraphql
   >('graphql', {
     buildFields: [],
-    addFields: () => ({
-      __typename: 'AttributeLocalizedEnumValue',
+    removeFields: ['label'],
+    addFields: ({ fields }) => ({
+      labelAllLocales: LocalizedString.toLocalizedField(fields.label),
+      __typename: 'LocalizableEnumValueType',
     }),
   }),
 };

--- a/models/product-type/src/attribute-localized-enum-value/types.ts
+++ b/models/product-type/src/attribute-localized-enum-value/types.ts
@@ -1,14 +1,27 @@
 import { AttributeLocalizedEnumValue } from '@commercetools/platform-sdk';
+import { TLocalizedStringGraphql } from '@commercetools-test-data/commons/src';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TAttributeLocalizedEnumValue = AttributeLocalizedEnumValue;
+export type TAttributeLocalizedEnumValueDraft = AttributeLocalizedEnumValue;
 
-export type TAttributeLocalizedEnumValueGraphql =
-  TAttributeLocalizedEnumValue & {
-    __typename: 'AttributeLocalizedEnumValue';
-  };
+export type TAttributeLocalizedEnumValueGraphql = Omit<
+  TAttributeLocalizedEnumValue,
+  // In GraphQL, we prefer to use `nameAllLocales` instead of `name`.
+  'label'
+> & {
+  labelAllLocales: TLocalizedStringGraphql | null;
+  __typename: 'LocalizableEnumValueType';
+};
+export type TAttributeLocalizedEnumValueDraftGraphql =
+  TAttributeLocalizedEnumValueDraft;
 
 export type TAttributeLocalizedEnumValueBuilder =
   TBuilder<TAttributeLocalizedEnumValue>;
+export type TAttributeLocalizedEnumValueDraftBuilder =
+  TBuilder<TAttributeLocalizedEnumValueDraft>;
+
 export type TCreateAttributeLocalizedEnumValueBuilder =
   () => TAttributeLocalizedEnumValueBuilder;
+export type TCreateAttributeLocalizedEnumValueDraftBuilder =
+  () => TAttributeLocalizedEnumValueDraftBuilder;

--- a/models/product-type/src/index.ts
+++ b/models/product-type/src/index.ts
@@ -2,6 +2,7 @@
 export * from './attribute-boolean-type/types';
 export * from './attribute-definition/types';
 export * from './attribute-enum-type/types';
+export * from './attribute-localized-enum-type/types';
 export * from './attribute-localized-enum-value/types';
 export * from './attribute-localizable-text-type/types';
 export * from './attribute-plain-enum-value/types';
@@ -16,6 +17,8 @@ export * as AttributeDefinitionDraft from './attribute-definition/attribute-defi
 export * as AttributePlainEnumValue from './attribute-plain-enum-value';
 export * as AttributeEnumType from './attribute-enum-type';
 export * as AttributeEnumTypeDraft from './attribute-enum-type/attribute-enum-type-draft';
+export * as AttributeLocalizedEnumType from './attribute-localized-enum-type';
+export * as AttributeLocalizedEnumTypeDraft from './attribute-localized-enum-type/attribute-localized-enum-type-draft';
 export * as AttributeLocalizedEnumValue from './attribute-localized-enum-value';
 export * as AttributeLocalizableTextType from './attribute-localizable-text-type';
 export * as AttributeTextType from './attribute-text-type';

--- a/models/product-type/src/product-type/product-type-draft/generator.ts
+++ b/models/product-type/src/product-type/product-type-draft/generator.ts
@@ -1,5 +1,5 @@
-import { AttributeDefinitionDraft } from '@commercetools-test-data/attribute-definition';
 import { fake, Generator } from '@commercetools-test-data/core';
+import { AttributeDefinitionDraft } from '../../';
 import type { TProductTypeDraft } from '../types';
 
 // https://docs.commercetools.com/api/projects/productTypes#producttypedraft

--- a/models/product-type/src/product-type/product-type-draft/transformers.ts
+++ b/models/product-type/src/product-type/product-type-draft/transformers.ts
@@ -1,5 +1,5 @@
-import { TAttributeDefinitionDraftGraphql } from '@commercetools-test-data/attribute-definition';
 import { buildField, Transformer } from '@commercetools-test-data/core';
+import { TAttributeDefinitionDraftGraphql } from '../../attribute-definition';
 import type { TProductTypeDraft, TProductTypeDraftGraphql } from '../types';
 
 const transformers = {

--- a/models/product-type/src/product-type/transformers.ts
+++ b/models/product-type/src/product-type/transformers.ts
@@ -1,5 +1,5 @@
-import { TAttributeDefinitionGraphql } from '@commercetools-test-data/attribute-definition';
 import { Transformer, buildField } from '@commercetools-test-data/core';
+import { TAttributeDefinitionGraphql } from '../attribute-definition';
 import type { TProductType, TProductTypeGraphql } from './types';
 
 const transformers = {
@@ -11,17 +11,15 @@ const transformers = {
   }),
   graphql: Transformer<TProductType, TProductTypeGraphql>('graphql', {
     buildFields: ['createdBy', 'lastModifiedBy'],
-    addFields: ({ fields }) => {
-      return {
-        __typename: 'ProductTypeDefinition',
-        attributeDefinitions: {
-          results: fields.attributes!.map((attribute) =>
-            buildField(attribute)
-          ) as Array<TAttributeDefinitionGraphql>,
-          __typename: 'AttributeDefinitionResult',
-        },
-      };
-    },
+    addFields: ({ fields }) => ({
+      __typename: 'ProductTypeDefinition',
+      attributeDefinitions: {
+        results: fields.attributes!.map((attribute) =>
+          buildField(attribute, 'graphql')
+        ) as Array<TAttributeDefinitionGraphql>,
+        __typename: 'AttributeDefinitionResult',
+      },
+    }),
   }),
 };
 

--- a/models/product-type/src/product-type/types.ts
+++ b/models/product-type/src/product-type/types.ts
@@ -1,9 +1,9 @@
 import { ProductType, ProductTypeDraft } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@commercetools-test-data/core';
 import {
   TAttributeDefinitionGraphql,
   TAttributeDefinitionDraftGraphql,
-} from '@commercetools-test-data/attribute-definition';
-import type { TBuilder } from '@commercetools-test-data/core';
+} from '../attribute-definition';
 
 export type TProductType = ProductType;
 


### PR DESCRIPTION
#### Summary
- Added `AttributeLocalizedEnumType` and `AttributeLocalizedEnumTypeDraft` models
- Added `AttributeLocalizedEnumValueDraft` for type draft model support
- Cleaned up imports in `product-type` directory