### PR TITLE
feat(tax category): edit goodstore presets to include US

### DIFF
--- a/.changeset/happy-comics-think.md
+++ b/.changeset/happy-comics-think.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/tax-category': minor
+---
+
+Updated goodstore tax presets to include the USA

--- a/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-goodstore/index.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-goodstore/index.ts
@@ -1,6 +1,7 @@
 import EUTaxCategory from './eu-tax-category';
 import EU2TaxCategory from './eu2-tax-category';
+import USTaxCategory from './us-tax-category';
 
-const presets = { EUTaxCategory, EU2TaxCategory };
+const presets = { EUTaxCategory, EU2TaxCategory, USTaxCategory };
 
 export default presets;

--- a/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-goodstore/us-tax-category.spec.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-goodstore/us-tax-category.spec.ts
@@ -1,0 +1,67 @@
+import type {
+  TTaxCategoryDraft,
+  TTaxCategoryDraftGraphql,
+} from '../../../types';
+import USTaxCategory from './us-tax-category';
+
+describe('with a tax rate preset `us tax category`', () => {
+  it('should return a tax category with name `US Tax Category` and 2 tax rates', () => {
+    const taxCategory = USTaxCategory().build<TTaxCategoryDraft>();
+
+    expect(taxCategory).toMatchInlineSnapshot(`
+      {
+        "description": undefined,
+        "key": "us-tax",
+        "name": "US Tax Category",
+        "rates": [
+          {
+            "amount": 0.04,
+            "country": "US",
+            "includedInPrice": false,
+            "name": "NY Sales Tax",
+            "state": "New York",
+            "subRates": [],
+          },
+          {
+            "amount": 0.0475,
+            "country": "US",
+            "includedInPrice": false,
+            "name": "NC Sales Tax",
+            "state": "North Carolina",
+            "subRates": [],
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should return a tax category with name `US Tax Category` when built for graphql', () => {
+    const taxCategoryGraphql =
+      USTaxCategory().buildGraphql<TTaxCategoryDraftGraphql>();
+    expect(taxCategoryGraphql).toMatchInlineSnapshot(`
+      {
+        "description": undefined,
+        "key": "us-tax",
+        "name": "US Tax Category",
+        "rates": [
+          {
+            "amount": 0.04,
+            "country": "US",
+            "includedInPrice": false,
+            "name": "NY Sales Tax",
+            "state": "New York",
+            "subRates": [],
+          },
+          {
+            "amount": 0.0475,
+            "country": "US",
+            "includedInPrice": false,
+            "name": "NC Sales Tax",
+            "state": "North Carolina",
+            "subRates": [],
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-goodstore/us-tax-category.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-goodstore/us-tax-category.ts
@@ -1,0 +1,28 @@
+import * as TaxRateDraft from '../../../../tax-rate/tax-rate-draft';
+import * as TaxCategoryDraft from '../../index';
+
+const USTaxCategory = () =>
+  TaxCategoryDraft.presets
+    .empty()
+    .key('us-tax')
+    .name('US Tax Category')
+    .rates([
+      TaxRateDraft.presets
+        .empty()
+        .name('NY Sales Tax')
+        .amount(0.04)
+        .includedInPrice(false)
+        .country('US')
+        .state('New York')
+        .subRates([]),
+      TaxRateDraft.presets
+        .empty()
+        .name('NC Sales Tax')
+        .amount(0.0475)
+        .includedInPrice(false)
+        .country('US')
+        .state('North Carolina')
+        .subRates([]),
+    ]);
+
+export default USTaxCategory;


### PR DESCRIPTION
Added US to the goodstore tax presets. The two US customers are from NY and NC, therefore only the two state taxes were added.