### PR TITLE
refactor(ci): to use github app auth over long-lived credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+       # Get GitHub token via the CT Changesets App
+      - name: Generate GitHub token (via CT Changesets App)
+        id: generate_github_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+          
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          # Pass a personal access token (using our `ct-release-bot` account) to be able to trigger
-          # other workflows
+          # Pass a personal access token (using our `ct-changesets` app) to be able to trigger other workflows
           # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
           # https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/8
-          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          token: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2.4.0
@@ -54,7 +61,7 @@ jobs:
           version: pnpm changeset:version-and-format
           commit: 'ci(changesets): version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
 
       # Publish canary releases only if the packages weren't published already
       - name: Publishing canary releases to npm registry
@@ -64,4 +71,4 @@ jobs:
           pnpm changeset version --snapshot canary
           pnpm changeset publish --tag canary
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}


### PR DESCRIPTION
## Summary

This refactors the authentication for the GitHub PAT for releasing via Changesets from a long-lived static credential to a short-lived dynamic credential issues through a GitHub App.

More information can be found in internal documentation or repositories.