### PR TITLE
chore(test-data): create product presets for GoodStore data (21-40)

### DIFF
--- a/.changeset/selfish-windows-know.md
+++ b/.changeset/selfish-windows-know.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/category': minor
+'@commercetools-test-data/product': minor
+---
+
+Include sample-data-goodstore product presets (21-40)

--- a/models/category/src/category-draft/presets/sample-data-goodstore/index.ts
+++ b/models/category/src/category-draft/presets/sample-data-goodstore/index.ts
@@ -1,7 +1,7 @@
 import armchairs from './armchairs';
 import bakeware from './bakeware';
 import barAccessories from './bar-accessories';
-import barGlassware from './bar-and-glassware';
+import barAndGlassware from './bar-and-glassware';
 import bedding from './bedding';
 import bedroomFurniture from './bedroom-furniture';
 import beds from './beds';
@@ -32,7 +32,7 @@ const presets = {
   armchairs,
   bakeware,
   barAccessories,
-  barGlassware,
+  barAndGlassware,
   bedding,
   bedroomFurniture,
   beds,

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cobblestone-rug-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cobblestone-rug-01.spec.ts
@@ -1,0 +1,182 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cobblestoneRug01 from './cobblestone-rug-01';
+
+describe(`with cobblestoneRug01 preset`, () => {
+  it(`should return a cobblestoneRug01 preset`, () => {
+    const cobblestoneRug01Preset =
+      cobblestoneRug01().build<TProductVariantDraft>();
+    expect(cobblestoneRug01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#808080",
+              "label": {
+                "de-DE": "Grau",
+                "en-GB": "Gray",
+                "en-US": "Gray",
+              },
+            },
+          },
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- 5 Fuß x 3 Fuß",
+              "en-GB": "- 5ft x 3ft",
+              "en-US": "- 5ft x 3ft",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 2820,
+              "w": 7006,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Cobblestone%20Rug-n-Cz7uBo.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 12999,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 12999,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 12999,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CR-098",
+      }
+    `);
+  });
+
+  it(`should return a cobblestoneRug01 preset when built for graphql`, () => {
+    const cobblestoneRug01PresetGraphql =
+      cobblestoneRug01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cobblestoneRug01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "color-filter",
+            "value": "{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}",
+          },
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- 5ft x 3ft","de-DE":"- 5 Fuß x 3 Fuß","en-US":"- 5ft x 3ft"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 2820,
+              "width": 7006,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Cobblestone%20Rug-n-Cz7uBo.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 12999,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 12999,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 12999,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CR-098",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cobblestone-rug-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cobblestone-rug-01.ts
@@ -1,0 +1,59 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cobblestoneRug01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CR-098')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(12999))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(12999))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(12999))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Cobblestone%20Rug-n-Cz7uBo.jpeg'
+        )
+        .dimensions({ w: 7006, h: 2820 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'de-DE':
+            'Der Cobblestone-Teppich kann in einer Vielzahl von Räumen verwendet werden, von Wohnzimmern über Schlafzimmer bis hin zu Heimbüros. Es ist besonders beliebt in modernen und zeitgenössischen Einrichtungsstilen, wo sie dem Raum ein mutiges und grafisches Element hinzufügen können.  Insgesamt ist ein Teppich mit geometrischen Akzenten eine stilvolle und vielseitige Designwahl, die jedem Raum im Haus visuelles Interesse und Textur verleihen kann.',
+          'en-GB':
+            'The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.',
+          'en-US':
+            'The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#808080',
+          label: { 'de-DE': 'Grau', 'en-GB': 'Gray', 'en-US': 'Gray' },
+        }),
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- 5ft x 3ft',
+          'de-DE': '- 5 Fuß x 3 Fuß',
+          'en-US': '- 5ft x 3ft',
+        }),
+    ]);
+
+export default cobblestoneRug01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cobblestone-rug-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cobblestone-rug-01.ts
@@ -32,28 +32,16 @@ const cobblestoneRug01 = (): TProductVariantDraftBuilder =>
     ])
     .attributes([
       AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'de-DE':
-            'Der Cobblestone-Teppich kann in einer Vielzahl von Räumen verwendet werden, von Wohnzimmern über Schlafzimmer bis hin zu Heimbüros. Es ist besonders beliebt in modernen und zeitgenössischen Einrichtungsstilen, wo sie dem Raum ein mutiges und grafisches Element hinzufügen können.  Insgesamt ist ein Teppich mit geometrischen Akzenten eine stilvolle und vielseitige Designwahl, die jedem Raum im Haus visuelles Interesse und Textur verleihen kann.',
-          'en-GB':
-            'The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.',
-          'en-US':
-            'The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.',
-        }),
-      AttributeDraft.random()
         .name('color-filter')
         .value({
           key: '#808080',
           label: { 'de-DE': 'Grau', 'en-GB': 'Gray', 'en-US': 'Gray' },
         }),
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- 5ft x 3ft',
-          'de-DE': '- 5 Fuß x 3 Fuß',
-          'en-US': '- 5ft x 3ft',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- 5ft x 3ft',
+        'de-DE': '- 5 Fuß x 3 Fuß',
+        'en-US': '- 5ft x 3ft',
+      }),
     ]);
 
 export default cobblestoneRug01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cobblestone-rug-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cobblestone-rug-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const cobblestoneRug01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Cobblestone%20Rug-n-Cz7uBo.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-01.spec.ts
@@ -1,0 +1,189 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cocktailShaker01 from './cocktail-shaker-01';
+
+describe(`with cocktailShaker01 preset`, () => {
+  it(`should return a cocktailShaker01 preset`, () => {
+    const cocktailShaker01Preset =
+      cocktailShaker01().build<TProductVariantDraft>();
+    expect(cocktailShaker01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Inklusive eingebautem Sieb
+      - Edelstahl
+      - Spülmaschinenfest",
+              "en-GB": "- Includes built in strainer
+      - Stainless steel
+      - Dishwasher safe",
+              "en-US": "- Includes built in strainer
+      - Stainless steel
+      - Dishwasher safe",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 5500,
+              "w": 3850,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_74255917-W96v6fME.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 3750,
+              "w": 5000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_74620379%20-og0Draq4.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 699,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 699,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 699,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "COCT-09",
+      }
+    `);
+  });
+
+  it(`should return a cocktailShaker01 preset when built for graphql`, () => {
+    const cocktailShaker01PresetGraphql =
+      cocktailShaker01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cocktailShaker01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Includes built in strainer\\n- Stainless steel\\n- Dishwasher safe","de-DE":"- Inklusive eingebautem Sieb\\n- Edelstahl\\n- Spülmaschinenfest","en-US":"- Includes built in strainer\\n- Stainless steel\\n- Dishwasher safe"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 5500,
+              "width": 3850,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_74255917-W96v6fME.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 3750,
+              "width": 5000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_74620379%20-og0Draq4.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 699,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 699,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 699,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "COCT-09",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,13 +23,13 @@ const cocktailShaker01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_74255917-W96v6fME.jpeg'
         )
         .dimensions({ w: 3850, h: 5500 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_74620379%20-og0Draq4.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-01.ts
@@ -37,26 +37,14 @@ const cocktailShaker01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 5000, h: 3750 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB':
-            '- Includes built in strainer\n- Stainless steel\n- Dishwasher safe',
-          'de-DE':
-            '- Inklusive eingebautem Sieb\n- Edelstahl\n- Spülmaschinenfest',
-          'en-US':
-            '- Includes built in strainer\n- Stainless steel\n- Dishwasher safe',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.',
-          'en-US':
-            'A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.',
-          'de-DE':
-            'Ein Cocktailshaker ist ein Werkzeug, das zum Mischen und Zubereiten von alkoholischen Getränken wie Cocktails verwendet wird. Es ist ein Metallbehälter mit einem Deckel, der dicht abschließt, um ein Verschütten zu verhindern. Der Behälter hat eine sich verjüngende Form mit einer breiteren Basis und einer schmaleren Oberseite. Dieses Design ermöglicht ein einfaches Mischen der Zutaten durch Schütteln. Der Deckel hat ein eingebautes Sieb, um die Flüssigkeit vom Eis und anderen festen Zutaten zu trennen. Der Shaker ist aus Edelstahl.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB':
+          '- Includes built in strainer\n- Stainless steel\n- Dishwasher safe',
+        'de-DE':
+          '- Inklusive eingebautem Sieb\n- Edelstahl\n- Spülmaschinenfest',
+        'en-US':
+          '- Includes built in strainer\n- Stainless steel\n- Dishwasher safe',
+      }),
     ]);
 
 export default cocktailShaker01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-01.ts
@@ -1,0 +1,62 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cocktailShaker01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('COCT-09')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(699))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(699))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(699))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_74255917-W96v6fME.jpeg'
+        )
+        .dimensions({ w: 3850, h: 5500 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_74620379%20-og0Draq4.jpeg'
+        )
+        .dimensions({ w: 5000, h: 3750 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB':
+            '- Includes built in strainer\n- Stainless steel\n- Dishwasher safe',
+          'de-DE':
+            '- Inklusive eingebautem Sieb\n- Edelstahl\n- Spülmaschinenfest',
+          'en-US':
+            '- Includes built in strainer\n- Stainless steel\n- Dishwasher safe',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.',
+          'en-US':
+            'A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.',
+          'de-DE':
+            'Ein Cocktailshaker ist ein Werkzeug, das zum Mischen und Zubereiten von alkoholischen Getränken wie Cocktails verwendet wird. Es ist ein Metallbehälter mit einem Deckel, der dicht abschließt, um ein Verschütten zu verhindern. Der Behälter hat eine sich verjüngende Form mit einer breiteren Basis und einer schmaleren Oberseite. Dieses Design ermöglicht ein einfaches Mischen der Zutaten durch Schütteln. Der Deckel hat ein eingebautes Sieb, um die Flüssigkeit vom Eis und anderen festen Zutaten zu trennen. Der Shaker ist aus Edelstahl.',
+        }),
+    ]);
+
+export default cocktailShaker01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-set-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-set-01.spec.ts
@@ -1,0 +1,209 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cocktailShakerSet01 from './cocktail-shaker-set-01';
+
+describe(`with cocktailShakerSet01 preset`, () => {
+  it(`should return a cocktailShakerSet01 preset`, () => {
+    const cocktailShakerSet01Preset =
+      cocktailShakerSet01().build<TProductVariantDraft>();
+    expect(cocktailShakerSet01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Edelstahl
+      - Handwäsche nur",
+              "en-GB": "- Stainless steel
+      - Hand wash only",
+              "en-US": "- Stainless steel
+      - Hand wash only",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Gold",
+              "en-GB": "Gold",
+              "en-US": "Gold",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#FFD700",
+              "label": {
+                "de-DE": "Gold",
+                "en-GB": "Gold",
+                "en-US": "Gold",
+              },
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#EED149",
+              "en-GB": "#EED149",
+              "en-US": "#EED149",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 5334,
+              "w": 4929,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_441132411-JDwT9QfX.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "COC-0843",
+      }
+    `);
+  });
+
+  it(`should return a cocktailShakerSet01 preset when built for graphql`, () => {
+    const cocktailShakerSet01PresetGraphql =
+      cocktailShakerSet01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cocktailShakerSet01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Stainless steel\\n- Hand wash only","de-DE":"- Edelstahl\\n- Handwäsche nur","en-US":"- Stainless steel\\n- Hand wash only"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Gold","de-DE":"Gold","en-US":"Gold"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#FFD700","label":{"de-DE":"Gold","en-GB":"Gold","en-US":"Gold"}}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#EED149","de-DE":"#EED149","en-US":"#EED149"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 5334,
+              "width": 4929,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_441132411-JDwT9QfX.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "COC-0843",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-set-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-set-01.ts
@@ -31,23 +31,11 @@ const cocktailShakerSet01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 4929, h: 5334 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Stainless steel\n- Hand wash only',
-          'de-DE': '- Edelstahl\n- Handwäsche nur',
-          'en-US': '- Stainless steel\n- Hand wash only',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            "This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home.",
-          'en-US':
-            "This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home.",
-          'de-DE':
-            'Dieses Set für die Cocktailzubereitung umfasst einen Shaker, ein Sieb, einen Jigger und eine Zange, die alle aus vergoldetem Edelstahl bestehen. Der Shaker ist ein zweiteiliger Behälter mit einem Deckel, der fest sitzt, um ein Verschütten zu verhindern. Das Sieb passt über die Oberseite des Shakers, um feste Zutaten oder Eis aus dem Cocktail zu entfernen, wenn er in das Glas gegossen wird. Der Jigger ist ein kleiner Messbecher, der dabei hilft, die Zutaten präzise abzumessen. Das Gold-Finish verleiht dem Set ein luxuriöses, elegantes Aussehen, das sich perfekt für die Unterhaltung oder die Zubereitung besonderer Cocktails zu Hause eignet.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Stainless steel\n- Hand wash only',
+        'de-DE': '- Edelstahl\n- Handwäsche nur',
+        'en-US': '- Stainless steel\n- Hand wash only',
+      }),
       AttributeDraft.random()
         .name('colorlabel')
         .value({ 'en-GB': 'Gold', 'de-DE': 'Gold', 'en-US': 'Gold' }),

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-set-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-set-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const cocktailShakerSet01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_441132411-JDwT9QfX.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-set-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-shaker-set-01.ts
@@ -1,0 +1,65 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cocktailShakerSet01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('COC-0843')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1599))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1599))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1599))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_441132411-JDwT9QfX.jpeg'
+        )
+        .dimensions({ w: 4929, h: 5334 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Stainless steel\n- Hand wash only',
+          'de-DE': '- Edelstahl\n- Handwäsche nur',
+          'en-US': '- Stainless steel\n- Hand wash only',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            "This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home.",
+          'en-US':
+            "This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home.",
+          'de-DE':
+            'Dieses Set für die Cocktailzubereitung umfasst einen Shaker, ein Sieb, einen Jigger und eine Zange, die alle aus vergoldetem Edelstahl bestehen. Der Shaker ist ein zweiteiliger Behälter mit einem Deckel, der fest sitzt, um ein Verschütten zu verhindern. Das Sieb passt über die Oberseite des Shakers, um feste Zutaten oder Eis aus dem Cocktail zu entfernen, wenn er in das Glas gegossen wird. Der Jigger ist ein kleiner Messbecher, der dabei hilft, die Zutaten präzise abzumessen. Das Gold-Finish verleiht dem Set ein luxuriöses, elegantes Aussehen, das sich perfekt für die Unterhaltung oder die Zubereitung besonderer Cocktails zu Hause eignet.',
+        }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'Gold', 'de-DE': 'Gold', 'en-US': 'Gold' }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#FFD700',
+          label: { 'de-DE': 'Gold', 'en-GB': 'Gold', 'en-US': 'Gold' },
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#EED149', 'de-DE': '#EED149', 'en-US': '#EED149' }),
+    ]);
+
+export default cocktailShakerSet01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-stirring-spoon-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-stirring-spoon-01.spec.ts
@@ -1,0 +1,170 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cocktailStirringSpoon01 from './cocktail-stirring-spoon-01';
+
+describe(`with cocktailStirringSpoon01 preset`, () => {
+  it(`should return a cocktailStirringSpoon01 preset`, () => {
+    const cocktailStirringSpoon01Preset =
+      cocktailStirringSpoon01().build<TProductVariantDraft>();
+    expect(cocktailStirringSpoon01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Edelstahl
+      - Spülmaschinenfest",
+              "en-GB": "- Stainless steel
+      - Dishwasher safe",
+              "en-US": "- Stainless steel
+      - Dishwasher safe",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 4555,
+              "w": 5757,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_138383562-Ewqpr7_V.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 199,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 199,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 199,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "Spoo-094",
+      }
+    `);
+  });
+
+  it(`should return a cocktailStirringSpoon01 preset when built for graphql`, () => {
+    const cocktailStirringSpoon01PresetGraphql =
+      cocktailStirringSpoon01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cocktailStirringSpoon01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Stainless steel\\n- Dishwasher safe","de-DE":"- Edelstahl\\n- Spülmaschinenfest","en-US":"- Stainless steel\\n- Dishwasher safe"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 4555,
+              "width": 5757,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_138383562-Ewqpr7_V.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 199,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 199,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 199,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "Spoo-094",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-stirring-spoon-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-stirring-spoon-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const cocktailStirringSpoon01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_138383562-Ewqpr7_V.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-stirring-spoon-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-stirring-spoon-01.ts
@@ -31,23 +31,11 @@ const cocktailStirringSpoon01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 5757, h: 4555 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Stainless steel\n- Dishwasher safe',
-          'de-DE': '- Edelstahl\n- Spülmaschinenfest',
-          'en-US': '- Stainless steel\n- Dishwasher safe',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.',
-          'en-US':
-            'A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.',
-          'de-DE':
-            'Ein Cocktail-Rührlöffel ist ein langes und schlankes Utensil aus Edelstahl, das zum Rühren und Mixen von Cocktails verwendet wird. Es ist normalerweise etwa 8 Zoll lang mit einem kleinen, flachen, scheibenförmigen Ende zum Vermischen von Zutaten und einem gedrehten oder spiralförmigen Griff zum einfachen Greifen. Der gedrehte Griff dient nicht nur der Dekoration, sondern verhilft auch zu einem besseren Halt beim Mixen von Cocktails.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Stainless steel\n- Dishwasher safe',
+        'de-DE': '- Edelstahl\n- Spülmaschinenfest',
+        'en-US': '- Stainless steel\n- Dishwasher safe',
+      }),
     ]);
 
 export default cocktailStirringSpoon01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-stirring-spoon-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-stirring-spoon-01.ts
@@ -1,0 +1,53 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cocktailStirringSpoon01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('Spoo-094')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(199))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(199))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(199))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_138383562-Ewqpr7_V.jpeg'
+        )
+        .dimensions({ w: 5757, h: 4555 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Stainless steel\n- Dishwasher safe',
+          'de-DE': '- Edelstahl\n- Spülmaschinenfest',
+          'en-US': '- Stainless steel\n- Dishwasher safe',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.',
+          'en-US':
+            'A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.',
+          'de-DE':
+            'Ein Cocktail-Rührlöffel ist ein langes und schlankes Utensil aus Edelstahl, das zum Rühren und Mixen von Cocktails verwendet wird. Es ist normalerweise etwa 8 Zoll lang mit einem kleinen, flachen, scheibenförmigen Ende zum Vermischen von Zutaten und einem gedrehten oder spiralförmigen Griff zum einfachen Greifen. Der gedrehte Griff dient nicht nur der Dekoration, sondern verhilft auch zu einem besseren Halt beim Mixen von Cocktails.',
+        }),
+    ]);
+
+export default cocktailStirringSpoon01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-strainer-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-strainer-01.spec.ts
@@ -1,0 +1,186 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cocktailStrainer01 from './cocktail-strainer-01';
+
+describe(`with cocktailStrainer01 preset`, () => {
+  it(`should return a cocktailStrainer01 preset`, () => {
+    const cocktailStrainer01Preset =
+      cocktailStrainer01().build<TProductVariantDraft>();
+    expect(cocktailStrainer01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Edelstahl
+      - Spülmaschinenfest",
+              "en-GB": "- Stainless steel
+      - Dishwasher safe",
+              "en-US": "- Stainless steel
+      - Dishwasher safe",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3648,
+              "w": 5472,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_93371908-9q9vrNXx.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 5472,
+              "w": 3648,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_97174497-F5iWBxGv.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 399,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 399,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 399,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "STRA-095",
+      }
+    `);
+  });
+
+  it(`should return a cocktailStrainer01 preset when built for graphql`, () => {
+    const cocktailStrainer01PresetGraphql =
+      cocktailStrainer01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cocktailStrainer01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Stainless steel\\n- Dishwasher safe","de-DE":"- Edelstahl\\n- Spülmaschinenfest","en-US":"- Stainless steel\\n- Dishwasher safe"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3648,
+              "width": 5472,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_93371908-9q9vrNXx.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 5472,
+              "width": 3648,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_97174497-F5iWBxGv.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 399,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 399,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 399,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "STRA-095",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-strainer-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-strainer-01.ts
@@ -1,0 +1,59 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cocktailStrainer01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('STRA-095')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(399))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(399))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(399))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_93371908-9q9vrNXx.jpeg'
+        )
+        .dimensions({ w: 5472, h: 3648 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_97174497-F5iWBxGv.jpeg'
+        )
+        .dimensions({ w: 3648, h: 5472 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Stainless steel\n- Dishwasher safe',
+          'de-DE': '- Edelstahl\n- Spülmaschinenfest',
+          'en-US': '- Stainless steel\n- Dishwasher safe',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.',
+          'en-US':
+            'A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.',
+          'de-DE':
+            'Ein Sieb für Cocktailshaker ist ein Barwerkzeug, das verwendet wird, um Eis und andere feste Zutaten aus Mixgetränken abzuseihen, während der flüssige Teil des Cocktails in ein Servierglas gegossen wird. Er besteht aus Metall und hat eine flache, perforierte Scheibe, die über die Öffnung des Shakers passt. Das Sieb wird an Ort und Stelle gehalten, indem man einen Finger über den kleinen, griffartigen Vorsprung auf einer Seite der Scheibe legt, während man die Flüssigkeit durch die größere Öffnung auf der anderen Seite ausgießt. Die perforierte Scheibe hilft dabei, kleine Eis- oder Fruchtstücke herauszufiltern, die in der Mischung zurückbleiben könnten, was zu einem glatten und raffinierten Cocktail führt. Das Sieb hat auch eine Feder um den Rand der Scheibe, die hilft, es sicher über dem Shaker zu halten und so ein Verschütten oder Tropfen zu verhindern.',
+        }),
+    ]);
+
+export default cocktailStrainer01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-strainer-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-strainer-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,13 +23,13 @@ const cocktailStrainer01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_93371908-9q9vrNXx.jpeg'
         )
         .dimensions({ w: 5472, h: 3648 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_97174497-F5iWBxGv.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-strainer-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocktail-strainer-01.ts
@@ -37,23 +37,11 @@ const cocktailStrainer01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 3648, h: 5472 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Stainless steel\n- Dishwasher safe',
-          'de-DE': '- Edelstahl\n- Spülmaschinenfest',
-          'en-US': '- Stainless steel\n- Dishwasher safe',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.',
-          'en-US':
-            'A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.',
-          'de-DE':
-            'Ein Sieb für Cocktailshaker ist ein Barwerkzeug, das verwendet wird, um Eis und andere feste Zutaten aus Mixgetränken abzuseihen, während der flüssige Teil des Cocktails in ein Servierglas gegossen wird. Er besteht aus Metall und hat eine flache, perforierte Scheibe, die über die Öffnung des Shakers passt. Das Sieb wird an Ort und Stelle gehalten, indem man einen Finger über den kleinen, griffartigen Vorsprung auf einer Seite der Scheibe legt, während man die Flüssigkeit durch die größere Öffnung auf der anderen Seite ausgießt. Die perforierte Scheibe hilft dabei, kleine Eis- oder Fruchtstücke herauszufiltern, die in der Mischung zurückbleiben könnten, was zu einem glatten und raffinierten Cocktail führt. Das Sieb hat auch eine Feder um den Rand der Scheibe, die hilft, es sicher über dem Shaker zu halten und so ein Verschütten oder Tropfen zu verhindern.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Stainless steel\n- Dishwasher safe',
+        'de-DE': '- Edelstahl\n- Spülmaschinenfest',
+        'en-US': '- Stainless steel\n- Dishwasher safe',
+      }),
     ]);
 
 export default cocktailStrainer01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocoa-pillow-cover-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocoa-pillow-cover-01.spec.ts
@@ -1,0 +1,209 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cocoaPillowCover01 from './cocoa-pillow-cover-01';
+
+describe(`with cocoaPillowCover01 preset`, () => {
+  it(`should return a cocoaPillowCover01 preset`, () => {
+    const cocoaPillowCover01Preset =
+      cocoaPillowCover01().build<TProductVariantDraft>();
+    expect(cocoaPillowCover01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Waschmaschinenfest
+      - Kissen nicht im Lieferumfang enthalten",
+              "en-GB": "- Machine washable
+      - Pillow not included",
+              "en-US": "- Machine washable
+      - Pillow not included",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#808080",
+              "label": {
+                "de-DE": "Grau",
+                "en-GB": "Gray",
+                "en-US": "Gray",
+              },
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#A1947C ",
+              "en-GB": "#A1947C ",
+              "en-US": "#A1947C ",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Tweed",
+              "en-GB": "Tweed",
+              "en-US": "Tweed",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 4160,
+              "w": 6240,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Cocoa%20Pillow%20Cover-W9ZgnFgU.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1099,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1099,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1099,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "BLPC-09",
+      }
+    `);
+  });
+
+  it(`should return a cocoaPillowCover01 preset when built for graphql`, () => {
+    const cocoaPillowCover01PresetGraphql =
+      cocoaPillowCover01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cocoaPillowCover01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Machine washable\\n- Pillow not included","de-DE":"- Waschmaschinenfest\\n- Kissen nicht im Lieferumfang enthalten","en-US":"- Machine washable\\n- Pillow not included"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#A1947C ","de-DE":"#A1947C ","en-US":"#A1947C "}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Tweed","de-DE":"Tweed","en-US":"Tweed"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 4160,
+              "width": 6240,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Cocoa%20Pillow%20Cover-W9ZgnFgU.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1099,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1099,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1099,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "BLPC-09",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocoa-pillow-cover-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocoa-pillow-cover-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const cocoaPillowCover01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Cocoa%20Pillow%20Cover-W9ZgnFgU.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocoa-pillow-cover-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocoa-pillow-cover-01.ts
@@ -1,0 +1,70 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cocoaPillowCover01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('BLPC-09')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1099))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1099))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1099))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Cocoa%20Pillow%20Cover-W9ZgnFgU.jpeg'
+        )
+        .dimensions({ w: 6240, h: 4160 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Machine washable\n- Pillow not included',
+          'de-DE':
+            '- Waschmaschinenfest\n- Kissen nicht im Lieferumfang enthalten',
+          'en-US': '- Machine washable\n- Pillow not included',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.',
+          'en-US':
+            'A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.',
+          'de-DE':
+            'Ein quadratischer Kissenbezug aus Leinen ist eine Art Textilbezug für ein quadratisches Kissen, das normalerweise verwendet wird, um einem Raum visuelles Interesse und Textur zu verleihen. Es besteht aus einem natürlichen Leinenstoff, der für seine Haltbarkeit, Atmungsaktivität und seinen klassischen Look bekannt ist.  Der Kissenbezug ist so konzipiert, dass er über ein quadratisches Kissen in Standardgröße passt, normalerweise etwa 18 Zoll im Quadrat.  Der Leinenstoff hat eine weiche und leicht strukturierte Oberfläche, die dem Kissen ein gemütliches und einladendes Gefühl verleiht. Die Kanten des Kissenbezugs sind mit einem sauberen Saum oder einer Paspelierung versehen, was dem Gesamtdesign einen eleganten Look verleiht.  Der Kissenbezug wird verwendet, um einem Raum einen Hauch von Wärme und natürlicher Eleganz zu verleihen, egal ob er auf einem Bett, einem Sofa oder einem Akzentstuhl platziert wird. Es kann alleine verwendet oder mit anderen dekorativen Kissen in verschiedenen Formen und Farben kombiniert werden, um einen mehrschichtigen und zusammenhängenden Look zu schaffen.  Insgesamt ist ein quadratischer Kissenbezug aus Leinen ein vielseitiges und zeitloses Akzentstück, das den Komfort und Stil jedes Raums im Haus verbessern kann.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#808080',
+          label: { 'de-DE': 'Grau', 'en-GB': 'Gray', 'en-US': 'Gray' },
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({
+          'en-GB': '#A1947C ',
+          'de-DE': '#A1947C ',
+          'en-US': '#A1947C ',
+        }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'Tweed', 'de-DE': 'Tweed', 'en-US': 'Tweed' }),
+    ]);
+
+export default cocoaPillowCover01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocoa-pillow-cover-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cocoa-pillow-cover-01.ts
@@ -31,37 +31,23 @@ const cocoaPillowCover01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 6240, h: 4160 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Machine washable\n- Pillow not included',
-          'de-DE':
-            '- Waschmaschinenfest\n- Kissen nicht im Lieferumfang enthalten',
-          'en-US': '- Machine washable\n- Pillow not included',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.',
-          'en-US':
-            'A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.',
-          'de-DE':
-            'Ein quadratischer Kissenbezug aus Leinen ist eine Art Textilbezug für ein quadratisches Kissen, das normalerweise verwendet wird, um einem Raum visuelles Interesse und Textur zu verleihen. Es besteht aus einem natürlichen Leinenstoff, der für seine Haltbarkeit, Atmungsaktivität und seinen klassischen Look bekannt ist.  Der Kissenbezug ist so konzipiert, dass er über ein quadratisches Kissen in Standardgröße passt, normalerweise etwa 18 Zoll im Quadrat.  Der Leinenstoff hat eine weiche und leicht strukturierte Oberfläche, die dem Kissen ein gemütliches und einladendes Gefühl verleiht. Die Kanten des Kissenbezugs sind mit einem sauberen Saum oder einer Paspelierung versehen, was dem Gesamtdesign einen eleganten Look verleiht.  Der Kissenbezug wird verwendet, um einem Raum einen Hauch von Wärme und natürlicher Eleganz zu verleihen, egal ob er auf einem Bett, einem Sofa oder einem Akzentstuhl platziert wird. Es kann alleine verwendet oder mit anderen dekorativen Kissen in verschiedenen Formen und Farben kombiniert werden, um einen mehrschichtigen und zusammenhängenden Look zu schaffen.  Insgesamt ist ein quadratischer Kissenbezug aus Leinen ein vielseitiges und zeitloses Akzentstück, das den Komfort und Stil jedes Raums im Haus verbessern kann.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Machine washable\n- Pillow not included',
+        'de-DE':
+          '- Waschmaschinenfest\n- Kissen nicht im Lieferumfang enthalten',
+        'en-US': '- Machine washable\n- Pillow not included',
+      }),
       AttributeDraft.random()
         .name('color-filter')
         .value({
           key: '#808080',
           label: { 'de-DE': 'Grau', 'en-GB': 'Gray', 'en-US': 'Gray' },
         }),
-      AttributeDraft.random()
-        .name('color')
-        .value({
-          'en-GB': '#A1947C ',
-          'de-DE': '#A1947C ',
-          'en-US': '#A1947C ',
-        }),
+      AttributeDraft.random().name('color').value({
+        'en-GB': '#A1947C ',
+        'de-DE': '#A1947C ',
+        'en-US': '#A1947C ',
+      }),
       AttributeDraft.random()
         .name('colorlabel')
         .value({ 'en-GB': 'Tweed', 'de-DE': 'Tweed', 'en-US': 'Tweed' }),

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/comfort-coffee-mug-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/comfort-coffee-mug-01.spec.ts
@@ -1,0 +1,209 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import comfortCoffeeMug01 from './comfort-coffee-mug-01';
+
+describe(`with comfortCoffeeMug01 preset`, () => {
+  it(`should return a comfortCoffeeMug01 preset`, () => {
+    const comfortCoffeeMug01Preset =
+      comfortCoffeeMug01().build<TProductVariantDraft>();
+    expect(comfortCoffeeMug01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Enthält 1 Tasse
+      - Spülmaschinen- und mikrowellengeeignet",
+              "en-GB": "- Includes 1 mug
+      - Dishwasher and microwave safe",
+              "en-US": "- Includes 1 mug
+      - Dishwasher and microwave safe",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#FFF",
+              "label": {
+                "de-DE": "Weiss",
+                "en-GB": "White",
+                "en-US": "White",
+              },
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#FFF",
+              "en-GB": "#FFF",
+              "en-US": "#FFF",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Weiß",
+              "en-GB": "White",
+              "en-US": "White",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 2256,
+              "w": 2340,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Comfort%20Coffee%20Mug-G7JxJ2T_.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 199,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 199,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 199,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CCM-089",
+      }
+    `);
+  });
+
+  it(`should return a comfortCoffeeMug01 preset when built for graphql`, () => {
+    const comfortCoffeeMug01PresetGraphql =
+      comfortCoffeeMug01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(comfortCoffeeMug01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Includes 1 mug\\n- Dishwasher and microwave safe","de-DE":"- Enthält 1 Tasse\\n- Spülmaschinen- und mikrowellengeeignet","en-US":"- Includes 1 mug\\n- Dishwasher and microwave safe"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"White","de-DE":"Weiß","en-US":"White"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 2256,
+              "width": 2340,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Comfort%20Coffee%20Mug-G7JxJ2T_.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 199,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 199,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 199,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CCM-089",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/comfort-coffee-mug-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/comfort-coffee-mug-01.ts
@@ -1,0 +1,66 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const comfortCoffeeMug01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CCM-089')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(199))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(199))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(199))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Comfort%20Coffee%20Mug-G7JxJ2T_.jpeg'
+        )
+        .dimensions({ w: 2340, h: 2256 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Includes 1 mug\n- Dishwasher and microwave safe',
+          'de-DE':
+            '- Enthält 1 Tasse\n- Spülmaschinen- und mikrowellengeeignet',
+          'en-US': '- Includes 1 mug\n- Dishwasher and microwave safe',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.',
+          'en-US':
+            'The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.',
+          'de-DE':
+            'Der Comfort Coffee Mug ist aus Keramik gefertigt. Das Design des Bechers soll das Halten und Trinken erleichtern, mit einem Griff auf einer Seite für bequemen Halt.  Der Becher ist schlicht, aber sein grundlegendes Design ist im Allgemeinen einfach und funktional. Der Körper des Bechers hat oft glatte Seiten und eine breite Öffnung, die das Eingießen und Trinken von Kaffee erleichtert.  Der Comfort Coffee Mug ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist der Comfort Coffee Mug ein praktisches und funktionelles Trinkgefäß, das sich ideal für den Kaffeegenuss zu Hause oder am Arbeitsplatz eignet. Sein einfaches Design und seine Benutzerfreundlichkeit machen ihn zu einer beliebten Wahl für Kaffeeliebhaber aller Art.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#FFF',
+          label: { 'de-DE': 'Weiss', 'en-GB': 'White', 'en-US': 'White' },
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'White', 'de-DE': 'Weiß', 'en-US': 'White' }),
+    ]);
+
+export default comfortCoffeeMug01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/comfort-coffee-mug-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/comfort-coffee-mug-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const comfortCoffeeMug01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Comfort%20Coffee%20Mug-G7JxJ2T_.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/comfort-coffee-mug-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/comfort-coffee-mug-01.ts
@@ -31,24 +31,11 @@ const comfortCoffeeMug01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 2340, h: 2256 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Includes 1 mug\n- Dishwasher and microwave safe',
-          'de-DE':
-            '- Enthält 1 Tasse\n- Spülmaschinen- und mikrowellengeeignet',
-          'en-US': '- Includes 1 mug\n- Dishwasher and microwave safe',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.',
-          'en-US':
-            'The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.',
-          'de-DE':
-            'Der Comfort Coffee Mug ist aus Keramik gefertigt. Das Design des Bechers soll das Halten und Trinken erleichtern, mit einem Griff auf einer Seite für bequemen Halt.  Der Becher ist schlicht, aber sein grundlegendes Design ist im Allgemeinen einfach und funktional. Der Körper des Bechers hat oft glatte Seiten und eine breite Öffnung, die das Eingießen und Trinken von Kaffee erleichtert.  Der Comfort Coffee Mug ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist der Comfort Coffee Mug ein praktisches und funktionelles Trinkgefäß, das sich ideal für den Kaffeegenuss zu Hause oder am Arbeitsplatz eignet. Sein einfaches Design und seine Benutzerfreundlichkeit machen ihn zu einer beliebten Wahl für Kaffeeliebhaber aller Art.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Includes 1 mug\n- Dishwasher and microwave safe',
+        'de-DE': '- Enthält 1 Tasse\n- Spülmaschinen- und mikrowellengeeignet',
+        'en-US': '- Includes 1 mug\n- Dishwasher and microwave safe',
+      }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.spec.ts
@@ -1,0 +1,230 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cottonSilkBedsheet01 from './cotton-silk-bedsheet-01';
+
+describe(`with cottonSilkBedsheet01 preset`, () => {
+  it(`should return a cottonSilkBedsheet01 preset`, () => {
+    const cottonSilkBedsheet01Preset =
+      cottonSilkBedsheet01().build<TProductVariantDraft>();
+    expect(cottonSilkBedsheet01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Weiß",
+              "en-GB": "White",
+              "en-US": "White",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#FFF",
+              "en-GB": "#FFF",
+              "en-US": "#FFF",
+            },
+          },
+          {
+            "name": "new-arrival",
+            "value": "false",
+          },
+          {
+            "name": "size",
+            "value": {
+              "en-GB": "Queen",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#FFF",
+              "label": {
+                "de-DE": "Weiss",
+                "en-GB": "White",
+                "en-US": "White",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 4500,
+              "w": 7500,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-L0ubiJAn.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CSKW-093",
+      }
+    `);
+  });
+
+  it(`should return a cottonSilkBedsheet01 preset when built for graphql`, () => {
+    const cottonSilkBedsheet01PresetGraphql =
+      cottonSilkBedsheet01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cottonSilkBedsheet01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","en-US":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","de-DE":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"White","de-DE":"Weiß","en-US":"White"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}",
+          },
+          {
+            "name": "new-arrival",
+            "value": ""false"",
+          },
+          {
+            "name": "size",
+            "value": "{"en-GB":"Queen"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 4500,
+              "width": 7500,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-L0ubiJAn.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CSKW-093",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const cottonSilkBedsheet01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-L0ubiJAn.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.ts
@@ -31,16 +31,14 @@ const cottonSilkBedsheet01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 7500, h: 4500 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'en-US':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'de-DE':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'en-US':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'de-DE':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+      }),
       AttributeDraft.random()
         .name('colorlabel')
         .value({ 'en-GB': 'White', 'de-DE': 'Weiß', 'en-US': 'White' }),
@@ -49,16 +47,6 @@ const cottonSilkBedsheet01 = (): TProductVariantDraftBuilder =>
         .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),
       AttributeDraft.random().name('new-arrival').value('false'),
       AttributeDraft.random().name('size').value({ 'en-GB': 'Queen' }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'en-US':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'de-DE':
-            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
-        }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.ts
@@ -1,0 +1,70 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cottonSilkBedsheet01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CSKW-093')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1599))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1599))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1599))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-L0ubiJAn.jpeg'
+        )
+        .dimensions({ w: 7500, h: 4500 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'en-US':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'de-DE':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'White', 'de-DE': 'Weiß', 'en-US': 'White' }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),
+      AttributeDraft.random().name('new-arrival').value('false'),
+      AttributeDraft.random().name('size').value({ 'en-GB': 'Queen' }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'en-US':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'de-DE':
+            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#FFF',
+          label: { 'de-DE': 'Weiss', 'en-GB': 'White', 'en-US': 'White' },
+        }),
+    ]);
+
+export default cottonSilkBedsheet01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-02.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-02.spec.ts
@@ -1,0 +1,222 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cottonSilkBedsheet02 from './cotton-silk-bedsheet-02';
+
+describe(`with cottonSilkBedsheet02 preset`, () => {
+  it(`should return a cottonSilkBedsheet02 preset`, () => {
+    const cottonSilkBedsheet02Preset =
+      cottonSilkBedsheet02().build<TProductVariantDraft>();
+    expect(cottonSilkBedsheet02Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#FFF",
+              "en-GB": "#FFF",
+              "en-US": "#FFF",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Weiß",
+              "en-GB": "White",
+              "en-US": "White",
+            },
+          },
+          {
+            "name": "size",
+            "value": {
+              "en-GB": "Twin",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#FFF",
+              "label": {
+                "de-DE": "Weiss",
+                "en-GB": "White",
+                "en-US": "White",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 4500,
+              "w": 7500,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-spHghd9J.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CSKW-0922",
+      }
+    `);
+  });
+
+  it(`should return a cottonSilkBedsheet02 preset when built for graphql`, () => {
+    const cottonSilkBedsheet02PresetGraphql =
+      cottonSilkBedsheet02().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cottonSilkBedsheet02PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","en-US":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","de-DE":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"White","de-DE":"Weiß","en-US":"White"}",
+          },
+          {
+            "name": "size",
+            "value": "{"en-GB":"Twin"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 4500,
+              "width": 7500,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-spHghd9J.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CSKW-0922",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-02.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-02.ts
@@ -1,0 +1,69 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cottonSilkBedsheet02 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CSKW-0922')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1299))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1299))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1299))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-spHghd9J.jpeg'
+        )
+        .dimensions({ w: 7500, h: 4500 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'en-US':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'de-DE':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'White', 'de-DE': 'Weiß', 'en-US': 'White' }),
+      AttributeDraft.random().name('size').value({ 'en-GB': 'Twin' }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'en-US':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'de-DE':
+            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#FFF',
+          label: { 'de-DE': 'Weiss', 'en-GB': 'White', 'en-US': 'White' },
+        }),
+    ]);
+
+export default cottonSilkBedsheet02;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-02.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-02.ts
@@ -31,16 +31,14 @@ const cottonSilkBedsheet02 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 7500, h: 4500 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'en-US':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'de-DE':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'en-US':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'de-DE':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+      }),
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),
@@ -48,16 +46,6 @@ const cottonSilkBedsheet02 = (): TProductVariantDraftBuilder =>
         .name('colorlabel')
         .value({ 'en-GB': 'White', 'de-DE': 'Weiß', 'en-US': 'White' }),
       AttributeDraft.random().name('size').value({ 'en-GB': 'Twin' }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'en-US':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'de-DE':
-            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
-        }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-02.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-02.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const cottonSilkBedsheet02 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-spHghd9J.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-03.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-03.spec.ts
@@ -1,0 +1,222 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cottonSilkBedsheet03 from './cotton-silk-bedsheet-03';
+
+describe(`with cottonSilkBedsheet03 preset`, () => {
+  it(`should return a cottonSilkBedsheet03 preset`, () => {
+    const cottonSilkBedsheet03Preset =
+      cottonSilkBedsheet03().build<TProductVariantDraft>();
+    expect(cottonSilkBedsheet03Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#FFF",
+              "en-GB": "#FFF",
+              "en-US": "#FFF",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Weiß",
+              "en-GB": "White",
+              "en-US": "White",
+            },
+          },
+          {
+            "name": "size",
+            "value": {
+              "en-GB": "King",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#FFF",
+              "label": {
+                "de-DE": "Weiss",
+                "en-GB": "White",
+                "en-US": "White",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 4500,
+              "w": 7500,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-RXVUnvih.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1899,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1899,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1899,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CSKW-9822",
+      }
+    `);
+  });
+
+  it(`should return a cottonSilkBedsheet03 preset when built for graphql`, () => {
+    const cottonSilkBedsheet03PresetGraphql =
+      cottonSilkBedsheet03().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cottonSilkBedsheet03PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","en-US":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","de-DE":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"White","de-DE":"Weiß","en-US":"White"}",
+          },
+          {
+            "name": "size",
+            "value": "{"en-GB":"King"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 4500,
+              "width": 7500,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-RXVUnvih.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1899,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1899,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1899,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CSKW-9822",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-03.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-03.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const cottonSilkBedsheet03 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-RXVUnvih.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-03.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-03.ts
@@ -1,0 +1,69 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cottonSilkBedsheet03 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CSKW-9822')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1899))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1899))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1899))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-RXVUnvih.jpeg'
+        )
+        .dimensions({ w: 7500, h: 4500 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'en-US':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'de-DE':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'White', 'de-DE': 'Weiß', 'en-US': 'White' }),
+      AttributeDraft.random().name('size').value({ 'en-GB': 'King' }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'en-US':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'de-DE':
+            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#FFF',
+          label: { 'de-DE': 'Weiss', 'en-GB': 'White', 'en-US': 'White' },
+        }),
+    ]);
+
+export default cottonSilkBedsheet03;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-03.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-03.ts
@@ -31,16 +31,14 @@ const cottonSilkBedsheet03 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 7500, h: 4500 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'en-US':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'de-DE':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'en-US':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'de-DE':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+      }),
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),
@@ -48,16 +46,6 @@ const cottonSilkBedsheet03 = (): TProductVariantDraftBuilder =>
         .name('colorlabel')
         .value({ 'en-GB': 'White', 'de-DE': 'Weiß', 'en-US': 'White' }),
       AttributeDraft.random().name('size').value({ 'en-GB': 'King' }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'en-US':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'de-DE':
-            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
-        }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-04.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-04.spec.ts
@@ -1,0 +1,238 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cottonSilkBedsheet04 from './cotton-silk-bedsheet-04';
+
+describe(`with cottonSilkBedsheet04 preset`, () => {
+  it(`should return a cottonSilkBedsheet04 preset`, () => {
+    const cottonSilkBedsheet04Preset =
+      cottonSilkBedsheet04().build<TProductVariantDraft>();
+    expect(cottonSilkBedsheet04Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Lachs",
+              "en-GB": "Salmon",
+              "en-US": "Salmon",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#ffc0cb",
+              "en-GB": "#ffc0cb",
+              "en-US": "#ffc0cb",
+            },
+          },
+          {
+            "name": "size",
+            "value": {
+              "en-GB": "Twin",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#FFC0CB",
+              "label": {
+                "de-DE": "Rosa",
+                "en-GB": "Pink",
+                "en-US": "Pink",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3627,
+              "w": 5589,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-SYnKs_os.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 3228,
+              "w": 5216,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-SqkvdFES.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CSKP-0934",
+      }
+    `);
+  });
+
+  it(`should return a cottonSilkBedsheet04 preset when built for graphql`, () => {
+    const cottonSilkBedsheet04PresetGraphql =
+      cottonSilkBedsheet04().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cottonSilkBedsheet04PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","en-US":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","de-DE":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Salmon","de-DE":"Lachs","en-US":"Salmon"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#ffc0cb","de-DE":"#ffc0cb","en-US":"#ffc0cb"}",
+          },
+          {
+            "name": "size",
+            "value": "{"en-GB":"Twin"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#FFC0CB","label":{"de-DE":"Rosa","en-GB":"Pink","en-US":"Pink"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3627,
+              "width": 5589,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-SYnKs_os.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 3228,
+              "width": 5216,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-SqkvdFES.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CSKP-0934",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-04.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-04.ts
@@ -37,16 +37,14 @@ const cottonSilkBedsheet04 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 5216, h: 3228 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'en-US':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'de-DE':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'en-US':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'de-DE':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+      }),
       AttributeDraft.random()
         .name('colorlabel')
         .value({ 'en-GB': 'Salmon', 'de-DE': 'Lachs', 'en-US': 'Salmon' }),
@@ -54,16 +52,6 @@ const cottonSilkBedsheet04 = (): TProductVariantDraftBuilder =>
         .name('color')
         .value({ 'en-GB': '#ffc0cb', 'de-DE': '#ffc0cb', 'en-US': '#ffc0cb' }),
       AttributeDraft.random().name('size').value({ 'en-GB': 'Twin' }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'en-US':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'de-DE':
-            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
-        }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-04.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-04.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,13 +23,13 @@ const cottonSilkBedsheet04 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-SYnKs_os.jpeg'
         )
         .dimensions({ w: 5589, h: 3627 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-SqkvdFES.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-04.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-04.ts
@@ -1,0 +1,75 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cottonSilkBedsheet04 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CSKP-0934')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1299))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1299))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1299))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-SYnKs_os.jpeg'
+        )
+        .dimensions({ w: 5589, h: 3627 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-SqkvdFES.jpeg'
+        )
+        .dimensions({ w: 5216, h: 3228 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'en-US':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'de-DE':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'Salmon', 'de-DE': 'Lachs', 'en-US': 'Salmon' }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#ffc0cb', 'de-DE': '#ffc0cb', 'en-US': '#ffc0cb' }),
+      AttributeDraft.random().name('size').value({ 'en-GB': 'Twin' }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'en-US':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'de-DE':
+            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#FFC0CB',
+          label: { 'de-DE': 'Rosa', 'en-GB': 'Pink', 'en-US': 'Pink' },
+        }),
+    ]);
+
+export default cottonSilkBedsheet04;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-05.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-05.spec.ts
@@ -1,0 +1,238 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cottonSilkBedsheet05 from './cotton-silk-bedsheet-05';
+
+describe(`with cottonSilkBedsheet05 preset`, () => {
+  it(`should return a cottonSilkBedsheet05 preset`, () => {
+    const cottonSilkBedsheet05Preset =
+      cottonSilkBedsheet05().build<TProductVariantDraft>();
+    expect(cottonSilkBedsheet05Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#ffc0cb",
+              "en-GB": "#ffc0cb",
+              "en-US": "#ffc0cb",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Lachs",
+              "en-GB": "Salmon",
+              "en-US": "Salmon",
+            },
+          },
+          {
+            "name": "size",
+            "value": {
+              "en-GB": "Queen",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#FFC0CB",
+              "label": {
+                "de-DE": "Rosa",
+                "en-GB": "Pink",
+                "en-US": "Pink",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3627,
+              "w": 5589,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-YYm1GR3y.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 3228,
+              "w": 5216,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-8eeyUKq9.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CSKP-0932",
+      }
+    `);
+  });
+
+  it(`should return a cottonSilkBedsheet05 preset when built for graphql`, () => {
+    const cottonSilkBedsheet05PresetGraphql =
+      cottonSilkBedsheet05().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cottonSilkBedsheet05PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","en-US":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","de-DE":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#ffc0cb","de-DE":"#ffc0cb","en-US":"#ffc0cb"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Salmon","de-DE":"Lachs","en-US":"Salmon"}",
+          },
+          {
+            "name": "size",
+            "value": "{"en-GB":"Queen"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#FFC0CB","label":{"de-DE":"Rosa","en-GB":"Pink","en-US":"Pink"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3627,
+              "width": 5589,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-YYm1GR3y.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 3228,
+              "width": 5216,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-8eeyUKq9.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CSKP-0932",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-05.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-05.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,13 +23,13 @@ const cottonSilkBedsheet05 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-YYm1GR3y.jpeg'
         )
         .dimensions({ w: 5589, h: 3627 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-8eeyUKq9.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-05.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-05.ts
@@ -37,16 +37,14 @@ const cottonSilkBedsheet05 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 5216, h: 3228 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'en-US':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'de-DE':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'en-US':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'de-DE':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+      }),
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#ffc0cb', 'de-DE': '#ffc0cb', 'en-US': '#ffc0cb' }),
@@ -54,16 +52,6 @@ const cottonSilkBedsheet05 = (): TProductVariantDraftBuilder =>
         .name('colorlabel')
         .value({ 'en-GB': 'Salmon', 'de-DE': 'Lachs', 'en-US': 'Salmon' }),
       AttributeDraft.random().name('size').value({ 'en-GB': 'Queen' }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'en-US':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'de-DE':
-            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
-        }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-05.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-05.ts
@@ -1,0 +1,75 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cottonSilkBedsheet05 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CSKP-0932')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1599))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1599))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1599))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-YYm1GR3y.jpeg'
+        )
+        .dimensions({ w: 5589, h: 3627 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-8eeyUKq9.jpeg'
+        )
+        .dimensions({ w: 5216, h: 3228 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'en-US':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'de-DE':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#ffc0cb', 'de-DE': '#ffc0cb', 'en-US': '#ffc0cb' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'Salmon', 'de-DE': 'Lachs', 'en-US': 'Salmon' }),
+      AttributeDraft.random().name('size').value({ 'en-GB': 'Queen' }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'en-US':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'de-DE':
+            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#FFC0CB',
+          label: { 'de-DE': 'Rosa', 'en-GB': 'Pink', 'en-US': 'Pink' },
+        }),
+    ]);
+
+export default cottonSilkBedsheet05;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-06.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-06.spec.ts
@@ -1,0 +1,238 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cottonSilkBedsheet06 from './cotton-silk-bedsheet-06';
+
+describe(`with cottonSilkBedsheet06 preset`, () => {
+  it(`should return a cottonSilkBedsheet06 preset`, () => {
+    const cottonSilkBedsheet06Preset =
+      cottonSilkBedsheet06().build<TProductVariantDraft>();
+    expect(cottonSilkBedsheet06Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#ffc0cb",
+              "en-GB": "#ffc0cb",
+              "en-US": "#ffc0cb",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Lachs",
+              "en-GB": "Salmon",
+              "en-US": "Salmon",
+            },
+          },
+          {
+            "name": "size",
+            "value": {
+              "en-GB": "King",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#FFC0CB",
+              "label": {
+                "de-DE": "Rosa",
+                "en-GB": "Pink",
+                "en-US": "Pink",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3627,
+              "w": 5589,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-bUbU_TKg.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 3228,
+              "w": 5216,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-I0XNqDPK.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1899,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1899,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1899,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CSKP-083",
+      }
+    `);
+  });
+
+  it(`should return a cottonSilkBedsheet06 preset when built for graphql`, () => {
+    const cottonSilkBedsheet06PresetGraphql =
+      cottonSilkBedsheet06().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cottonSilkBedsheet06PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","en-US":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","de-DE":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#ffc0cb","de-DE":"#ffc0cb","en-US":"#ffc0cb"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Salmon","de-DE":"Lachs","en-US":"Salmon"}",
+          },
+          {
+            "name": "size",
+            "value": "{"en-GB":"King"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#FFC0CB","label":{"de-DE":"Rosa","en-GB":"Pink","en-US":"Pink"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3627,
+              "width": 5589,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-bUbU_TKg.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 3228,
+              "width": 5216,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-I0XNqDPK.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1899,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1899,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1899,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CSKP-083",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-06.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-06.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,13 +23,13 @@ const cottonSilkBedsheet06 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-bUbU_TKg.jpeg'
         )
         .dimensions({ w: 5589, h: 3627 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-I0XNqDPK.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-06.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-06.ts
@@ -1,0 +1,75 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cottonSilkBedsheet06 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CSKP-083')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1899))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1899))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1899))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-bUbU_TKg.jpeg'
+        )
+        .dimensions({ w: 5589, h: 3627 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-I0XNqDPK.jpeg'
+        )
+        .dimensions({ w: 5216, h: 3228 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'en-US':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'de-DE':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#ffc0cb', 'de-DE': '#ffc0cb', 'en-US': '#ffc0cb' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'Salmon', 'de-DE': 'Lachs', 'en-US': 'Salmon' }),
+      AttributeDraft.random().name('size').value({ 'en-GB': 'King' }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'en-US':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'de-DE':
+            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#FFC0CB',
+          label: { 'de-DE': 'Rosa', 'en-GB': 'Pink', 'en-US': 'Pink' },
+        }),
+    ]);
+
+export default cottonSilkBedsheet06;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-06.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-06.ts
@@ -37,16 +37,14 @@ const cottonSilkBedsheet06 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 5216, h: 3228 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'en-US':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'de-DE':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'en-US':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'de-DE':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+      }),
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#ffc0cb', 'de-DE': '#ffc0cb', 'en-US': '#ffc0cb' }),
@@ -54,16 +52,6 @@ const cottonSilkBedsheet06 = (): TProductVariantDraftBuilder =>
         .name('colorlabel')
         .value({ 'en-GB': 'Salmon', 'de-DE': 'Lachs', 'en-US': 'Salmon' }),
       AttributeDraft.random().name('size').value({ 'en-GB': 'King' }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'en-US':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'de-DE':
-            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
-        }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-07.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-07.spec.ts
@@ -1,0 +1,222 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cottonSilkBedsheet07 from './cotton-silk-bedsheet-07';
+
+describe(`with cottonSilkBedsheet07 preset`, () => {
+  it(`should return a cottonSilkBedsheet07 preset`, () => {
+    const cottonSilkBedsheet07Preset =
+      cottonSilkBedsheet07().build<TProductVariantDraft>();
+    expect(cottonSilkBedsheet07Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#bcbcbc",
+              "en-GB": "#bcbcbc",
+              "en-US": "#bcbcbc",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Grau",
+              "en-GB": "Gray",
+              "en-US": "Gray",
+            },
+          },
+          {
+            "name": "size",
+            "value": {
+              "en-GB": "Twin",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#808080",
+              "label": {
+                "de-DE": "Grau",
+                "en-GB": "Gray",
+                "en-US": "Gray",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3848,
+              "w": 6016,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-qnDiKfx7.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CSKG-92",
+      }
+    `);
+  });
+
+  it(`should return a cottonSilkBedsheet07 preset when built for graphql`, () => {
+    const cottonSilkBedsheet07PresetGraphql =
+      cottonSilkBedsheet07().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cottonSilkBedsheet07PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","en-US":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","de-DE":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#bcbcbc","de-DE":"#bcbcbc","en-US":"#bcbcbc"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Gray","de-DE":"Grau","en-US":"Gray"}",
+          },
+          {
+            "name": "size",
+            "value": "{"en-GB":"Twin"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3848,
+              "width": 6016,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-qnDiKfx7.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CSKG-92",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-07.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-07.ts
@@ -1,0 +1,69 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cottonSilkBedsheet07 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CSKG-92')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1299))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1299))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1299))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-qnDiKfx7.jpeg'
+        )
+        .dimensions({ w: 6016, h: 3848 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'en-US':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'de-DE':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#bcbcbc', 'de-DE': '#bcbcbc', 'en-US': '#bcbcbc' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'Gray', 'de-DE': 'Grau', 'en-US': 'Gray' }),
+      AttributeDraft.random().name('size').value({ 'en-GB': 'Twin' }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'en-US':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'de-DE':
+            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#808080',
+          label: { 'de-DE': 'Grau', 'en-GB': 'Gray', 'en-US': 'Gray' },
+        }),
+    ]);
+
+export default cottonSilkBedsheet07;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-07.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-07.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const cottonSilkBedsheet07 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-qnDiKfx7.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-07.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-07.ts
@@ -31,16 +31,14 @@ const cottonSilkBedsheet07 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 6016, h: 3848 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'en-US':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'de-DE':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'en-US':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'de-DE':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+      }),
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#bcbcbc', 'de-DE': '#bcbcbc', 'en-US': '#bcbcbc' }),
@@ -48,16 +46,6 @@ const cottonSilkBedsheet07 = (): TProductVariantDraftBuilder =>
         .name('colorlabel')
         .value({ 'en-GB': 'Gray', 'de-DE': 'Grau', 'en-US': 'Gray' }),
       AttributeDraft.random().name('size').value({ 'en-GB': 'Twin' }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'en-US':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'de-DE':
-            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
-        }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-08.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-08.spec.ts
@@ -1,0 +1,222 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cottonSilkBedsheet08 from './cotton-silk-bedsheet-08';
+
+describe(`with cottonSilkBedsheet08 preset`, () => {
+  it(`should return a cottonSilkBedsheet08 preset`, () => {
+    const cottonSilkBedsheet08Preset =
+      cottonSilkBedsheet08().build<TProductVariantDraft>();
+    expect(cottonSilkBedsheet08Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#bcbcbc",
+              "en-GB": "#bcbcbc",
+              "en-US": "#bcbcbc",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Grau",
+              "en-GB": "Gray",
+              "en-US": "Gray",
+            },
+          },
+          {
+            "name": "size",
+            "value": {
+              "en-GB": "Queen",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#808080",
+              "label": {
+                "de-DE": "Grau",
+                "en-GB": "Gray",
+                "en-US": "Gray",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3848,
+              "w": 6016,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-BPilhC_x.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CSKG-023",
+      }
+    `);
+  });
+
+  it(`should return a cottonSilkBedsheet08 preset when built for graphql`, () => {
+    const cottonSilkBedsheet08PresetGraphql =
+      cottonSilkBedsheet08().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cottonSilkBedsheet08PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","en-US":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","de-DE":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#bcbcbc","de-DE":"#bcbcbc","en-US":"#bcbcbc"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Gray","de-DE":"Grau","en-US":"Gray"}",
+          },
+          {
+            "name": "size",
+            "value": "{"en-GB":"Queen"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3848,
+              "width": 6016,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-BPilhC_x.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CSKG-023",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-08.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-08.ts
@@ -31,16 +31,14 @@ const cottonSilkBedsheet08 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 6016, h: 3848 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'en-US':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'de-DE':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'en-US':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'de-DE':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+      }),
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#bcbcbc', 'de-DE': '#bcbcbc', 'en-US': '#bcbcbc' }),
@@ -48,16 +46,6 @@ const cottonSilkBedsheet08 = (): TProductVariantDraftBuilder =>
         .name('colorlabel')
         .value({ 'en-GB': 'Gray', 'de-DE': 'Grau', 'en-US': 'Gray' }),
       AttributeDraft.random().name('size').value({ 'en-GB': 'Queen' }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'en-US':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'de-DE':
-            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
-        }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-08.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-08.ts
@@ -1,0 +1,69 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cottonSilkBedsheet08 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CSKG-023')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1599))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1599))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1599))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-BPilhC_x.jpeg'
+        )
+        .dimensions({ w: 6016, h: 3848 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'en-US':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'de-DE':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#bcbcbc', 'de-DE': '#bcbcbc', 'en-US': '#bcbcbc' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'Gray', 'de-DE': 'Grau', 'en-US': 'Gray' }),
+      AttributeDraft.random().name('size').value({ 'en-GB': 'Queen' }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'en-US':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'de-DE':
+            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#808080',
+          label: { 'de-DE': 'Grau', 'en-GB': 'Gray', 'en-US': 'Gray' },
+        }),
+    ]);
+
+export default cottonSilkBedsheet08;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-08.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-08.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const cottonSilkBedsheet08 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-BPilhC_x.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-09.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-09.spec.ts
@@ -1,0 +1,222 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cottonSilkBedsheet09 from './cotton-silk-bedsheet-09';
+
+describe(`with cottonSilkBedsheet09 preset`, () => {
+  it(`should return a cottonSilkBedsheet09 preset`, () => {
+    const cottonSilkBedsheet09Preset =
+      cottonSilkBedsheet09().build<TProductVariantDraft>();
+    expect(cottonSilkBedsheet09Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#bcbcbc",
+              "en-GB": "#bcbcbc",
+              "en-US": "#bcbcbc",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Grau",
+              "en-GB": "Gray",
+              "en-US": "Gray",
+            },
+          },
+          {
+            "name": "size",
+            "value": {
+              "en-GB": "King",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#808080",
+              "label": {
+                "de-DE": "Grau",
+                "en-GB": "Gray",
+                "en-US": "Gray",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3848,
+              "w": 6016,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-KFchHtXM.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1899,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1899,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1899,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CSKG-2345",
+      }
+    `);
+  });
+
+  it(`should return a cottonSilkBedsheet09 preset when built for graphql`, () => {
+    const cottonSilkBedsheet09PresetGraphql =
+      cottonSilkBedsheet09().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cottonSilkBedsheet09PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","en-US":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet","de-DE":"- Machine washable\\n- 600 thread count\\n- Includes 1 fitted sheet"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#bcbcbc","de-DE":"#bcbcbc","en-US":"#bcbcbc"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Gray","de-DE":"Grau","en-US":"Gray"}",
+          },
+          {
+            "name": "size",
+            "value": "{"en-GB":"King"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3848,
+              "width": 6016,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-KFchHtXM.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1899,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1899,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1899,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CSKG-2345",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-09.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-09.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const cottonSilkBedsheet09 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-KFchHtXM.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-09.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-09.ts
@@ -1,0 +1,69 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cottonSilkBedsheet09 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CSKG-2345')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1899))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1899))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1899))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-KFchHtXM.jpeg'
+        )
+        .dimensions({ w: 6016, h: 3848 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'en-US':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+          'de-DE':
+            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#bcbcbc', 'de-DE': '#bcbcbc', 'en-US': '#bcbcbc' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'Gray', 'de-DE': 'Grau', 'en-US': 'Gray' }),
+      AttributeDraft.random().name('size').value({ 'en-GB': 'King' }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'en-US':
+            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
+          'de-DE':
+            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#808080',
+          label: { 'de-DE': 'Grau', 'en-GB': 'Gray', 'en-US': 'Gray' },
+        }),
+    ]);
+
+export default cottonSilkBedsheet09;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-09.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-09.ts
@@ -31,16 +31,14 @@ const cottonSilkBedsheet09 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 6016, h: 3848 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'en-US':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-          'de-DE':
-            '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'en-US':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+        'de-DE':
+          '- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet',
+      }),
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#bcbcbc', 'de-DE': '#bcbcbc', 'en-US': '#bcbcbc' }),
@@ -48,16 +46,6 @@ const cottonSilkBedsheet09 = (): TProductVariantDraftBuilder =>
         .name('colorlabel')
         .value({ 'en-GB': 'Gray', 'de-DE': 'Grau', 'en-US': 'Gray' }),
       AttributeDraft.random().name('size').value({ 'en-GB': 'King' }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'en-US':
-            'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ',
-          'de-DE':
-            'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.',
-        }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-two-seater-sofa-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-two-seater-sofa-01.spec.ts
@@ -1,0 +1,226 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cottonTwoSeaterSofa01 from './cotton-two-seater-sofa-01';
+
+describe(`with cottonTwoSeaterSofa01 preset`, () => {
+  it(`should return a cottonTwoSeaterSofa01 preset`, () => {
+    const cottonTwoSeaterSofa01Preset =
+      cottonTwoSeaterSofa01().build<TProductVariantDraft>();
+    expect(cottonTwoSeaterSofa01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#FFF",
+              "en-GB": "#FFF",
+              "en-US": "#FFF",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Weiß",
+              "en-GB": "White",
+              "en-US": "White",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#FFF",
+              "label": {
+                "de-DE": "Weiss",
+                "en-GB": "White",
+                "en-US": "White",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 2969,
+              "w": 5035,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_225174101-6XExeL2D.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 637,
+              "w": 1000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_202436963-ZB2HxGeB.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 3840,
+              "w": 5760,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377510554-dyXzuIQC.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 54900,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 54900,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 54900,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CTSS-0983",
+      }
+    `);
+  });
+
+  it(`should return a cottonTwoSeaterSofa01 preset when built for graphql`, () => {
+    const cottonTwoSeaterSofa01PresetGraphql =
+      cottonTwoSeaterSofa01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cottonTwoSeaterSofa01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "color",
+            "value": "{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"White","de-DE":"Weiß","en-US":"White"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 2969,
+              "width": 5035,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_225174101-6XExeL2D.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 637,
+              "width": 1000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_202436963-ZB2HxGeB.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 3840,
+              "width": 5760,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377510554-dyXzuIQC.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 54900,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 54900,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 54900,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CTSS-0983",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-two-seater-sofa-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-two-seater-sofa-01.ts
@@ -44,16 +44,6 @@ const cottonTwoSeaterSofa01 = (): TProductVariantDraftBuilder =>
     ])
     .attributes([
       AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            "The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room.",
-          'en-US':
-            "The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room.",
-          'de-DE':
-            'Das 2-Sitzer-Baumwollsofa ist eine gemütliche und bequeme Sitzgelegenheit für jedes Zuhause. Aus weichem, hochwertigem Baumwollstoff gefertigt, ist dieses Sofa sanft zur Haut und pflegeleicht. Die beiden Sitzkissen sind weich und stützend und bieten ein komfortables Sitzerlebnis. Die Rückenlehne des Sofas ist gut gepolstert und bietet reichlich Rückenunterstützung, während die Armlehnen für ein bequemes und entspanntes Gefühl sanft abgerundet sind. Der Holzrahmen des Sofas ist robust und langlebig, sodass er viele Jahre hält. Mit einer neutralen Farbe fügt sich dieses Sofa nahtlos in jeden Einrichtungsstil ein, während das schlichte und elegante Design jedem Raum einen Hauch von Raffinesse verleiht.',
-        }),
-      AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),
       AttributeDraft.random()

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-two-seater-sofa-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-two-seater-sofa-01.ts
@@ -1,0 +1,70 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cottonTwoSeaterSofa01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CTSS-0983')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(54900))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(54900))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(54900))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_225174101-6XExeL2D.jpeg'
+        )
+        .dimensions({ w: 5035, h: 2969 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_202436963-ZB2HxGeB.jpeg'
+        )
+        .dimensions({ w: 1000, h: 637 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377510554-dyXzuIQC.jpeg'
+        )
+        .dimensions({ w: 5760, h: 3840 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            "The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room.",
+          'en-US':
+            "The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room.",
+          'de-DE':
+            'Das 2-Sitzer-Baumwollsofa ist eine gemütliche und bequeme Sitzgelegenheit für jedes Zuhause. Aus weichem, hochwertigem Baumwollstoff gefertigt, ist dieses Sofa sanft zur Haut und pflegeleicht. Die beiden Sitzkissen sind weich und stützend und bieten ein komfortables Sitzerlebnis. Die Rückenlehne des Sofas ist gut gepolstert und bietet reichlich Rückenunterstützung, während die Armlehnen für ein bequemes und entspanntes Gefühl sanft abgerundet sind. Der Holzrahmen des Sofas ist robust und langlebig, sodass er viele Jahre hält. Mit einer neutralen Farbe fügt sich dieses Sofa nahtlos in jeden Einrichtungsstil ein, während das schlichte und elegante Design jedem Raum einen Hauch von Raffinesse verleiht.',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'White', 'de-DE': 'Weiß', 'en-US': 'White' }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#FFF',
+          label: { 'de-DE': 'Weiss', 'en-GB': 'White', 'en-US': 'White' },
+        }),
+    ]);
+
+export default cottonTwoSeaterSofa01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-two-seater-sofa-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-two-seater-sofa-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,19 +23,19 @@ const cottonTwoSeaterSofa01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_225174101-6XExeL2D.jpeg'
         )
         .dimensions({ w: 5035, h: 2969 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_202436963-ZB2HxGeB.jpeg'
         )
         .dimensions({ w: 1000, h: 637 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377510554-dyXzuIQC.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/crystal-drinking-glass-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/crystal-drinking-glass-01.spec.ts
@@ -1,0 +1,167 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import crystalDrinkingGlass01 from './crystal-drinking-glass-01';
+
+describe(`with crystalDrinkingGlass01 preset`, () => {
+  it(`should return a crystalDrinkingGlass01 preset`, () => {
+    const crystalDrinkingGlass01Preset =
+      crystalDrinkingGlass01().build<TProductVariantDraft>();
+    expect(crystalDrinkingGlass01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Das Set enthält 6 Gläser",
+              "en-GB": "- Set includes 6 glasses",
+              "en-US": "- Set includes 6 glasses",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3000,
+              "w": 3000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Crystal%20Drinking%20Gla-8ynxF_aM.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 3499,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 3499,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 3499,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CDG-09",
+      }
+    `);
+  });
+
+  it(`should return a crystalDrinkingGlass01 preset when built for graphql`, () => {
+    const crystalDrinkingGlass01PresetGraphql =
+      crystalDrinkingGlass01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(crystalDrinkingGlass01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Set includes 6 glasses","de-DE":"- Das Set enthält 6 Gläser","en-US":"- Set includes 6 glasses"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3000,
+              "width": 3000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Crystal%20Drinking%20Gla-8ynxF_aM.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 3499,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 3499,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 3499,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CDG-09",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/crystal-drinking-glass-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/crystal-drinking-glass-01.ts
@@ -1,0 +1,53 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const crystalDrinkingGlass01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CDG-09')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(3499))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(3499))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(3499))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Crystal%20Drinking%20Gla-8ynxF_aM.jpeg'
+        )
+        .dimensions({ w: 3000, h: 3000 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Set includes 6 glasses',
+          'de-DE': '- Das Set enthält 6 Gläser',
+          'en-US': '- Set includes 6 glasses',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.',
+          'en-US':
+            'This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.',
+          'de-DE':
+            'Dieses Kristall-Trinkglas besteht aus hochwertigem, bleifreiem Kristallglas, das dünn und zart, aber dennoch stark und langlebig ist. Das Kristallmaterial des Longdrinkglases wertet das Getränk auf und lässt es funkelnder und farbenfroher erscheinen. Es verbessert auch das Aroma und den Geschmack des Getränks und ermöglicht es dem Trinker, die Komplexität der Zutaten voll zu schätzen.  Das Design des Glases soll die Zugabe von Eis, Soda oder anderen Mixern ermöglichen und dennoch viel Platz für das Getränk selbst lassen. Die weite Öffnung des Glases lässt den Trinker das Aroma des Getränks riechen, während die geraden Seiten und die glatte Oberfläche das Trinken und Genießen erleichtern.  Das Kristall-Highballglas ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist das Highball-Glas aus Kristall ein stilvolles und elegantes Glasgeschirr, das sich perfekt zum Servieren von großen Mixgetränken eignet. Sein zartes Kristallmaterial und sein kompliziertes Design machen es zu einer beliebten Wahl für besondere Anlässe und gehobene Speiseerlebnisse.',
+        }),
+    ]);
+
+export default crystalDrinkingGlass01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/crystal-drinking-glass-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/crystal-drinking-glass-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const crystalDrinkingGlass01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Crystal%20Drinking%20Gla-8ynxF_aM.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/crystal-drinking-glass-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/crystal-drinking-glass-01.ts
@@ -31,23 +31,11 @@ const crystalDrinkingGlass01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 3000, h: 3000 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Set includes 6 glasses',
-          'de-DE': '- Das Set enthält 6 Gläser',
-          'en-US': '- Set includes 6 glasses',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.',
-          'en-US':
-            'This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.',
-          'de-DE':
-            'Dieses Kristall-Trinkglas besteht aus hochwertigem, bleifreiem Kristallglas, das dünn und zart, aber dennoch stark und langlebig ist. Das Kristallmaterial des Longdrinkglases wertet das Getränk auf und lässt es funkelnder und farbenfroher erscheinen. Es verbessert auch das Aroma und den Geschmack des Getränks und ermöglicht es dem Trinker, die Komplexität der Zutaten voll zu schätzen.  Das Design des Glases soll die Zugabe von Eis, Soda oder anderen Mixern ermöglichen und dennoch viel Platz für das Getränk selbst lassen. Die weite Öffnung des Glases lässt den Trinker das Aroma des Getränks riechen, während die geraden Seiten und die glatte Oberfläche das Trinken und Genießen erleichtern.  Das Kristall-Highballglas ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist das Highball-Glas aus Kristall ein stilvolles und elegantes Glasgeschirr, das sich perfekt zum Servieren von großen Mixgetränken eignet. Sein zartes Kristallmaterial und sein kompliziertes Design machen es zu einer beliebten Wahl für besondere Anlässe und gehobene Speiseerlebnisse.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Set includes 6 glasses',
+        'de-DE': '- Das Set enthält 6 Gläser',
+        'en-US': '- Set includes 6 glasses',
+      }),
     ]);
 
 export default crystalDrinkingGlass01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cube-jute-basket-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cube-jute-basket-01.spec.ts
@@ -1,0 +1,212 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import cubeJuteBasket01 from './cube-jute-basket-01';
+
+describe(`with cubeJuteBasket01 preset`, () => {
+  it(`should return a cubeJuteBasket01 preset`, () => {
+    const cubeJuteBasket01Preset =
+      cubeJuteBasket01().build<TProductVariantDraft>();
+    expect(cubeJuteBasket01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Jute
+      - Vormontiert
+      - 1 Fuß x 1 Fuß x 1 Fuß",
+              "en-GB": "- Jute
+      - Preassembled
+      - 1ft x 1ft x 1ft",
+              "en-US": "- Jute
+      - Preassembled
+      - 1ft x 1ft x 1ft",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#D2B48C",
+              "label": {
+                "de-DE": "Bräunen",
+                "en-GB": "Tan",
+                "en-US": "Tan",
+              },
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#EEB348",
+              "en-GB": "#EEB348",
+              "en-US": "#EEB348",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Jute",
+              "en-GB": "Jute",
+              "en-US": "Jute",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3564,
+              "w": 4684,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_355946576-nRxA5NAP.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1299,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "CJB-01",
+      }
+    `);
+  });
+
+  it(`should return a cubeJuteBasket01 preset when built for graphql`, () => {
+    const cubeJuteBasket01PresetGraphql =
+      cubeJuteBasket01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(cubeJuteBasket01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Jute\\n- Preassembled\\n- 1ft x 1ft x 1ft","de-DE":"- Jute\\n- Vormontiert\\n- 1 Fuß x 1 Fuß x 1 Fuß","en-US":"- Jute\\n- Preassembled\\n- 1ft x 1ft x 1ft"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#D2B48C","label":{"de-DE":"Bräunen","en-GB":"Tan","en-US":"Tan"}}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#EEB348","de-DE":"#EEB348","en-US":"#EEB348"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Jute","de-DE":"Jute","en-US":"Jute"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3564,
+              "width": 4684,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_355946576-nRxA5NAP.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1299,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "CJB-01",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cube-jute-basket-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cube-jute-basket-01.ts
@@ -31,23 +31,11 @@ const cubeJuteBasket01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 4684, h: 3564 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Jute\n- Preassembled\n- 1ft x 1ft x 1ft',
-          'de-DE': '- Jute\n- Vormontiert\n- 1 Fuß x 1 Fuß x 1 Fuß',
-          'en-US': '- Jute\n- Preassembled\n- 1ft x 1ft x 1ft',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.',
-          'en-US':
-            'A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.',
-          'de-DE':
-            'Ein Würfel-Jutekorb für das Wohnzimmer ist eine praktische und stilvolle Aufbewahrungslösung, die dem Raum Wärme und Struktur verleiht. Der Korb besteht aus natürlichen Jutefasern, die eng miteinander verwoben sind, um eine robuste und langlebige Struktur zu schaffen.  Die Würfelform des Korbs eignet sich perfekt zur Aufbewahrung einer Vielzahl von Gegenständen wie Decken, Zeitschriften, Fernbedienungen oder sogar kleinen Pflanzen. Die offene Oberseite des Korbs ermöglicht einen einfachen Zugriff auf den Inhalt, während die Seiten eine sichere Barriere bieten, um alles ordentlich zu verstauen.  Die neutrale Farbe der Jutefasern ergänzt eine Vielzahl von Einrichtungsstilen, von böhmisch über küstennah bis rustikal. Der Korb kann auf den Boden oder in ein Regal gestellt werden und lässt sich dank seiner kompakten Größe bei Bedarf leicht bewegen.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Jute\n- Preassembled\n- 1ft x 1ft x 1ft',
+        'de-DE': '- Jute\n- Vormontiert\n- 1 Fuß x 1 Fuß x 1 Fuß',
+        'en-US': '- Jute\n- Preassembled\n- 1ft x 1ft x 1ft',
+      }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cube-jute-basket-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cube-jute-basket-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const cubeJuteBasket01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_355946576-nRxA5NAP.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cube-jute-basket-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cube-jute-basket-01.ts
@@ -1,0 +1,65 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const cubeJuteBasket01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('CJB-01')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1299))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1299))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1299))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_355946576-nRxA5NAP.jpeg'
+        )
+        .dimensions({ w: 4684, h: 3564 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Jute\n- Preassembled\n- 1ft x 1ft x 1ft',
+          'de-DE': '- Jute\n- Vormontiert\n- 1 Fuß x 1 Fuß x 1 Fuß',
+          'en-US': '- Jute\n- Preassembled\n- 1ft x 1ft x 1ft',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.',
+          'en-US':
+            'A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.',
+          'de-DE':
+            'Ein Würfel-Jutekorb für das Wohnzimmer ist eine praktische und stilvolle Aufbewahrungslösung, die dem Raum Wärme und Struktur verleiht. Der Korb besteht aus natürlichen Jutefasern, die eng miteinander verwoben sind, um eine robuste und langlebige Struktur zu schaffen.  Die Würfelform des Korbs eignet sich perfekt zur Aufbewahrung einer Vielzahl von Gegenständen wie Decken, Zeitschriften, Fernbedienungen oder sogar kleinen Pflanzen. Die offene Oberseite des Korbs ermöglicht einen einfachen Zugriff auf den Inhalt, während die Seiten eine sichere Barriere bieten, um alles ordentlich zu verstauen.  Die neutrale Farbe der Jutefasern ergänzt eine Vielzahl von Einrichtungsstilen, von böhmisch über küstennah bis rustikal. Der Korb kann auf den Boden oder in ein Regal gestellt werden und lässt sich dank seiner kompakten Größe bei Bedarf leicht bewegen.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#D2B48C',
+          label: { 'de-DE': 'Bräunen', 'en-GB': 'Tan', 'en-US': 'Tan' },
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#EEB348', 'de-DE': '#EEB348', 'en-US': '#EEB348' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'Jute', 'de-DE': 'Jute', 'en-US': 'Jute' }),
+    ]);
+
+export default cubeJuteBasket01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-sided-shot-glass-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-sided-shot-glass-01.spec.ts
@@ -1,0 +1,170 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import doubleSidedShotGlass01 from './double-sided-shot-glass-01';
+
+describe(`with doubleSidedShotGlass01 preset`, () => {
+  it(`should return a doubleSidedShotGlass01 preset`, () => {
+    const doubleSidedShotGlass01Preset =
+      doubleSidedShotGlass01().build<TProductVariantDraft>();
+    expect(doubleSidedShotGlass01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Edelstahl
+      - Spülmaschinenfest",
+              "en-GB": "- Stainless steel
+      - Dishwasher safe",
+              "en-US": "- Stainless steel
+      - Dishwasher safe",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 5472,
+              "w": 3648,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_95721248-5HSKgKgr.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 299,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 299,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 299,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "SHOT-095",
+      }
+    `);
+  });
+
+  it(`should return a doubleSidedShotGlass01 preset when built for graphql`, () => {
+    const doubleSidedShotGlass01PresetGraphql =
+      doubleSidedShotGlass01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(doubleSidedShotGlass01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Stainless steel\\n- Dishwasher safe","de-DE":"- Edelstahl\\n- Spülmaschinenfest","en-US":"- Stainless steel\\n- Dishwasher safe"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 5472,
+              "width": 3648,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_95721248-5HSKgKgr.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 299,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 299,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 299,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "SHOT-095",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-sided-shot-glass-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-sided-shot-glass-01.ts
@@ -31,23 +31,11 @@ const doubleSidedShotGlass01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 3648, h: 5472 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Stainless steel\n- Dishwasher safe',
-          'de-DE': '- Edelstahl\n- Spülmaschinenfest',
-          'en-US': '- Stainless steel\n- Dishwasher safe',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.',
-          'en-US':
-            'This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.',
-          'de-DE':
-            'Dieses Stahlschnapsglas besteht aus Stahl und hat zwei Enden, eines zum Messen eines Standardschnapses und das andere zum Messen eines größeren Doppelschnapses. Die Enden sind wie kleine Tassen mit abgerundeten Kanten zum einfachen Ausgießen geformt. Die Stahlkonstruktion macht es langlebig und verschleißfest und bietet gleichzeitig ein elegantes und modernes Erscheinungsbild.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Stainless steel\n- Dishwasher safe',
+        'de-DE': '- Edelstahl\n- Spülmaschinenfest',
+        'en-US': '- Stainless steel\n- Dishwasher safe',
+      }),
     ]);
 
 export default doubleSidedShotGlass01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-sided-shot-glass-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-sided-shot-glass-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const doubleSidedShotGlass01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_95721248-5HSKgKgr.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-sided-shot-glass-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-sided-shot-glass-01.ts
@@ -1,0 +1,53 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const doubleSidedShotGlass01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('SHOT-095')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(299))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(299))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(299))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_95721248-5HSKgKgr.jpeg'
+        )
+        .dimensions({ w: 3648, h: 5472 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Stainless steel\n- Dishwasher safe',
+          'de-DE': '- Edelstahl\n- Spülmaschinenfest',
+          'en-US': '- Stainless steel\n- Dishwasher safe',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.',
+          'en-US':
+            'This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.',
+          'de-DE':
+            'Dieses Stahlschnapsglas besteht aus Stahl und hat zwei Enden, eines zum Messen eines Standardschnapses und das andere zum Messen eines größeren Doppelschnapses. Die Enden sind wie kleine Tassen mit abgerundeten Kanten zum einfachen Ausgießen geformt. Die Stahlkonstruktion macht es langlebig und verschleißfest und bietet gleichzeitig ein elegantes und modernes Erscheinungsbild.',
+        }),
+    ]);
+
+export default doubleSidedShotGlass01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-walled-espresso-glass-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-walled-espresso-glass-01.spec.ts
@@ -1,0 +1,183 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import doubleWalledEspressoGlass01 from './double-walled-espresso-glass-01';
+
+describe(`with doubleWalledEspressoGlass01 preset`, () => {
+  it(`should return a doubleWalledEspressoGlass01 preset`, () => {
+    const doubleWalledEspressoGlass01Preset =
+      doubleWalledEspressoGlass01().build<TProductVariantDraft>();
+    expect(doubleWalledEspressoGlass01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Das Set enthält 4 Gläser",
+              "en-GB": "- Set includes 4 glasses",
+              "en-US": "- Set includes 4 glasses",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3098,
+              "w": 3371,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_571236838-yanGZ5gf.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 1481,
+              "w": 987,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/photo-1585975761152--ZGxY2KXD.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 4299,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 4299,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 4299,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "DWEG-09",
+      }
+    `);
+  });
+
+  it(`should return a doubleWalledEspressoGlass01 preset when built for graphql`, () => {
+    const doubleWalledEspressoGlass01PresetGraphql =
+      doubleWalledEspressoGlass01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(doubleWalledEspressoGlass01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Set includes 4 glasses","de-DE":"- Das Set enthält 4 Gläser","en-US":"- Set includes 4 glasses"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3098,
+              "width": 3371,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_571236838-yanGZ5gf.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 1481,
+              "width": 987,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/photo-1585975761152--ZGxY2KXD.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 4299,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 4299,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 4299,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "DWEG-09",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-walled-espresso-glass-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-walled-espresso-glass-01.ts
@@ -37,23 +37,11 @@ const doubleWalledEspressoGlass01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 987, h: 1481 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'de-DE':
-            'Eine doppelwandige Espressotasse aus Glas ist eine Art Trinkgefäß, das speziell zum Servieren von Espresso entwickelt wurde. Sie besteht aus Glas und ist doppelwandig aufgebaut, was bedeutet, dass es zwei Glasschichten gibt, die durch einen kleinen Spalt getrennt sind.  Das doppelwandige Design der Espressotasse aus Glas bietet mehrere Vorteile. Erstens hilft es, den Espresso zu isolieren, wodurch er länger heiß bleibt. Zweitens sorgt die doppelwandige Konstruktion dafür, dass sich die Außenseite der Tasse kühl anfühlt, wodurch sie auch bei sehr heißem Espresso angenehm in der Hand liegt.  Die Tasse ist normalerweise klein und hat ein Fassungsvermögen von etwa 2-3 Unzen, was die perfekte Größe für einen Schuss Espresso ist. Das Glas ist außerdem transparent, sodass Sie die satte, dunkle Farbe des Espressos sehen können, wenn er eingeschenkt und getrunken wird.  Die doppelwandige Espressotasse aus Glas wird oft mit einer passenden Untertasse kombiniert, die der Tasse einen stabilen Stand bietet und auch Platz für einen kleinen Löffel oder Keks bietet. Insgesamt ist die doppelwandige Espressotasse aus Glas eine stilvolle und funktionale Möglichkeit, die reichen und komplexen Aromen eines Espressos zu genießen.',
-          'en-GB':
-            'A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso.',
-          'en-US':
-            'A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso.',
-        }),
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Set includes 4 glasses',
-          'de-DE': '- Das Set enthält 4 Gläser',
-          'en-US': '- Set includes 4 glasses',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Set includes 4 glasses',
+        'de-DE': '- Das Set enthält 4 Gläser',
+        'en-US': '- Set includes 4 glasses',
+      }),
     ]);
 
 export default doubleWalledEspressoGlass01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-walled-espresso-glass-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-walled-espresso-glass-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,13 +23,13 @@ const doubleWalledEspressoGlass01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_571236838-yanGZ5gf.jpeg'
         )
         .dimensions({ w: 3371, h: 3098 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/photo-1585975761152--ZGxY2KXD.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-walled-espresso-glass-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/double-walled-espresso-glass-01.ts
@@ -1,0 +1,59 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const doubleWalledEspressoGlass01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('DWEG-09')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(4299))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(4299))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(4299))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_571236838-yanGZ5gf.jpeg'
+        )
+        .dimensions({ w: 3371, h: 3098 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/photo-1585975761152--ZGxY2KXD.jpeg'
+        )
+        .dimensions({ w: 987, h: 1481 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'de-DE':
+            'Eine doppelwandige Espressotasse aus Glas ist eine Art Trinkgefäß, das speziell zum Servieren von Espresso entwickelt wurde. Sie besteht aus Glas und ist doppelwandig aufgebaut, was bedeutet, dass es zwei Glasschichten gibt, die durch einen kleinen Spalt getrennt sind.  Das doppelwandige Design der Espressotasse aus Glas bietet mehrere Vorteile. Erstens hilft es, den Espresso zu isolieren, wodurch er länger heiß bleibt. Zweitens sorgt die doppelwandige Konstruktion dafür, dass sich die Außenseite der Tasse kühl anfühlt, wodurch sie auch bei sehr heißem Espresso angenehm in der Hand liegt.  Die Tasse ist normalerweise klein und hat ein Fassungsvermögen von etwa 2-3 Unzen, was die perfekte Größe für einen Schuss Espresso ist. Das Glas ist außerdem transparent, sodass Sie die satte, dunkle Farbe des Espressos sehen können, wenn er eingeschenkt und getrunken wird.  Die doppelwandige Espressotasse aus Glas wird oft mit einer passenden Untertasse kombiniert, die der Tasse einen stabilen Stand bietet und auch Platz für einen kleinen Löffel oder Keks bietet. Insgesamt ist die doppelwandige Espressotasse aus Glas eine stilvolle und funktionale Möglichkeit, die reichen und komplexen Aromen eines Espressos zu genießen.',
+          'en-GB':
+            'A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso.',
+          'en-US':
+            'A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso.',
+        }),
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Set includes 4 glasses',
+          'de-DE': '- Das Set enthält 4 Gläser',
+          'en-US': '- Set includes 4 glasses',
+        }),
+    ]);
+
+export default doubleWalledEspressoGlass01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ecru-double-bed-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ecru-double-bed-01.spec.ts
@@ -1,0 +1,185 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import ecruDoubleBed01 from './ecru-double-bed-01';
+
+describe(`with ecruDoubleBed01 preset`, () => {
+  it(`should return a ecruDoubleBed01 preset`, () => {
+    const ecruDoubleBed01Preset =
+      ecruDoubleBed01().build<TProductVariantDraft>();
+    expect(ecruDoubleBed01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Mit gepolstertem Kopfteil
+      - Montage inklusive",
+              "en-GB": "- Comes with pillow-top headboard
+      - Assembly included",
+              "en-US": "- Comes with pillow-top headboard
+      - Assembly included",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#F5F5DC",
+              "label": {
+                "de-DE": "Beige",
+                "en-GB": "Beige",
+                "en-US": "Beige",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 2000,
+              "w": 2000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Ecru%20Twin%20Bed-q6309G4v.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 89900,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 89900,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 89900,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "SQB-034",
+      }
+    `);
+  });
+
+  it(`should return a ecruDoubleBed01 preset when built for graphql`, () => {
+    const ecruDoubleBed01PresetGraphql =
+      ecruDoubleBed01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(ecruDoubleBed01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Comes with pillow-top headboard\\n- Assembly included","de-DE":"- Mit gepolstertem Kopfteil\\n- Montage inklusive","en-US":"- Comes with pillow-top headboard\\n- Assembly included"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#F5F5DC","label":{"de-DE":"Beige","en-GB":"Beige","en-US":"Beige"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 2000,
+              "width": 2000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Ecru%20Twin%20Bed-q6309G4v.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 89900,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 89900,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 89900,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "SQB-034",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ecru-double-bed-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ecru-double-bed-01.ts
@@ -31,23 +31,11 @@ const ecruDoubleBed01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 2000, h: 2000 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Comes with pillow-top headboard\n- Assembly included',
-          'de-DE': '- Mit gepolstertem Kopfteil\n- Montage inklusive',
-          'en-US': '- Comes with pillow-top headboard\n- Assembly included',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.',
-          'en-US':
-            'A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.',
-          'de-DE':
-            'Ein Doppelbett mit Sofakopfteil ist ein einzigartiges und vielseitiges Möbelstück, das den Komfort eines Bettes mit der Funktionalität eines Sofas verbindet. Der Bettrahmen ist rechteckig und groß genug, um eine Standard-Doppelmatratze aufzunehmen. Das Kopfteil hat die Form eines Sofas, das oben am Bettrahmen befestigt ist. Das Kopfteil des Sofas bietet eine bequeme Rückenlehne zum Sitzen im Bett, um zu lesen, fernzusehen oder an einem Laptop zu arbeiten. Das Kopfteil des Sofas ist mit einem weichen und strapazierfähigen Stoff bezogen und bietet eine bequeme Sitzfläche. Insgesamt ist ein Queensize-Bett mit Sofa-Kopfteil ein praktisches und stilvolles Möbelstück, das jedem Schlafzimmer sowohl Komfort als auch Funktionalität verleiht.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Comes with pillow-top headboard\n- Assembly included',
+        'de-DE': '- Mit gepolstertem Kopfteil\n- Montage inklusive',
+        'en-US': '- Comes with pillow-top headboard\n- Assembly included',
+      }),
       AttributeDraft.random()
         .name('color-filter')
         .value({

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ecru-double-bed-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ecru-double-bed-01.ts
@@ -1,0 +1,59 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const ecruDoubleBed01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('SQB-034')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(89900))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(89900))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(89900))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Ecru%20Twin%20Bed-q6309G4v.jpeg'
+        )
+        .dimensions({ w: 2000, h: 2000 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Comes with pillow-top headboard\n- Assembly included',
+          'de-DE': '- Mit gepolstertem Kopfteil\n- Montage inklusive',
+          'en-US': '- Comes with pillow-top headboard\n- Assembly included',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.',
+          'en-US':
+            'A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.',
+          'de-DE':
+            'Ein Doppelbett mit Sofakopfteil ist ein einzigartiges und vielseitiges Möbelstück, das den Komfort eines Bettes mit der Funktionalität eines Sofas verbindet. Der Bettrahmen ist rechteckig und groß genug, um eine Standard-Doppelmatratze aufzunehmen. Das Kopfteil hat die Form eines Sofas, das oben am Bettrahmen befestigt ist. Das Kopfteil des Sofas bietet eine bequeme Rückenlehne zum Sitzen im Bett, um zu lesen, fernzusehen oder an einem Laptop zu arbeiten. Das Kopfteil des Sofas ist mit einem weichen und strapazierfähigen Stoff bezogen und bietet eine bequeme Sitzfläche. Insgesamt ist ein Queensize-Bett mit Sofa-Kopfteil ein praktisches und stilvolles Möbelstück, das jedem Schlafzimmer sowohl Komfort als auch Funktionalität verleiht.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#F5F5DC',
+          label: { 'de-DE': 'Beige', 'en-GB': 'Beige', 'en-US': 'Beige' },
+        }),
+    ]);
+
+export default ecruDoubleBed01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ecru-double-bed-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ecru-double-bed-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const ecruDoubleBed01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Ecru%20Twin%20Bed-q6309G4v.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/edgar-armchair-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/edgar-armchair-01.spec.ts
@@ -1,0 +1,230 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import edgarArmchair01 from './edgar-armchair-01';
+
+describe(`with edgarArmchair01 preset`, () => {
+  it(`should return a edgarArmchair01 preset`, () => {
+    const edgarArmchair01Preset =
+      edgarArmchair01().build<TProductVariantDraft>();
+    expect(edgarArmchair01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Montage bei Lieferung",
+              "en-GB": "- Assembly on delivery",
+              "en-US": "- Assembly on delivery",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Leichter Salbei",
+              "en-GB": "Light Sage",
+              "en-US": "Light Sage",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#B6C9B6",
+              "en-GB": "#B6C9B6",
+              "en-US": "#B6C9B6",
+            },
+          },
+          {
+            "name": "finishlabel",
+            "value": {
+              "de-DE": "Eisen",
+              "en-GB": "Iron",
+              "en-US": "Iron",
+            },
+          },
+          {
+            "name": "finish",
+            "value": {
+              "de-DE": "#000",
+              "en-GB": "#000",
+              "en-US": "#000",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#00FF00",
+              "label": {
+                "de-DE": "Grün",
+                "en-GB": "Green",
+                "en-US": "Green",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 4000,
+              "w": 5000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_438943116-tYXWisJi.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 129900,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 129900,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 129900,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "EARM-04",
+      }
+    `);
+  });
+
+  it(`should return a edgarArmchair01 preset when built for graphql`, () => {
+    const edgarArmchair01PresetGraphql =
+      edgarArmchair01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(edgarArmchair01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Assembly on delivery","de-DE":"- Montage bei Lieferung","en-US":"- Assembly on delivery"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Light Sage","de-DE":"Leichter Salbei","en-US":"Light Sage"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#B6C9B6","de-DE":"#B6C9B6","en-US":"#B6C9B6"}",
+          },
+          {
+            "name": "finishlabel",
+            "value": "{"en-GB":"Iron","de-DE":"Eisen","en-US":"Iron"}",
+          },
+          {
+            "name": "finish",
+            "value": "{"en-GB":"#000","de-DE":"#000","en-US":"#000"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#00FF00","label":{"de-DE":"Grün","en-GB":"Green","en-US":"Green"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 4000,
+              "width": 5000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_438943116-tYXWisJi.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 129900,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 129900,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 129900,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "EARM-04",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/edgar-armchair-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/edgar-armchair-01.ts
@@ -31,30 +31,16 @@ const edgarArmchair01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 5000, h: 4000 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Assembly on delivery',
-          'de-DE': '- Montage bei Lieferung',
-          'en-US': '- Assembly on delivery',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.',
-          'en-US':
-            'An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.',
-          'de-DE':
-            'Ein Sessel im abstrakten modernen Stil mit Metallbeinen ist ein einzigartiges Möbelstück, das jedem Raum einen Hauch von Raffinesse verleiht. Der Stuhl ist mit klaren Linien und einem schlanken Profil gestaltet und verfügt über einen niedrigen, breiten Sitz und eine hohe Rückenlehne, die sich sanft um die Seiten des Stuhls krümmt. Der Sitz und die Rückenlehne sind mit einem strukturierten, strapazierfähigen Stoff bezogen, der dem klassischen Sesseldesign eine zeitgemäße Note verleiht. Die Metallbeine sind dünn und konisch zulaufend und bilden eine filigrane und dennoch stabile Basis für den Stuhl. Insgesamt ist dieser Sessel eine perfekte Mischung aus Stil und Komfort, was ihn zu einer großartigen Ergänzung für jeden modernen Wohnraum macht.',
-        }),
-      AttributeDraft.random()
-        .name('colorlabel')
-        .value({
-          'en-GB': 'Light Sage',
-          'de-DE': 'Leichter Salbei',
-          'en-US': 'Light Sage',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Assembly on delivery',
+        'de-DE': '- Montage bei Lieferung',
+        'en-US': '- Assembly on delivery',
+      }),
+      AttributeDraft.random().name('colorlabel').value({
+        'en-GB': 'Light Sage',
+        'de-DE': 'Leichter Salbei',
+        'en-US': 'Light Sage',
+      }),
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#B6C9B6', 'de-DE': '#B6C9B6', 'en-US': '#B6C9B6' }),

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/edgar-armchair-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/edgar-armchair-01.ts
@@ -1,0 +1,75 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const edgarArmchair01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('EARM-04')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(129900))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(129900))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(129900))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_438943116-tYXWisJi.jpeg'
+        )
+        .dimensions({ w: 5000, h: 4000 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Assembly on delivery',
+          'de-DE': '- Montage bei Lieferung',
+          'en-US': '- Assembly on delivery',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.',
+          'en-US':
+            'An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.',
+          'de-DE':
+            'Ein Sessel im abstrakten modernen Stil mit Metallbeinen ist ein einzigartiges Möbelstück, das jedem Raum einen Hauch von Raffinesse verleiht. Der Stuhl ist mit klaren Linien und einem schlanken Profil gestaltet und verfügt über einen niedrigen, breiten Sitz und eine hohe Rückenlehne, die sich sanft um die Seiten des Stuhls krümmt. Der Sitz und die Rückenlehne sind mit einem strukturierten, strapazierfähigen Stoff bezogen, der dem klassischen Sesseldesign eine zeitgemäße Note verleiht. Die Metallbeine sind dünn und konisch zulaufend und bilden eine filigrane und dennoch stabile Basis für den Stuhl. Insgesamt ist dieser Sessel eine perfekte Mischung aus Stil und Komfort, was ihn zu einer großartigen Ergänzung für jeden modernen Wohnraum macht.',
+        }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({
+          'en-GB': 'Light Sage',
+          'de-DE': 'Leichter Salbei',
+          'en-US': 'Light Sage',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#B6C9B6', 'de-DE': '#B6C9B6', 'en-US': '#B6C9B6' }),
+      AttributeDraft.random()
+        .name('finishlabel')
+        .value({ 'en-GB': 'Iron', 'de-DE': 'Eisen', 'en-US': 'Iron' }),
+      AttributeDraft.random()
+        .name('finish')
+        .value({ 'en-GB': '#000', 'de-DE': '#000', 'en-US': '#000' }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#00FF00',
+          label: { 'de-DE': 'Grün', 'en-GB': 'Green', 'en-US': 'Green' },
+        }),
+    ]);
+
+export default edgarArmchair01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/edgar-armchair-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/edgar-armchair-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const edgarArmchair01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_438943116-tYXWisJi.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ella-square-plate-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ella-square-plate-01.spec.ts
@@ -1,0 +1,222 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import ellaSquarePlate01 from './ella-square-plate-01';
+
+describe(`with ellaSquarePlate01 preset`, () => {
+  it(`should return a ellaSquarePlate01 preset`, () => {
+    const ellaSquarePlate01Preset =
+      ellaSquarePlate01().build<TProductVariantDraft>();
+    expect(ellaSquarePlate01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Enthält 1 Teller",
+              "en-GB": "- Includes 1 plate",
+              "en-US": "- Includes 1 plate",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#FFF",
+              "en-GB": "#FFF",
+              "en-US": "#FFF",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Weiß",
+              "en-GB": "White",
+              "en-US": "White",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#FFF",
+              "label": {
+                "de-DE": "Weiss",
+                "en-GB": "White",
+                "en-US": "White",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3412,
+              "w": 5692,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_96107425-uNhRfSVg.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 4912,
+              "w": 7360,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_297660480-6pQH9vjF.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 1599,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "ESP-1",
+      }
+    `);
+  });
+
+  it(`should return a ellaSquarePlate01 preset when built for graphql`, () => {
+    const ellaSquarePlate01PresetGraphql =
+      ellaSquarePlate01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(ellaSquarePlate01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Includes 1 plate","de-DE":"- Enthält 1 Teller","en-US":"- Includes 1 plate"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"White","de-DE":"Weiß","en-US":"White"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3412,
+              "width": 5692,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_96107425-uNhRfSVg.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 4912,
+              "width": 7360,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_297660480-6pQH9vjF.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 1599,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "ESP-1",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ella-square-plate-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ella-square-plate-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,13 +23,13 @@ const ellaSquarePlate01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_96107425-uNhRfSVg.jpeg'
         )
         .dimensions({ w: 5692, h: 3412 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_297660480-6pQH9vjF.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ella-square-plate-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ella-square-plate-01.ts
@@ -37,23 +37,11 @@ const ellaSquarePlate01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 7360, h: 4912 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Includes 1 plate',
-          'de-DE': '- Enthält 1 Teller',
-          'en-US': '- Includes 1 plate',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'de-DE':
-            'Dieser quadratische Ella-Keramikteller ist eine flache, vierseitige Schale, die sich ideal zum Servieren oder Präsentieren von Speisen eignet. Eine flache quadratische Servierplatte ist ideal zum Servieren einer Vielzahl von Speisen, von Vorspeisen und Hauptgerichten bis hin zu Desserts und Snacks. Es kann sowohl für formelle als auch für ungezwungene Anlässe verwendet werden, und seine Einfachheit und Vielseitigkeit machen es zu einer beliebten Wahl für viele verschiedene Arten von Küchen.  Insgesamt ist ein quadratischer Keramikteller eine funktionale und stilvolle Wahl zum Servieren von Mahlzeiten und kann jedem Speiseerlebnis einen Hauch von Eleganz verleihen.',
-          'en-GB':
-            'This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience.',
-          'en-US':
-            'This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Includes 1 plate',
+        'de-DE': '- Enthält 1 Teller',
+        'en-US': '- Includes 1 plate',
+      }),
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ella-square-plate-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/ella-square-plate-01.ts
@@ -1,0 +1,71 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const ellaSquarePlate01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('ESP-1')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(1599))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(1599))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(1599))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_96107425-uNhRfSVg.jpeg'
+        )
+        .dimensions({ w: 5692, h: 3412 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_297660480-6pQH9vjF.jpeg'
+        )
+        .dimensions({ w: 7360, h: 4912 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Includes 1 plate',
+          'de-DE': '- Enthält 1 Teller',
+          'en-US': '- Includes 1 plate',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'de-DE':
+            'Dieser quadratische Ella-Keramikteller ist eine flache, vierseitige Schale, die sich ideal zum Servieren oder Präsentieren von Speisen eignet. Eine flache quadratische Servierplatte ist ideal zum Servieren einer Vielzahl von Speisen, von Vorspeisen und Hauptgerichten bis hin zu Desserts und Snacks. Es kann sowohl für formelle als auch für ungezwungene Anlässe verwendet werden, und seine Einfachheit und Vielseitigkeit machen es zu einer beliebten Wahl für viele verschiedene Arten von Küchen.  Insgesamt ist ein quadratischer Keramikteller eine funktionale und stilvolle Wahl zum Servieren von Mahlzeiten und kann jedem Speiseerlebnis einen Hauch von Eleganz verleihen.',
+          'en-GB':
+            'This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience.',
+          'en-US':
+            'This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience.',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'White', 'de-DE': 'Weiß', 'en-US': 'White' }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#FFF',
+          label: { 'de-DE': 'Weiss', 'en-GB': 'White', 'en-US': 'White' },
+        }),
+    ]);
+
+export default ellaSquarePlate01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/emerald-velvet-chair-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/emerald-velvet-chair-01.spec.ts
@@ -1,0 +1,230 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import emeraldVelvetChair01 from './emerald-velvet-chair-01';
+
+describe(`with emeraldVelvetChair01 preset`, () => {
+  it(`should return a emeraldVelvetChair01 preset`, () => {
+    const emeraldVelvetChair01Preset =
+      emeraldVelvetChair01().build<TProductVariantDraft>();
+    expect(emeraldVelvetChair01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Nur chemische Reinigung",
+              "en-GB": "- Dry clean only",
+              "en-US": "- Dry clean only",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Smaragd",
+              "en-GB": "Emerald",
+              "en-US": "Emerald",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#219A0E",
+              "en-GB": "#219A0E",
+              "en-US": "#219A0E",
+            },
+          },
+          {
+            "name": "finishlabel",
+            "value": {
+              "de-DE": "Gold",
+              "en-GB": "Gold",
+              "en-US": "Gold",
+            },
+          },
+          {
+            "name": "finish",
+            "value": {
+              "de-DE": "#F8EE18",
+              "en-GB": "#F8EE18",
+              "en-US": "#F8EE18",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#00FF00",
+              "label": {
+                "de-DE": "Grün",
+                "en-GB": "Green",
+                "en-US": "Green",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 4800,
+              "w": 6000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_298830220-MjoqNbBu.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 39900,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 39900,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 39900,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "VARM-09",
+      }
+    `);
+  });
+
+  it(`should return a emeraldVelvetChair01 preset when built for graphql`, () => {
+    const emeraldVelvetChair01PresetGraphql =
+      emeraldVelvetChair01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(emeraldVelvetChair01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Dry clean only","de-DE":"- Nur chemische Reinigung","en-US":"- Dry clean only"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Emerald","de-DE":"Smaragd","en-US":"Emerald"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#219A0E","de-DE":"#219A0E","en-US":"#219A0E"}",
+          },
+          {
+            "name": "finishlabel",
+            "value": "{"en-GB":"Gold","de-DE":"Gold","en-US":"Gold"}",
+          },
+          {
+            "name": "finish",
+            "value": "{"en-GB":"#F8EE18","de-DE":"#F8EE18","en-US":"#F8EE18"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#00FF00","label":{"de-DE":"Grün","en-GB":"Green","en-US":"Green"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 4800,
+              "width": 6000,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_298830220-MjoqNbBu.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 39900,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 39900,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 39900,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "VARM-09",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/emerald-velvet-chair-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/emerald-velvet-chair-01.ts
@@ -31,23 +31,11 @@ const emeraldVelvetChair01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 6000, h: 4800 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Dry clean only',
-          'de-DE': '- Nur chemische Reinigung',
-          'en-US': '- Dry clean only',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.',
-          'en-US':
-            'A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.',
-          'de-DE':
-            'Ein Samtstuhl mit Messinggestell ist ein elegantes und luxuriöses Möbelstück. Das weiche, plüschige Samtmaterial des Stuhls sorgt für ein bequemes und gemütliches Sitzerlebnis. Die smaragdgrüne Farbe des Samtstoffs ist weich und zart und verleiht dem Gesamtbild des Stuhls einen Hauch von Weiblichkeit.  Der Messingrahmen des Stuhls ist robust und langlebig und bietet eine solide Grundlage für den Sitzbereich. Die Messingfarbe des Gestells verleiht dem Gesamtbild des Stuhls einen Hauch von Wärme und Raffinesse. Die Kombination aus Samt und Messingrahmen schafft einen auffälligen Kontrast und macht diesen Stuhl zu einem Statement-Piece in jedem Raum.  Der Stuhl verfügt über eine hohe Rückenlehne mit geschwungenem Design, die Rücken und Schultern stützt. Der Stuhl ist sowohl auf Stil als auch auf Komfort ausgelegt, was ihn zu einer großartigen Ergänzung für jedes Wohnzimmer, Schlafzimmer oder Büro macht.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Dry clean only',
+        'de-DE': '- Nur chemische Reinigung',
+        'en-US': '- Dry clean only',
+      }),
       AttributeDraft.random()
         .name('colorlabel')
         .value({ 'en-GB': 'Emerald', 'de-DE': 'Smaragd', 'en-US': 'Emerald' }),

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/emerald-velvet-chair-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/emerald-velvet-chair-01.ts
@@ -1,0 +1,71 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const emeraldVelvetChair01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('VARM-09')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(39900))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(39900))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(39900))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_298830220-MjoqNbBu.jpeg'
+        )
+        .dimensions({ w: 6000, h: 4800 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Dry clean only',
+          'de-DE': '- Nur chemische Reinigung',
+          'en-US': '- Dry clean only',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.',
+          'en-US':
+            'A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.',
+          'de-DE':
+            'Ein Samtstuhl mit Messinggestell ist ein elegantes und luxuriöses Möbelstück. Das weiche, plüschige Samtmaterial des Stuhls sorgt für ein bequemes und gemütliches Sitzerlebnis. Die smaragdgrüne Farbe des Samtstoffs ist weich und zart und verleiht dem Gesamtbild des Stuhls einen Hauch von Weiblichkeit.  Der Messingrahmen des Stuhls ist robust und langlebig und bietet eine solide Grundlage für den Sitzbereich. Die Messingfarbe des Gestells verleiht dem Gesamtbild des Stuhls einen Hauch von Wärme und Raffinesse. Die Kombination aus Samt und Messingrahmen schafft einen auffälligen Kontrast und macht diesen Stuhl zu einem Statement-Piece in jedem Raum.  Der Stuhl verfügt über eine hohe Rückenlehne mit geschwungenem Design, die Rücken und Schultern stützt. Der Stuhl ist sowohl auf Stil als auch auf Komfort ausgelegt, was ihn zu einer großartigen Ergänzung für jedes Wohnzimmer, Schlafzimmer oder Büro macht.',
+        }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({ 'en-GB': 'Emerald', 'de-DE': 'Smaragd', 'en-US': 'Emerald' }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#219A0E', 'de-DE': '#219A0E', 'en-US': '#219A0E' }),
+      AttributeDraft.random()
+        .name('finishlabel')
+        .value({ 'en-GB': 'Gold', 'de-DE': 'Gold', 'en-US': 'Gold' }),
+      AttributeDraft.random()
+        .name('finish')
+        .value({ 'en-GB': '#F8EE18', 'de-DE': '#F8EE18', 'en-US': '#F8EE18' }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#00FF00',
+          label: { 'de-DE': 'Grün', 'en-GB': 'Green', 'en-US': 'Green' },
+        }),
+    ]);
+
+export default emeraldVelvetChair01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/emerald-velvet-chair-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/emerald-velvet-chair-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const emeraldVelvetChair01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_298830220-MjoqNbBu.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/entryway-closet-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/entryway-closet-01.spec.ts
@@ -1,0 +1,238 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import entrywayCloset01 from './entryway-closet-01';
+
+describe(`with entrywayCloset01 preset`, () => {
+  it(`should return a entrywayCloset01 preset`, () => {
+    const entrywayCloset01Preset =
+      entrywayCloset01().build<TProductVariantDraft>();
+    expect(entrywayCloset01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Montage im Lieferumfang enthalten",
+              "en-GB": "- Assembly included in delivery",
+              "en-US": "- Assembly included in delivery",
+            },
+          },
+          {
+            "name": "finishlabel",
+            "value": {
+              "de-DE": "weiße Eiche",
+              "en-GB": "White Oak",
+              "en-US": "White Oak",
+            },
+          },
+          {
+            "name": "finish",
+            "value": {
+              "de-DE": "#EFDBB4",
+              "en-GB": "#EFDBB4",
+              "en-US": "#EFDBB4",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#F5F5DC",
+              "label": {
+                "de-DE": "Beige",
+                "en-GB": "Beige",
+                "en-US": "Beige",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 4125,
+              "w": 5500,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072189-VkrMZMom.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 4512,
+              "w": 4700,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072356-yRaYUH0J.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 4125,
+              "w": 5500,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072850-w10HxuUM.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 259900,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 259900,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 259900,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "EWC-07",
+      }
+    `);
+  });
+
+  it(`should return a entrywayCloset01 preset when built for graphql`, () => {
+    const entrywayCloset01PresetGraphql =
+      entrywayCloset01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(entrywayCloset01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Assembly included in delivery","de-DE":"- Montage im Lieferumfang enthalten","en-US":"- Assembly included in delivery"}",
+          },
+          {
+            "name": "finishlabel",
+            "value": "{"en-GB":"White Oak","de-DE":"weiße Eiche","en-US":"White Oak"}",
+          },
+          {
+            "name": "finish",
+            "value": "{"en-GB":"#EFDBB4","de-DE":"#EFDBB4","en-US":"#EFDBB4"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#F5F5DC","label":{"de-DE":"Beige","en-GB":"Beige","en-US":"Beige"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 4125,
+              "width": 5500,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072189-VkrMZMom.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 4512,
+              "width": 4700,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072356-yRaYUH0J.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 4125,
+              "width": 5500,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072850-w10HxuUM.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 259900,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 259900,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 259900,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "EWC-07",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/entryway-closet-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/entryway-closet-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,19 +23,19 @@ const entrywayCloset01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072189-VkrMZMom.jpeg'
         )
         .dimensions({ w: 5500, h: 4125 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072356-yRaYUH0J.jpeg'
         )
         .dimensions({ w: 4700, h: 4512 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072850-w10HxuUM.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/entryway-closet-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/entryway-closet-01.ts
@@ -1,0 +1,81 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const entrywayCloset01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('EWC-07')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(259900))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(259900))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(259900))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072189-VkrMZMom.jpeg'
+        )
+        .dimensions({ w: 5500, h: 4125 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072356-yRaYUH0J.jpeg'
+        )
+        .dimensions({ w: 4700, h: 4512 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072850-w10HxuUM.jpeg'
+        )
+        .dimensions({ w: 5500, h: 4125 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Assembly included in delivery',
+          'de-DE': '- Montage im Lieferumfang enthalten',
+          'en-US': '- Assembly included in delivery',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.',
+          'en-US':
+            'An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.',
+          'de-DE':
+            'Ein Eingangsschrank mit Spiegeln und Leuchten ist ein Einbauschrank, der sich in der Nähe des Eingangs eines Hauses oder einer Wohnung befindet. Der Schrank verfügt über Ganzkörperspiegel, die es den Menschen ermöglichen, ihr Aussehen zu überprüfen, bevor sie das Haus verlassen. Der Schrank verfügt über eine Beleuchtung, die dazu beitragen kann, den Raum aufzuhellen und das Auffinden und Greifen von darin aufbewahrten Gegenständen zu erleichtern. Das Gesamtdesign des Schranks ist von Natur aus minimalistisch, mit klaren Linien und einem einfachen Farbschema, das sich nahtlos in das umgebende Dekor einfügen soll. Zusätzlich zu Spiegeln und Beleuchtung kann der Schrank Haken oder Regale zum Aufbewahren von Jacken, Hüten, Schuhen und anderen Accessoires aufweisen.',
+        }),
+      AttributeDraft.random()
+        .name('finishlabel')
+        .value({
+          'en-GB': 'White Oak',
+          'de-DE': 'weiße Eiche',
+          'en-US': 'White Oak',
+        }),
+      AttributeDraft.random()
+        .name('finish')
+        .value({ 'en-GB': '#EFDBB4', 'de-DE': '#EFDBB4', 'en-US': '#EFDBB4' }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#F5F5DC',
+          label: { 'de-DE': 'Beige', 'en-GB': 'Beige', 'en-US': 'Beige' },
+        }),
+    ]);
+
+export default entrywayCloset01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/entryway-closet-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/entryway-closet-01.ts
@@ -43,30 +43,16 @@ const entrywayCloset01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 5500, h: 4125 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Assembly included in delivery',
-          'de-DE': '- Montage im Lieferumfang enthalten',
-          'en-US': '- Assembly included in delivery',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.',
-          'en-US':
-            'An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.',
-          'de-DE':
-            'Ein Eingangsschrank mit Spiegeln und Leuchten ist ein Einbauschrank, der sich in der Nähe des Eingangs eines Hauses oder einer Wohnung befindet. Der Schrank verfügt über Ganzkörperspiegel, die es den Menschen ermöglichen, ihr Aussehen zu überprüfen, bevor sie das Haus verlassen. Der Schrank verfügt über eine Beleuchtung, die dazu beitragen kann, den Raum aufzuhellen und das Auffinden und Greifen von darin aufbewahrten Gegenständen zu erleichtern. Das Gesamtdesign des Schranks ist von Natur aus minimalistisch, mit klaren Linien und einem einfachen Farbschema, das sich nahtlos in das umgebende Dekor einfügen soll. Zusätzlich zu Spiegeln und Beleuchtung kann der Schrank Haken oder Regale zum Aufbewahren von Jacken, Hüten, Schuhen und anderen Accessoires aufweisen.',
-        }),
-      AttributeDraft.random()
-        .name('finishlabel')
-        .value({
-          'en-GB': 'White Oak',
-          'de-DE': 'weiße Eiche',
-          'en-US': 'White Oak',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Assembly included in delivery',
+        'de-DE': '- Montage im Lieferumfang enthalten',
+        'en-US': '- Assembly included in delivery',
+      }),
+      AttributeDraft.random().name('finishlabel').value({
+        'en-GB': 'White Oak',
+        'de-DE': 'weiße Eiche',
+        'en-US': 'White Oak',
+      }),
       AttributeDraft.random()
         .name('finish')
         .value({ 'en-GB': '#EFDBB4', 'de-DE': '#EFDBB4', 'en-US': '#EFDBB4' }),

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/evergreen-candle-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/evergreen-candle-01.spec.ts
@@ -1,0 +1,226 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import evergreenCandle01 from './evergreen-candle-01';
+
+describe(`with evergreenCandle01 preset`, () => {
+  it(`should return a evergreenCandle01 preset`, () => {
+    const evergreenCandle01Preset =
+      evergreenCandle01().build<TProductVariantDraft>();
+    expect(evergreenCandle01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#00FF00",
+              "label": {
+                "de-DE": "Grün",
+                "en-GB": "Green",
+                "en-US": "Green",
+              },
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Immergrün",
+              "en-GB": "Evergreen",
+              "en-US": "Evergreen",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#156F29",
+              "en-GB": "#156F29",
+              "en-US": "#156F29",
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 2160,
+              "w": 3840,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_537837949-oKQ-Kd3Q.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 2160,
+              "w": 3840,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_537917105-H0lwB1x2.jpeg",
+          },
+          {
+            "dimensions": {
+              "h": 6720,
+              "w": 4480,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_485090921-6JFeqs-M.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 299,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 299,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 299,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "EC-0993",
+      }
+    `);
+  });
+
+  it(`should return a evergreenCandle01 preset when built for graphql`, () => {
+    const evergreenCandle01PresetGraphql =
+      evergreenCandle01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(evergreenCandle01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "color-filter",
+            "value": "{"key":"#00FF00","label":{"de-DE":"Grün","en-GB":"Green","en-US":"Green"}}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"Evergreen","de-DE":"Immergrün","en-US":"Evergreen"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#156F29","de-DE":"#156F29","en-US":"#156F29"}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 2160,
+              "width": 3840,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_537837949-oKQ-Kd3Q.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 2160,
+              "width": 3840,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_537917105-H0lwB1x2.jpeg",
+          },
+          {
+            "dimensions": {
+              "height": 6720,
+              "width": 4480,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_485090921-6JFeqs-M.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 299,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 299,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 299,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "EC-0993",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/evergreen-candle-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/evergreen-candle-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,19 +23,19 @@ const evergreenCandle01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_537837949-oKQ-Kd3Q.jpeg'
         )
         .dimensions({ w: 3840, h: 2160 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_537917105-H0lwB1x2.jpeg'
         )
         .dimensions({ w: 3840, h: 2160 }),
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_485090921-6JFeqs-M.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/evergreen-candle-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/evergreen-candle-01.ts
@@ -44,28 +44,16 @@ const evergreenCandle01 = (): TProductVariantDraftBuilder =>
     ])
     .attributes([
       AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            'The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.',
-          'en-US':
-            'The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.',
-          'de-DE':
-            'Der Kerzenhalter hat ein schlichtes, rustikales Design mit einer hohen, schlanken Form, die an einen Baumstamm erinnert. Es kann auch mit kleinen immergrünen Zweigen, Beeren und Tannenzapfen dekoriert werden, um ein natürlicheres und organischeres Aussehen zu schaffen.  Wenn die Kerze angezündet wird, wirft sie einen warmen und gemütlichen Schein und schafft eine festliche und einladende Atmosphäre in jedem Raum. Der immergrüne Duft des Kerzenhalters kann auch durch die Wärme der Kerze verstärkt werden und erfüllt den Raum mit dem natürlichen Duft von Kiefer und Holz.  Insgesamt ist ein immergrüner Kerzenhalter während der Ferienzeit eine charmante und rustikale Ergänzung für jedes Zuhause. Seine natürlichen Materialien und Erdtöne können dazu beitragen, eine warme und einladende Atmosphäre zu schaffen, während sein einfaches, aber elegantes Design jedem Raum einen Hauch von Natur verleiht.',
-        }),
-      AttributeDraft.random()
         .name('color-filter')
         .value({
           key: '#00FF00',
           label: { 'de-DE': 'Grün', 'en-GB': 'Green', 'en-US': 'Green' },
         }),
-      AttributeDraft.random()
-        .name('colorlabel')
-        .value({
-          'en-GB': 'Evergreen',
-          'de-DE': 'Immergrün',
-          'en-US': 'Evergreen',
-        }),
+      AttributeDraft.random().name('colorlabel').value({
+        'en-GB': 'Evergreen',
+        'de-DE': 'Immergrün',
+        'en-US': 'Evergreen',
+      }),
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#156F29', 'de-DE': '#156F29', 'en-US': '#156F29' }),

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/evergreen-candle-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/evergreen-candle-01.ts
@@ -1,0 +1,74 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const evergreenCandle01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('EC-0993')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(299))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(299))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(299))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_537837949-oKQ-Kd3Q.jpeg'
+        )
+        .dimensions({ w: 3840, h: 2160 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_537917105-H0lwB1x2.jpeg'
+        )
+        .dimensions({ w: 3840, h: 2160 }),
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_485090921-6JFeqs-M.jpeg'
+        )
+        .dimensions({ w: 4480, h: 6720 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            'The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.',
+          'en-US':
+            'The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.',
+          'de-DE':
+            'Der Kerzenhalter hat ein schlichtes, rustikales Design mit einer hohen, schlanken Form, die an einen Baumstamm erinnert. Es kann auch mit kleinen immergrünen Zweigen, Beeren und Tannenzapfen dekoriert werden, um ein natürlicheres und organischeres Aussehen zu schaffen.  Wenn die Kerze angezündet wird, wirft sie einen warmen und gemütlichen Schein und schafft eine festliche und einladende Atmosphäre in jedem Raum. Der immergrüne Duft des Kerzenhalters kann auch durch die Wärme der Kerze verstärkt werden und erfüllt den Raum mit dem natürlichen Duft von Kiefer und Holz.  Insgesamt ist ein immergrüner Kerzenhalter während der Ferienzeit eine charmante und rustikale Ergänzung für jedes Zuhause. Seine natürlichen Materialien und Erdtöne können dazu beitragen, eine warme und einladende Atmosphäre zu schaffen, während sein einfaches, aber elegantes Design jedem Raum einen Hauch von Natur verleiht.',
+        }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#00FF00',
+          label: { 'de-DE': 'Grün', 'en-GB': 'Green', 'en-US': 'Green' },
+        }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({
+          'en-GB': 'Evergreen',
+          'de-DE': 'Immergrün',
+          'en-US': 'Evergreen',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#156F29', 'de-DE': '#156F29', 'en-US': '#156F29' }),
+    ]);
+
+export default evergreenCandle01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/fawn-armchair-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/fawn-armchair-01.spec.ts
@@ -1,0 +1,229 @@
+import type {
+  TProductVariantDraft,
+  TProductVariantDraftGraphql,
+} from '../../../types';
+import fawnArmchair01 from './fawn-armchair-01';
+
+describe(`with fawnArmchair01 preset`, () => {
+  it(`should return a fawnArmchair01 preset`, () => {
+    const fawnArmchair01Preset = fawnArmchair01().build<TProductVariantDraft>();
+    expect(fawnArmchair01Preset).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "de-DE": "- Leder erfordert besondere Pflege",
+              "en-GB": "- Leather requires special care",
+              "en-US": "- Leather requires special care",
+            },
+          },
+          {
+            "name": "color",
+            "value": {
+              "de-DE": "#FFF8ED",
+              "en-GB": "#FFF8ED",
+              "en-US": "#FFF8ED",
+            },
+          },
+          {
+            "name": "colorlabel",
+            "value": {
+              "de-DE": "Weißes Leder",
+              "en-GB": "White Leather",
+              "en-US": "White Leather",
+            },
+          },
+          {
+            "name": "finishlabel",
+            "value": {
+              "de-DE": "Kastanie",
+              "en-GB": "Chestnut",
+              "en-US": "Chestnut",
+            },
+          },
+          {
+            "name": "finish",
+            "value": {
+              "de-DE": "#1B1101",
+              "en-GB": "#1B1101",
+              "en-US": "#1B1101",
+            },
+          },
+          {
+            "name": "color-filter",
+            "value": {
+              "key": "#F5F5DC",
+              "label": {
+                "de-DE": "Beige",
+                "en-GB": "Beige",
+                "en-US": "Beige",
+              },
+            },
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "h": 3200,
+              "w": 2400,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Fawn%20Armchair-aPr3Rbhn.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 59900,
+              "currencyCode": "EUR",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 59900,
+              "currencyCode": "GBP",
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centAmount": 59900,
+              "currencyCode": "USD",
+            },
+          },
+        ],
+        "sku": "FARM-05",
+      }
+    `);
+  });
+
+  it(`should return a fawnArmchair01 preset when built for graphql`, () => {
+    const fawnArmchair01PresetGraphql =
+      fawnArmchair01().buildGraphql<TProductVariantDraftGraphql>();
+    expect(fawnArmchair01PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "assets": undefined,
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": "{"en-GB":"- Leather requires special care","de-DE":"- Leder erfordert besondere Pflege","en-US":"- Leather requires special care"}",
+          },
+          {
+            "name": "color",
+            "value": "{"en-GB":"#FFF8ED","de-DE":"#FFF8ED","en-US":"#FFF8ED"}",
+          },
+          {
+            "name": "colorlabel",
+            "value": "{"en-GB":"White Leather","de-DE":"Weißes Leder","en-US":"White Leather"}",
+          },
+          {
+            "name": "finishlabel",
+            "value": "{"en-GB":"Chestnut","de-DE":"Kastanie","en-US":"Chestnut"}",
+          },
+          {
+            "name": "finish",
+            "value": "{"en-GB":"#1B1101","de-DE":"#1B1101","en-US":"#1B1101"}",
+          },
+          {
+            "name": "color-filter",
+            "value": "{"key":"#F5F5DC","label":{"de-DE":"Beige","en-GB":"Beige","en-US":"Beige"}}",
+          },
+        ],
+        "images": [
+          {
+            "dimensions": {
+              "height": 3200,
+              "width": 2400,
+            },
+            "label": undefined,
+            "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Fawn%20Armchair-aPr3Rbhn.jpeg",
+          },
+        ],
+        "key": undefined,
+        "prices": [
+          {
+            "channel": undefined,
+            "country": "DE",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 59900,
+                "currencyCode": "EUR",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "GB",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 59900,
+                "currencyCode": "GBP",
+              },
+            },
+          },
+          {
+            "channel": undefined,
+            "country": "US",
+            "custom": undefined,
+            "customerGroup": undefined,
+            "discounted": undefined,
+            "key": undefined,
+            "tiers": undefined,
+            "validFrom": undefined,
+            "validUntil": undefined,
+            "value": {
+              "centPrecision": {
+                "centAmount": 59900,
+                "currencyCode": "USD",
+              },
+            },
+          },
+        ],
+        "sku": "FARM-05",
+      }
+    `);
+  });
+});

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/fawn-armchair-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/fawn-armchair-01.ts
@@ -31,40 +31,24 @@ const fawnArmchair01 = (): TProductVariantDraftBuilder =>
         .dimensions({ w: 2400, h: 3200 }),
     ])
     .attributes([
-      AttributeDraft.random()
-        .name('productspec')
-        .value({
-          'en-GB': '- Leather requires special care',
-          'de-DE': '- Leder erfordert besondere Pflege',
-          'en-US': '- Leather requires special care',
-        }),
-      AttributeDraft.random()
-        .name('product-description')
-        .value({
-          'en-GB':
-            "An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room.",
-          'en-US':
-            "An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room.",
-          'de-DE':
-            'Ein Art-Deco-Lederstuhl mit Ebenholzbeinen hat ein schlankes, stromlinienförmiges Design, das Raffinesse und Eleganz ausstrahlt. Der Stuhl hat einen bequem gepolsterten Sitz und eine Rückenlehne, wobei die Lederpolsterung ein weiches und luxuriöses Gefühl vermittelt. Die Beine aus Ebenholz sind lang und konisch zulaufend, mit einer glatten Oberfläche, die den modernen Stil des Stuhls betont. Der Stuhl weist auch markante Art-Deco-Elemente wie eckige Formen, kräftige Linien und geometrische Muster auf. Insgesamt wäre dieser Stuhl ein markantes Möbelstück, das jedem Raum sowohl Stil als auch Komfort verleiht.',
-        }),
+      AttributeDraft.random().name('productspec').value({
+        'en-GB': '- Leather requires special care',
+        'de-DE': '- Leder erfordert besondere Pflege',
+        'en-US': '- Leather requires special care',
+      }),
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#FFF8ED', 'de-DE': '#FFF8ED', 'en-US': '#FFF8ED' }),
-      AttributeDraft.random()
-        .name('colorlabel')
-        .value({
-          'en-GB': 'White Leather',
-          'de-DE': 'Weißes Leder',
-          'en-US': 'White Leather',
-        }),
-      AttributeDraft.random()
-        .name('finishlabel')
-        .value({
-          'en-GB': 'Chestnut',
-          'de-DE': 'Kastanie',
-          'en-US': 'Chestnut',
-        }),
+      AttributeDraft.random().name('colorlabel').value({
+        'en-GB': 'White Leather',
+        'de-DE': 'Weißes Leder',
+        'en-US': 'White Leather',
+      }),
+      AttributeDraft.random().name('finishlabel').value({
+        'en-GB': 'Chestnut',
+        'de-DE': 'Kastanie',
+        'en-US': 'Chestnut',
+      }),
       AttributeDraft.random()
         .name('finish')
         .value({ 'en-GB': '#1B1101', 'de-DE': '#1B1101', 'en-US': '#1B1101' }),

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/fawn-armchair-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/fawn-armchair-01.ts
@@ -1,6 +1,6 @@
 import { Money, PriceDraft } from '@commercetools-test-data/commons';
 import { AttributeDraft } from '../../../../attribute';
-import * as Image from '../../../../image';
+import { ImageDraft } from '../../../../image';
 import type { TProductVariantDraftBuilder } from '../../../types';
 import * as ProductVariantDraft from '../../index';
 
@@ -23,7 +23,7 @@ const fawnArmchair01 = (): TProductVariantDraftBuilder =>
         .country('US'),
     ])
     .images([
-      Image.ImageDraft.presets
+      ImageDraft.presets
         .empty()
         .url(
           'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Fawn%20Armchair-aPr3Rbhn.jpeg'

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/fawn-armchair-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/fawn-armchair-01.ts
@@ -1,0 +1,79 @@
+import { Money, PriceDraft } from '@commercetools-test-data/commons';
+import { AttributeDraft } from '../../../../attribute';
+import * as Image from '../../../../image';
+import type { TProductVariantDraftBuilder } from '../../../types';
+import * as ProductVariantDraft from '../../index';
+
+const fawnArmchair01 = (): TProductVariantDraftBuilder =>
+  ProductVariantDraft.presets
+    .empty()
+    .sku('FARM-05')
+    .prices([
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('EUR').centAmount(59900))
+        .country('DE'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('GBP').centAmount(59900))
+        .country('GB'),
+      PriceDraft.presets
+        .empty()
+        .value(Money.random().currencyCode('USD').centAmount(59900))
+        .country('US'),
+    ])
+    .images([
+      Image.ImageDraft.presets
+        .empty()
+        .url(
+          'https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Fawn%20Armchair-aPr3Rbhn.jpeg'
+        )
+        .dimensions({ w: 2400, h: 3200 }),
+    ])
+    .attributes([
+      AttributeDraft.random()
+        .name('productspec')
+        .value({
+          'en-GB': '- Leather requires special care',
+          'de-DE': '- Leder erfordert besondere Pflege',
+          'en-US': '- Leather requires special care',
+        }),
+      AttributeDraft.random()
+        .name('product-description')
+        .value({
+          'en-GB':
+            "An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room.",
+          'en-US':
+            "An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room.",
+          'de-DE':
+            'Ein Art-Deco-Lederstuhl mit Ebenholzbeinen hat ein schlankes, stromlinienförmiges Design, das Raffinesse und Eleganz ausstrahlt. Der Stuhl hat einen bequem gepolsterten Sitz und eine Rückenlehne, wobei die Lederpolsterung ein weiches und luxuriöses Gefühl vermittelt. Die Beine aus Ebenholz sind lang und konisch zulaufend, mit einer glatten Oberfläche, die den modernen Stil des Stuhls betont. Der Stuhl weist auch markante Art-Deco-Elemente wie eckige Formen, kräftige Linien und geometrische Muster auf. Insgesamt wäre dieser Stuhl ein markantes Möbelstück, das jedem Raum sowohl Stil als auch Komfort verleiht.',
+        }),
+      AttributeDraft.random()
+        .name('color')
+        .value({ 'en-GB': '#FFF8ED', 'de-DE': '#FFF8ED', 'en-US': '#FFF8ED' }),
+      AttributeDraft.random()
+        .name('colorlabel')
+        .value({
+          'en-GB': 'White Leather',
+          'de-DE': 'Weißes Leder',
+          'en-US': 'White Leather',
+        }),
+      AttributeDraft.random()
+        .name('finishlabel')
+        .value({
+          'en-GB': 'Chestnut',
+          'de-DE': 'Kastanie',
+          'en-US': 'Chestnut',
+        }),
+      AttributeDraft.random()
+        .name('finish')
+        .value({ 'en-GB': '#1B1101', 'de-DE': '#1B1101', 'en-US': '#1B1101' }),
+      AttributeDraft.random()
+        .name('color-filter')
+        .value({
+          key: '#F5F5DC',
+          label: { 'de-DE': 'Beige', 'en-GB': 'Beige', 'en-US': 'Beige' },
+        }),
+    ]);
+
+export default fawnArmchair01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/index.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/index.ts
@@ -18,6 +18,7 @@ import classicCoffeeCup01 from './classic-coffee-cup-01';
 import classicServingTray01 from './classic-serving-tray-01';
 import clinkChampagneGlass01 from './clink-champagne-glass-01';
 import cloudQueenBed01 from './cloud-queen-bed-01';
+import cobblestoneRug01 from './cobblestone-rug-01';
 
 const presets = {
   abigailLoungeChair01,
@@ -40,6 +41,7 @@ const presets = {
   classicServingTray01,
   clinkChampagneGlass01,
   cloudQueenBed01,
+  cobblestoneRug01,
 };
 
 export default presets;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/index.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/index.ts
@@ -21,8 +21,10 @@ import cloudQueenBed01 from './cloud-queen-bed-01';
 import cobblestoneRug01 from './cobblestone-rug-01';
 import cocktailShaker01 from './cocktail-shaker-01';
 import cocktailShakerSet01 from './cocktail-shaker-set-01';
+import cocktailStirringSpoon01 from './cocktail-stirring-spoon-01';
 import cocktailStrainer01 from './cocktail-strainer-01';
 import cocoaPillowCover01 from './cocoa-pillow-cover-01';
+import comfortCoffeeMug01 from './comfort-coffee-mug-01';
 import cottonSilkBedsheet01 from './cotton-silk-bedsheet-01';
 import cottonSilkBedsheet02 from './cotton-silk-bedsheet-02';
 import cottonSilkBedsheet03 from './cotton-silk-bedsheet-03';
@@ -69,8 +71,10 @@ const presets = {
   cobblestoneRug01,
   cocktailShaker01,
   cocktailShakerSet01,
+  cocktailStirringSpoon01,
   cocktailStrainer01,
   cocoaPillowCover01,
+  comfortCoffeeMug01,
   cottonSilkBedsheet01,
   cottonSilkBedsheet02,
   cottonSilkBedsheet03,

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/index.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/index.ts
@@ -19,6 +19,31 @@ import classicServingTray01 from './classic-serving-tray-01';
 import clinkChampagneGlass01 from './clink-champagne-glass-01';
 import cloudQueenBed01 from './cloud-queen-bed-01';
 import cobblestoneRug01 from './cobblestone-rug-01';
+import cocktailShaker01 from './cocktail-shaker-01';
+import cocktailShakerSet01 from './cocktail-shaker-set-01';
+import cocktailStrainer01 from './cocktail-strainer-01';
+import cocoaPillowCover01 from './cocoa-pillow-cover-01';
+import cottonSilkBedsheet01 from './cotton-silk-bedsheet-01';
+import cottonSilkBedsheet02 from './cotton-silk-bedsheet-02';
+import cottonSilkBedsheet03 from './cotton-silk-bedsheet-03';
+import cottonSilkBedsheet04 from './cotton-silk-bedsheet-04';
+import cottonSilkBedsheet05 from './cotton-silk-bedsheet-05';
+import cottonSilkBedsheet06 from './cotton-silk-bedsheet-06';
+import cottonSilkBedsheet07 from './cotton-silk-bedsheet-07';
+import cottonSilkBedsheet08 from './cotton-silk-bedsheet-08';
+import cottonSilkBedsheet09 from './cotton-silk-bedsheet-09';
+import cottonTwoSeaterSofa01 from './cotton-two-seater-sofa-01';
+import crystalDrinkingGlass01 from './crystal-drinking-glass-01';
+import cubeJuteBasket01 from './cube-jute-basket-01';
+import doubleSidedShotGlass01 from './double-sided-shot-glass-01';
+import doubleWalledEspressoGlass01 from './double-walled-espresso-glass-01';
+import ecruDoubleBed01 from './ecru-double-bed-01';
+import edgarArmchair01 from './edgar-armchair-01';
+import ellaSquarePlate01 from './ella-square-plate-01';
+import emeraldVelvetChair01 from './emerald-velvet-chair-01';
+import entrywayCloset01 from './entryway-closet-01';
+import evergreenCandle01 from './evergreen-candle-01';
+import fawnArmchair01 from './fawn-armchair-01';
 
 const presets = {
   abigailLoungeChair01,
@@ -42,6 +67,31 @@ const presets = {
   clinkChampagneGlass01,
   cloudQueenBed01,
   cobblestoneRug01,
+  cocktailShaker01,
+  cocktailShakerSet01,
+  cocktailStrainer01,
+  cocoaPillowCover01,
+  cottonSilkBedsheet01,
+  cottonSilkBedsheet02,
+  cottonSilkBedsheet03,
+  cottonSilkBedsheet04,
+  cottonSilkBedsheet05,
+  cottonSilkBedsheet06,
+  cottonSilkBedsheet07,
+  cottonSilkBedsheet08,
+  cottonSilkBedsheet09,
+  cottonTwoSeaterSofa01,
+  crystalDrinkingGlass01,
+  cubeJuteBasket01,
+  doubleSidedShotGlass01,
+  doubleWalledEspressoGlass01,
+  ecruDoubleBed01,
+  edgarArmchair01,
+  ellaSquarePlate01,
+  emeraldVelvetChair01,
+  entrywayCloset01,
+  evergreenCandle01,
+  fawnArmchair01,
 };
 
 export default presets;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/chianti-wine-glass.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/chianti-wine-glass.ts
@@ -32,7 +32,7 @@ const glasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .build<TCategoryDraft>();
 
 const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
-  .barGlassware()
+  .barAndGlassware()
   .build<TCategoryDraft>();
 
 const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-beer-mug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-beer-mug.ts
@@ -32,7 +32,7 @@ const glasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .build<TCategoryDraft>();
 
 const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
-  .barGlassware()
+  .barAndGlassware()
   .build<TCategoryDraft>();
 
 const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-champagne-glasses.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-champagne-glasses.ts
@@ -32,7 +32,7 @@ const glasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .build<TCategoryDraft>();
 
 const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
-  .barGlassware()
+  .barAndGlassware()
   .build<TCategoryDraft>();
 
 const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-coffee-cup.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-coffee-cup.ts
@@ -28,7 +28,7 @@ const classicCoffeeCupProductTypeDraft =
     .build<TProductTypeDraft>();
 
 const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
-  .barGlassware()
+  .barAndGlassware()
   .build<TCategoryDraft>();
 
 const glasswareDraft = CategoryDraft.presets.sampleDataGoodStore

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/clink-champagne-glass.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/clink-champagne-glass.ts
@@ -32,7 +32,7 @@ const glasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .build<TCategoryDraft>();
 
 const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
-  .barGlassware()
+  .barAndGlassware()
   .build<TCategoryDraft>();
 
 const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.spec.ts
@@ -1,0 +1,64 @@
+import type { TProductDraft } from '../../../types';
+import cobblestoneRug from './cobblestone-rug';
+describe(`with cobblestoneRug preset`, () => {
+  it('should return a sample cobblestoneRug product preset', () => {
+    const cobblestoneRugPreset = cobblestoneRug().build<TProductDraft>();
+    expect(cobblestoneRugPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "rugs",
+            "typeId": "category",
+          },
+          {
+            "key": "room-decor",
+            "typeId": "category",
+          },
+          {
+            "key": "home-decor",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "cobblestone-rug",
+      "name": {
+            "de-DE": "Kopfsteinpflaster",
+            "en-GB": "Cobblestone Rug",
+            "en-US": "Cobblestone Rug"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "kopfsteinpflaster",
+            "en-GB": "cobblestone-rug",
+            "en-US": "cobblestone-rug"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"product-description","value":{"de-DE":"Der Cobblestone-Teppich kann in einer Vielzahl von Räumen verwendet werden, von Wohnzimmern über Schlafzimmer bis hin zu Heimbüros. Es ist besonders beliebt in modernen und zeitgenössischen Einrichtungsstilen, wo sie dem Raum ein mutiges und grafisches Element hinzufügen können.  Insgesamt ist ein Teppich mit geometrischen Akzenten eine stilvolle und vielseitige Designwahl, die jedem Raum im Haus visuelles Interesse und Textur verleihen kann.","en-GB":"The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.","en-US":"The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home."}},{"name":"color-filter","value":{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}},{"name":"productspec","value":{"en-GB":"- 5ft x 3ft","de-DE":"- 5 Fuß x 3 Fuß","en-US":"- 5ft x 3ft"}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.spec.ts
@@ -1,4 +1,4 @@
-import type { TProductDraft } from '../../../types';
+import type { TProductDraft, TProductDraftGraphql } from '../../../types';
 import cobblestoneRug from './cobblestone-rug';
 describe(`with cobblestoneRug preset`, () => {
   it('should return a sample cobblestoneRug product preset', () => {
@@ -17,47 +17,308 @@ describe(`with cobblestoneRug preset`, () => {
           {
             "key": "home-decor",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "cobblestone-rug",
-      "name": {
-            "de-DE": "Kopfsteinpflaster",
-            "en-GB": "Cobblestone Rug",
-            "en-US": "Cobblestone Rug"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "kopfsteinpflaster",
-            "en-GB": "cobblestone-rug",
-            "en-US": "cobblestone-rug"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Der Cobblestone-Teppich kann in einer Vielzahl von Räumen verwendet werden, von Wohnzimmern über Schlafzimmer bis hin zu Heimbüros. Es ist besonders beliebt in modernen und zeitgenössischen Einrichtungsstilen, wo sie dem Raum ein mutiges und grafisches Element hinzufügen können.  Insgesamt ist ein Teppich mit geometrischen Akzenten eine stilvolle und vielseitige Designwahl, die jedem Raum im Haus visuelles Interesse und Textur verleihen kann.",
+          "en": undefined,
+          "en-GB": "The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.",
+          "en-US": "The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.",
+          "fr": undefined,
         },
-        {
+        "key": "cobblestone-rug",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#808080",
+                "label": {
+                  "de-DE": "Grau",
+                  "en-GB": "Gray",
+                  "en-US": "Gray",
+                },
+              },
+            },
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- 5 Fuß x 3 Fuß",
+                "en-GB": "- 5ft x 3ft",
+                "en-US": "- 5ft x 3ft",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 2820,
+                "w": 7006,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Cobblestone%20Rug-n-Cz7uBo.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 12999,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 12999,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 12999,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "CR-098",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Kopfsteinpflaster",
+          "en": undefined,
+          "en-GB": "Cobblestone Rug",
+          "en-US": "Cobblestone Rug",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "kopfsteinpflaster",
+          "en": undefined,
+          "en-GB": "cobblestone-rug",
+          "en-US": "cobblestone-rug",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
+      }
+    `);
+  });
+
+  it('should return a sample cobblestoneRug product preset when built for Graphql', () => {
+    const cobblestoneRugPresetGraphql =
+      cobblestoneRug().buildGraphql<TProductDraftGraphql>();
+    expect(cobblestoneRugPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "__typename": "Reference",
+            "key": "rugs",
+            "typeId": "category",
+          },
+          {
+            "__typename": "Reference",
+            "key": "room-decor",
+            "typeId": "category",
+          },
+          {
+            "__typename": "Reference",
+            "key": "home-decor",
+            "typeId": "category",
+          },
+        ],
+        "categoryOrderHints": undefined,
+        "description": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "de-DE",
+            "value": "Der Cobblestone-Teppich kann in einer Vielzahl von Räumen verwendet werden, von Wohnzimmern über Schlafzimmer bis hin zu Heimbüros. Es ist besonders beliebt in modernen und zeitgenössischen Einrichtungsstilen, wo sie dem Raum ein mutiges und grafisches Element hinzufügen können.  Insgesamt ist ein Teppich mit geometrischen Akzenten eine stilvolle und vielseitige Designwahl, die jedem Raum im Haus visuelles Interesse und Textur verleihen kann.",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-GB",
+            "value": "The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-US",
+            "value": "The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.",
+          },
+        ],
+        "key": "cobblestone-rug",
         "masterVariant": {
           "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
+          "attributes": [
+            {
+              "name": "color-filter",
+              "value": "{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}",
+            },
+            {
+              "name": "productspec",
+              "value": "{"en-GB":"- 5ft x 3ft","de-DE":"- 5 Fuß x 3 Fuß","en-US":"- 5ft x 3ft"}",
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "height": 2820,
+                "width": 7006,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Cobblestone%20Rug-n-Cz7uBo.jpeg",
+            },
+          ],
           "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"product-description","value":{"de-DE":"Der Cobblestone-Teppich kann in einer Vielzahl von Räumen verwendet werden, von Wohnzimmern über Schlafzimmer bis hin zu Heimbüros. Es ist besonders beliebt in modernen und zeitgenössischen Einrichtungsstilen, wo sie dem Raum ein mutiges und grafisches Element hinzufügen können.  Insgesamt ist ein Teppich mit geometrischen Akzenten eine stilvolle und vielseitige Designwahl, die jedem Raum im Haus visuelles Interesse und Textur verleihen kann.","en-GB":"The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.","en-US":"The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home."}},{"name":"color-filter","value":{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}},{"name":"productspec","value":{"en-GB":"- 5ft x 3ft","de-DE":"- 5 Fuß x 3 Fuß","en-US":"- 5ft x 3ft"}}],
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centPrecision": {
+                  "centAmount": 12999,
+                  "currencyCode": "EUR",
+                },
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centPrecision": {
+                  "centAmount": 12999,
+                  "currencyCode": "GBP",
+                },
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centPrecision": {
+                  "centAmount": 12999,
+                  "currencyCode": "USD",
+                },
+              },
+            },
+          ],
+          "sku": "CR-098",
         },
-        "variants": [
-
-       ]
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-GB",
+            "value": "Cobblestone Rug",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "de-DE",
+            "value": "Kopfsteinpflaster",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-US",
+            "value": "Cobblestone Rug",
+          },
+        ],
+        "priceMode": undefined,
+        "productType": {
+          "__typename": "Reference",
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-GB",
+            "value": "cobblestone-rug",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "de-DE",
+            "value": "kopfsteinpflaster",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-US",
+            "value": "cobblestone-rug",
+          },
+        ],
+        "state": undefined,
+        "taxCategory": {
+          "__typename": "Reference",
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const cobblestoneRugProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodStore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const rugsDraft = CategoryDraft.presets.sampleDataGoodStore
+  .rugs()
+  .build<TCategoryDraft>();
+
+const roomDecorDraft = CategoryDraft.presets.sampleDataGoodStore
+  .roomDecor()
+  .build<TCategoryDraft>();
+
+const homeDecorDraft = CategoryDraft.presets.sampleDataGoodStore
+  .homeDecor()
+  .build<TCategoryDraft>();
+
+const cobblestoneRug = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('cobblestone-rug')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Cobblestone Rug')
+        ['de-DE']('Kopfsteinpflaster')
+        ['en-US']('Cobblestone Rug')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('cobblestone-rug')
+        ['de-DE']('kopfsteinpflaster')
+        ['en-US']('cobblestone-rug')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(cobblestoneRugProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodStore.cobblestoneRug01()
+    )
+    .categories([
+      KeyReference.presets.category().key(rugsDraft.key!),
+      KeyReference.presets.category().key(roomDecorDraft.key!),
+      KeyReference.presets.category().key(homeDecorDraft.key!),
+    ]);
+
+export default cobblestoneRug;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.ts
@@ -10,11 +10,11 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
@@ -49,6 +49,19 @@ const cobblestoneRug = (): TProductDraftBuilder =>
         ['en-GB']('Cobblestone Rug')
         ['de-DE']('Kopfsteinpflaster')
         ['en-US']('Cobblestone Rug')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['de-DE'](
+          'Der Cobblestone-Teppich kann in einer Vielzahl von Räumen verwendet werden, von Wohnzimmern über Schlafzimmer bis hin zu Heimbüros. Es ist besonders beliebt in modernen und zeitgenössischen Einrichtungsstilen, wo sie dem Raum ein mutiges und grafisches Element hinzufügen können.  Insgesamt ist ein Teppich mit geometrischen Akzenten eine stilvolle und vielseitige Designwahl, die jedem Raum im Haus visuelles Interesse und Textur verleihen kann.'
+        )
+        ['en-GB'](
+          'The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.'
+        )
+        ['en-US'](
+          'The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.'
+        )
     )
     .slug(
       LocalizedString.presets

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.ts
@@ -18,8 +18,8 @@ import {
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodStore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const cobblestoneRugProductTypeDraft =
@@ -64,7 +64,7 @@ const cobblestoneRug = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
       ProductVariantDraft.presets.sampleDataGoodStore.cobblestoneRug01()

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker-set.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker-set.spec.ts
@@ -1,0 +1,64 @@
+import type { TProductDraft } from '../../../types';
+import cocktailShakerSet from './cocktail-shaker-set';
+describe(`with cocktailShakerSet preset`, () => {
+  it('should return a sample cocktailShakerSet product preset', () => {
+    const cocktailShakerSetPreset = cocktailShakerSet().build<TProductDraft>();
+    expect(cocktailShakerSetPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "bar-accessories",
+            "typeId": "category",
+          },
+          {
+            "key": "bar-and-glassware",
+            "typeId": "category",
+          },
+          {
+            "key": "kitchen",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "cocktail-shaker-set",
+      "name": {
+            "de-DE": "Cocktail Shaker Set",
+            "en-GB": "Cocktail Shaker Set",
+            "en-US": "Cocktail Shaker Set"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "cocktail-shaker-set",
+            "en-GB": "cocktail-shaker-set",
+            "en-US": "cocktail-shaker-set"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Stainless steel\n- Hand wash only","de-DE":"- Edelstahl\n- Handwäsche nur","en-US":"- Stainless steel\n- Hand wash only"}},{"name":"product-description","value":{"en-GB":"This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home.","en-US":"This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home.","de-DE":"Dieses Set für die Cocktailzubereitung umfasst einen Shaker, ein Sieb, einen Jigger und eine Zange, die alle aus vergoldetem Edelstahl bestehen. Der Shaker ist ein zweiteiliger Behälter mit einem Deckel, der fest sitzt, um ein Verschütten zu verhindern. Das Sieb passt über die Oberseite des Shakers, um feste Zutaten oder Eis aus dem Cocktail zu entfernen, wenn er in das Glas gegossen wird. Der Jigger ist ein kleiner Messbecher, der dabei hilft, die Zutaten präzise abzumessen. Das Gold-Finish verleiht dem Set ein luxuriöses, elegantes Aussehen, das sich perfekt für die Unterhaltung oder die Zubereitung besonderer Cocktails zu Hause eignet."}},{"name":"colorlabel","value":{"en-GB":"Gold","de-DE":"Gold","en-US":"Gold"}},{"name":"color-filter","value":{"key":"#FFD700","label":{"de-DE":"Gold","en-GB":"Gold","en-US":"Gold"}}},{"name":"color","value":{"en-GB":"#EED149","de-DE":"#EED149","en-US":"#EED149"}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker-set.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker-set.spec.ts
@@ -17,47 +17,152 @@ describe(`with cocktailShakerSet preset`, () => {
           {
             "key": "kitchen",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "cocktail-shaker-set",
-      "name": {
-            "de-DE": "Cocktail Shaker Set",
-            "en-GB": "Cocktail Shaker Set",
-            "en-US": "Cocktail Shaker Set"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "cocktail-shaker-set",
-            "en-GB": "cocktail-shaker-set",
-            "en-US": "cocktail-shaker-set"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Dieses Set für die Cocktailzubereitung umfasst einen Shaker, ein Sieb, einen Jigger und eine Zange, die alle aus vergoldetem Edelstahl bestehen. Der Shaker ist ein zweiteiliger Behälter mit einem Deckel, der fest sitzt, um ein Verschütten zu verhindern. Das Sieb passt über die Oberseite des Shakers, um feste Zutaten oder Eis aus dem Cocktail zu entfernen, wenn er in das Glas gegossen wird. Der Jigger ist ein kleiner Messbecher, der dabei hilft, die Zutaten präzise abzumessen. Das Gold-Finish verleiht dem Set ein luxuriöses, elegantes Aussehen, das sich perfekt für die Unterhaltung oder die Zubereitung besonderer Cocktails zu Hause eignet.",
+          "en": undefined,
+          "en-GB": "This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home.",
+          "en-US": "This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home.",
+          "fr": undefined,
         },
-        {
+        "key": "cocktail-shaker-set",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Edelstahl
+      - Handwäsche nur",
+                "en-GB": "- Stainless steel
+      - Hand wash only",
+                "en-US": "- Stainless steel
+      - Hand wash only",
+              },
+            },
+            {
+              "name": "colorlabel",
+              "value": {
+                "de-DE": "Gold",
+                "en-GB": "Gold",
+                "en-US": "Gold",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#FFD700",
+                "label": {
+                  "de-DE": "Gold",
+                  "en-GB": "Gold",
+                  "en-US": "Gold",
+                },
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "de-DE": "#EED149",
+                "en-GB": "#EED149",
+                "en-US": "#EED149",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 5334,
+                "w": 4929,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_441132411-JDwT9QfX.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1599,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1599,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1599,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "COC-0843",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Cocktail Shaker Set",
+          "en": undefined,
+          "en-GB": "Cocktail Shaker Set",
+          "en-US": "Cocktail Shaker Set",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Stainless steel\n- Hand wash only","de-DE":"- Edelstahl\n- Handwäsche nur","en-US":"- Stainless steel\n- Hand wash only"}},{"name":"product-description","value":{"en-GB":"This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home.","en-US":"This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home.","de-DE":"Dieses Set für die Cocktailzubereitung umfasst einen Shaker, ein Sieb, einen Jigger und eine Zange, die alle aus vergoldetem Edelstahl bestehen. Der Shaker ist ein zweiteiliger Behälter mit einem Deckel, der fest sitzt, um ein Verschütten zu verhindern. Das Sieb passt über die Oberseite des Shakers, um feste Zutaten oder Eis aus dem Cocktail zu entfernen, wenn er in das Glas gegossen wird. Der Jigger ist ein kleiner Messbecher, der dabei hilft, die Zutaten präzise abzumessen. Das Gold-Finish verleiht dem Set ein luxuriöses, elegantes Aussehen, das sich perfekt für die Unterhaltung oder die Zubereitung besonderer Cocktails zu Hause eignet."}},{"name":"colorlabel","value":{"en-GB":"Gold","de-DE":"Gold","en-US":"Gold"}},{"name":"color-filter","value":{"key":"#FFD700","label":{"de-DE":"Gold","en-GB":"Gold","en-US":"Gold"}}},{"name":"color","value":{"en-GB":"#EED149","de-DE":"#EED149","en-US":"#EED149"}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "cocktail-shaker-set",
+          "en": undefined,
+          "en-GB": "cocktail-shaker-set",
+          "en-US": "cocktail-shaker-set",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker-set.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker-set.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const cocktailShakerSetProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAccessories()
   .build<TCategoryDraft>();
 
-const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAndGlassware()
   .build<TCategoryDraft>();
 
-const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore
   .kitchen()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const cocktailShakerSet = (): TProductDraftBuilder =>
         ['en-GB']('Cocktail Shaker Set')
         ['de-DE']('Cocktail Shaker Set')
         ['en-US']('Cocktail Shaker Set')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          "This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home."
+        )
+        ['de-DE'](
+          'Dieses Set für die Cocktailzubereitung umfasst einen Shaker, ein Sieb, einen Jigger und eine Zange, die alle aus vergoldetem Edelstahl bestehen. Der Shaker ist ein zweiteiliger Behälter mit einem Deckel, der fest sitzt, um ein Verschütten zu verhindern. Das Sieb passt über die Oberseite des Shakers, um feste Zutaten oder Eis aus dem Cocktail zu entfernen, wenn er in das Glas gegossen wird. Der Jigger ist ein kleiner Messbecher, der dabei hilft, die Zutaten präzise abzumessen. Das Gold-Finish verleiht dem Set ein luxuriöses, elegantes Aussehen, das sich perfekt für die Unterhaltung oder die Zubereitung besonderer Cocktails zu Hause eignet.'
+        )
+        ['en-US'](
+          "This cocktail making set includes a shaker, strainer, a jigger, and tongs, all of which are made of stainless steel with a gold-plated finish. The shaker is a two-piece container with a lid that fits tightly to prevent spillage. The strainer fits over the top of the shaker to remove any solid ingredients or ice from the cocktail as it's poured into the glass. The jigger is a small measuring cup that helps ensure precise measurements of ingredients. The gold finish gives the set a luxurious, elegant look that's perfect for entertaining or creating special cocktails at home."
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const cocktailShakerSet = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.cocktailShakerSet01()
+      ProductVariantDraft.presets.sampleDataGoodStore.cocktailShakerSet01()
     )
     .categories([
       KeyReference.presets.category().key(barAccessoriesDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker-set.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker-set.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const cocktailShakerSetProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAccessories()
+  .build<TCategoryDraft>();
+
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAndGlassware()
+  .build<TCategoryDraft>();
+
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+  .kitchen()
+  .build<TCategoryDraft>();
+
+const cocktailShakerSet = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('cocktail-shaker-set')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Cocktail Shaker Set')
+        ['de-DE']('Cocktail Shaker Set')
+        ['en-US']('Cocktail Shaker Set')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('cocktail-shaker-set')
+        ['de-DE']('cocktail-shaker-set')
+        ['en-US']('cocktail-shaker-set')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(cocktailShakerSetProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.cocktailShakerSet01()
+    )
+    .categories([
+      KeyReference.presets.category().key(barAccessoriesDraft.key!),
+      KeyReference.presets.category().key(barAndGlasswareDraft.key!),
+      KeyReference.presets.category().key(kitchenDraft.key!),
+    ]);
+
+export default cocktailShakerSet;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker.spec.ts
@@ -1,0 +1,59 @@
+import type { TProductDraft } from '../../../types';
+import cocktailShaker from './cocktail-shaker';
+describe(`with cocktailShaker preset`, () => {
+  it('should return a sample cocktailShaker product preset', () => {
+    const cocktailShakerPreset = cocktailShaker().build<TProductDraft>();
+    expect(cocktailShakerPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "bar-accessories",
+            "typeId": "category",
+          },
+          {
+            "key": "bar-and-glassware",
+            "typeId": "category",
+          },
+          {
+            "key": "kitchen",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "cocktail-shaker",
+      "name": {
+            "de-DE": "Cocktail Shaker",
+            "en-GB": "Cocktail Shaker",
+            "en-US": "Cocktail Shaker"
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "cocktail-shaker",
+            "en-GB": "cocktail-shaker",
+            "en-US": "cocktail-shaker"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Includes built in strainer\n- Stainless steel\n- Dishwasher safe","de-DE":"- Inklusive eingebautem Sieb\n- Edelstahl\n- Spülmaschinenfest","en-US":"- Includes built in strainer\n- Stainless steel\n- Dishwasher safe"}},{"name":"product-description","value":{"en-GB":"A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.","en-US":"A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.","de-DE":"Ein Cocktailshaker ist ein Werkzeug, das zum Mischen und Zubereiten von alkoholischen Getränken wie Cocktails verwendet wird. Es ist ein Metallbehälter mit einem Deckel, der dicht abschließt, um ein Verschütten zu verhindern. Der Behälter hat eine sich verjüngende Form mit einer breiteren Basis und einer schmaleren Oberseite. Dieses Design ermöglicht ein einfaches Mischen der Zutaten durch Schütteln. Der Deckel hat ein eingebautes Sieb, um die Flüssigkeit vom Eis und anderen festen Zutaten zu trennen. Der Shaker ist aus Edelstahl."}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker.spec.ts
@@ -17,42 +17,136 @@ describe(`with cocktailShaker preset`, () => {
           {
             "key": "kitchen",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "cocktail-shaker",
-      "name": {
-            "de-DE": "Cocktail Shaker",
-            "en-GB": "Cocktail Shaker",
-            "en-US": "Cocktail Shaker"
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "cocktail-shaker",
-            "en-GB": "cocktail-shaker",
-            "en-US": "cocktail-shaker"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Ein Cocktailshaker ist ein Werkzeug, das zum Mischen und Zubereiten von alkoholischen Getränken wie Cocktails verwendet wird. Es ist ein Metallbehälter mit einem Deckel, der dicht abschließt, um ein Verschütten zu verhindern. Der Behälter hat eine sich verjüngende Form mit einer breiteren Basis und einer schmaleren Oberseite. Dieses Design ermöglicht ein einfaches Mischen der Zutaten durch Schütteln. Der Deckel hat ein eingebautes Sieb, um die Flüssigkeit vom Eis und anderen festen Zutaten zu trennen. Der Shaker ist aus Edelstahl.",
+          "en": undefined,
+          "en-GB": "A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.",
+          "en-US": "A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.",
+          "fr": undefined,
         },
-        {
+        "key": "cocktail-shaker",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Inklusive eingebautem Sieb
+      - Edelstahl
+      - Spülmaschinenfest",
+                "en-GB": "- Includes built in strainer
+      - Stainless steel
+      - Dishwasher safe",
+                "en-US": "- Includes built in strainer
+      - Stainless steel
+      - Dishwasher safe",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 5500,
+                "w": 3850,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_74255917-W96v6fME.jpeg",
+            },
+            {
+              "dimensions": {
+                "h": 3750,
+                "w": 5000,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_74620379%20-og0Draq4.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 699,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 699,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 699,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "COCT-09",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Cocktail Shaker",
+          "en": undefined,
+          "en-GB": "Cocktail Shaker",
+          "en-US": "Cocktail Shaker",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Includes built in strainer\n- Stainless steel\n- Dishwasher safe","de-DE":"- Inklusive eingebautem Sieb\n- Edelstahl\n- Spülmaschinenfest","en-US":"- Includes built in strainer\n- Stainless steel\n- Dishwasher safe"}},{"name":"product-description","value":{"en-GB":"A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.","en-US":"A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.","de-DE":"Ein Cocktailshaker ist ein Werkzeug, das zum Mischen und Zubereiten von alkoholischen Getränken wie Cocktails verwendet wird. Es ist ein Metallbehälter mit einem Deckel, der dicht abschließt, um ein Verschütten zu verhindern. Der Behälter hat eine sich verjüngende Form mit einer breiteren Basis und einer schmaleren Oberseite. Dieses Design ermöglicht ein einfaches Mischen der Zutaten durch Schütteln. Der Deckel hat ein eingebautes Sieb, um die Flüssigkeit vom Eis und anderen festen Zutaten zu trennen. Der Shaker ist aus Edelstahl."}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "cocktail-shaker",
+          "en": undefined,
+          "en-GB": "cocktail-shaker",
+          "en-US": "cocktail-shaker",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const cocktailShakerProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAccessories()
+  .build<TCategoryDraft>();
+
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAndGlassware()
+  .build<TCategoryDraft>();
+
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+  .kitchen()
+  .build<TCategoryDraft>();
+
+const cocktailShaker = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('cocktail-shaker')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Cocktail Shaker')
+        ['de-DE']('Cocktail Shaker')
+        ['en-US']('Cocktail Shaker')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('cocktail-shaker')
+        ['de-DE']('cocktail-shaker')
+        ['en-US']('cocktail-shaker')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(cocktailShakerProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.cocktailShaker01()
+    )
+    .categories([
+      KeyReference.presets.category().key(barAccessoriesDraft.key!),
+      KeyReference.presets.category().key(barAndGlasswareDraft.key!),
+      KeyReference.presets.category().key(kitchenDraft.key!),
+    ]);
+
+export default cocktailShaker;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-shaker.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const cocktailShakerProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAccessories()
   .build<TCategoryDraft>();
 
-const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAndGlassware()
   .build<TCategoryDraft>();
 
-const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore
   .kitchen()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const cocktailShaker = (): TProductDraftBuilder =>
         ['en-GB']('Cocktail Shaker')
         ['de-DE']('Cocktail Shaker')
         ['en-US']('Cocktail Shaker')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.'
+        )
+        ['de-DE'](
+          'Ein Cocktailshaker ist ein Werkzeug, das zum Mischen und Zubereiten von alkoholischen Getränken wie Cocktails verwendet wird. Es ist ein Metallbehälter mit einem Deckel, der dicht abschließt, um ein Verschütten zu verhindern. Der Behälter hat eine sich verjüngende Form mit einer breiteren Basis und einer schmaleren Oberseite. Dieses Design ermöglicht ein einfaches Mischen der Zutaten durch Schütteln. Der Deckel hat ein eingebautes Sieb, um die Flüssigkeit vom Eis und anderen festen Zutaten zu trennen. Der Shaker ist aus Edelstahl.'
+        )
+        ['en-US'](
+          'A cocktail shaker is a tool used in mixing and preparing alcoholic beverages such as cocktails. It is a metal container with a lid that seals tightly to prevent spills. The container has a tapered shape, with a wider base and a narrower top. This design allows for easy mixing of ingredients by shaking them together. The lid has a built-in strainer to separate the liquid from the ice and other solid ingredients. The shaker is made of stainless steel.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const cocktailShaker = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.cocktailShaker01()
+      ProductVariantDraft.presets.sampleDataGoodStore.cocktailShaker01()
     )
     .categories([
       KeyReference.presets.category().key(barAccessoriesDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-stirring-spoon.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-stirring-spoon.spec.ts
@@ -18,47 +18,125 @@ describe(`with cocktailStirringSpoon preset`, () => {
           {
             "key": "kitchen",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "cocktail-stirring-spoon",
-      "name": {
-            "de-DE": "Cocktail-Rührlöffel",
-            "en-GB": "Cocktail Stirring Spoon",
-            "en-US": "Cocktail Stirring Spoon"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "cocktail-rhrlffel",
-            "en-GB": "cocktail-stirring-spoon",
-            "en-US": "cocktail-stirring-spoon"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Ein Cocktail-Rührlöffel ist ein langes und schlankes Utensil aus Edelstahl, das zum Rühren und Mixen von Cocktails verwendet wird. Es ist normalerweise etwa 8 Zoll lang mit einem kleinen, flachen, scheibenförmigen Ende zum Vermischen von Zutaten und einem gedrehten oder spiralförmigen Griff zum einfachen Greifen. Der gedrehte Griff dient nicht nur der Dekoration, sondern verhilft auch zu einem besseren Halt beim Mixen von Cocktails.",
+          "en": undefined,
+          "en-GB": "A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.",
+          "en-US": "A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.",
+          "fr": undefined,
         },
-        {
+        "key": "cocktail-stirring-spoon",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Edelstahl
+      - Spülmaschinenfest",
+                "en-GB": "- Stainless steel
+      - Dishwasher safe",
+                "en-US": "- Stainless steel
+      - Dishwasher safe",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 4555,
+                "w": 5757,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_138383562-Ewqpr7_V.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 199,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 199,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 199,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "Spoo-094",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Cocktail-Rührlöffel",
+          "en": undefined,
+          "en-GB": "Cocktail Stirring Spoon",
+          "en-US": "Cocktail Stirring Spoon",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Stainless steel\n- Dishwasher safe","de-DE":"- Edelstahl\n- Spülmaschinenfest","en-US":"- Stainless steel\n- Dishwasher safe"}},{"name":"product-description","value":{"en-GB":"A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.","en-US":"A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.","de-DE":"Ein Cocktail-Rührlöffel ist ein langes und schlankes Utensil aus Edelstahl, das zum Rühren und Mixen von Cocktails verwendet wird. Es ist normalerweise etwa 8 Zoll lang mit einem kleinen, flachen, scheibenförmigen Ende zum Vermischen von Zutaten und einem gedrehten oder spiralförmigen Griff zum einfachen Greifen. Der gedrehte Griff dient nicht nur der Dekoration, sondern verhilft auch zu einem besseren Halt beim Mixen von Cocktails."}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "cocktail-rhrlffel",
+          "en": undefined,
+          "en-GB": "cocktail-stirring-spoon",
+          "en-US": "cocktail-stirring-spoon",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-stirring-spoon.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-stirring-spoon.spec.ts
@@ -1,0 +1,65 @@
+import type { TProductDraft } from '../../../types';
+import cocktailStirringSpoon from './cocktail-stirring-spoon';
+describe(`with cocktailStirringSpoon preset`, () => {
+  it('should return a sample cocktailStirringSpoon product preset', () => {
+    const cocktailStirringSpoonPreset =
+      cocktailStirringSpoon().build<TProductDraft>();
+    expect(cocktailStirringSpoonPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "bar-accessories",
+            "typeId": "category",
+          },
+          {
+            "key": "bar-and-glassware",
+            "typeId": "category",
+          },
+          {
+            "key": "kitchen",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "cocktail-stirring-spoon",
+      "name": {
+            "de-DE": "Cocktail-Rührlöffel",
+            "en-GB": "Cocktail Stirring Spoon",
+            "en-US": "Cocktail Stirring Spoon"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "cocktail-rhrlffel",
+            "en-GB": "cocktail-stirring-spoon",
+            "en-US": "cocktail-stirring-spoon"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Stainless steel\n- Dishwasher safe","de-DE":"- Edelstahl\n- Spülmaschinenfest","en-US":"- Stainless steel\n- Dishwasher safe"}},{"name":"product-description","value":{"en-GB":"A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.","en-US":"A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.","de-DE":"Ein Cocktail-Rührlöffel ist ein langes und schlankes Utensil aus Edelstahl, das zum Rühren und Mixen von Cocktails verwendet wird. Es ist normalerweise etwa 8 Zoll lang mit einem kleinen, flachen, scheibenförmigen Ende zum Vermischen von Zutaten und einem gedrehten oder spiralförmigen Griff zum einfachen Greifen. Der gedrehte Griff dient nicht nur der Dekoration, sondern verhilft auch zu einem besseren Halt beim Mixen von Cocktails."}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-stirring-spoon.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-stirring-spoon.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const cocktailStirringSpoonProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAccessories()
+  .build<TCategoryDraft>();
+
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAndGlassware()
+  .build<TCategoryDraft>();
+
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+  .kitchen()
+  .build<TCategoryDraft>();
+
+const cocktailStirringSpoon = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('cocktail-stirring-spoon')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Cocktail Stirring Spoon')
+        ['de-DE']('Cocktail-Rührlöffel')
+        ['en-US']('Cocktail Stirring Spoon')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('cocktail-stirring-spoon')
+        ['de-DE']('cocktail-rhrlffel')
+        ['en-US']('cocktail-stirring-spoon')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(cocktailStirringSpoonProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.cocktailStirringSpoon01()
+    )
+    .categories([
+      KeyReference.presets.category().key(barAccessoriesDraft.key!),
+      KeyReference.presets.category().key(barAndGlasswareDraft.key!),
+      KeyReference.presets.category().key(kitchenDraft.key!),
+    ]);
+
+export default cocktailStirringSpoon;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-stirring-spoon.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-stirring-spoon.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const cocktailStirringSpoonProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAccessories()
   .build<TCategoryDraft>();
 
-const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAndGlassware()
   .build<TCategoryDraft>();
 
-const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore
   .kitchen()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const cocktailStirringSpoon = (): TProductDraftBuilder =>
         ['en-GB']('Cocktail Stirring Spoon')
         ['de-DE']('Cocktail-Rührlöffel')
         ['en-US']('Cocktail Stirring Spoon')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.'
+        )
+        ['de-DE'](
+          'Ein Cocktail-Rührlöffel ist ein langes und schlankes Utensil aus Edelstahl, das zum Rühren und Mixen von Cocktails verwendet wird. Es ist normalerweise etwa 8 Zoll lang mit einem kleinen, flachen, scheibenförmigen Ende zum Vermischen von Zutaten und einem gedrehten oder spiralförmigen Griff zum einfachen Greifen. Der gedrehte Griff dient nicht nur der Dekoration, sondern verhilft auch zu einem besseren Halt beim Mixen von Cocktails.'
+        )
+        ['en-US'](
+          'A cocktail stirring spoon is a long and slender utensil, made of stainless steel, used for stirring and mixing cocktails. It is usually around 8 inches long with a small, flat disc-shaped end for muddling ingredients and a twisted or spiraled handle for easy gripping. The twisted handle is not just for decoration, but also helps to create a better grip when mixing cocktails.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const cocktailStirringSpoon = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.cocktailStirringSpoon01()
+      ProductVariantDraft.presets.sampleDataGoodStore.cocktailStirringSpoon01()
     )
     .categories([
       KeyReference.presets.category().key(barAccessoriesDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-strainer.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-strainer.spec.ts
@@ -1,0 +1,64 @@
+import type { TProductDraft } from '../../../types';
+import cocktailStrainer from './cocktail-strainer';
+describe(`with cocktailStrainer preset`, () => {
+  it('should return a sample cocktailStrainer product preset', () => {
+    const cocktailStrainerPreset = cocktailStrainer().build<TProductDraft>();
+    expect(cocktailStrainerPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "bar-accessories",
+            "typeId": "category",
+          },
+          {
+            "key": "bar-and-glassware",
+            "typeId": "category",
+          },
+          {
+            "key": "kitchen",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "cocktail-strainer",
+      "name": {
+            "de-DE": "Cocktailsieb",
+            "en-GB": "Cocktail Strainer",
+            "en-US": "Cocktail Strainer"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "cocktailsieb",
+            "en-GB": "cocktail-strainer",
+            "en-US": "cocktail-strainer"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Stainless steel\n- Dishwasher safe","de-DE":"- Edelstahl\n- Spülmaschinenfest","en-US":"- Stainless steel\n- Dishwasher safe"}},{"name":"product-description","value":{"en-GB":"A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.","en-US":"A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.","de-DE":"Ein Sieb für Cocktailshaker ist ein Barwerkzeug, das verwendet wird, um Eis und andere feste Zutaten aus Mixgetränken abzuseihen, während der flüssige Teil des Cocktails in ein Servierglas gegossen wird. Er besteht aus Metall und hat eine flache, perforierte Scheibe, die über die Öffnung des Shakers passt. Das Sieb wird an Ort und Stelle gehalten, indem man einen Finger über den kleinen, griffartigen Vorsprung auf einer Seite der Scheibe legt, während man die Flüssigkeit durch die größere Öffnung auf der anderen Seite ausgießt. Die perforierte Scheibe hilft dabei, kleine Eis- oder Fruchtstücke herauszufiltern, die in der Mischung zurückbleiben könnten, was zu einem glatten und raffinierten Cocktail führt. Das Sieb hat auch eine Feder um den Rand der Scheibe, die hilft, es sicher über dem Shaker zu halten und so ein Verschütten oder Tropfen zu verhindern."}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-strainer.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-strainer.spec.ts
@@ -17,47 +17,133 @@ describe(`with cocktailStrainer preset`, () => {
           {
             "key": "kitchen",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "cocktail-strainer",
-      "name": {
-            "de-DE": "Cocktailsieb",
-            "en-GB": "Cocktail Strainer",
-            "en-US": "Cocktail Strainer"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "cocktailsieb",
-            "en-GB": "cocktail-strainer",
-            "en-US": "cocktail-strainer"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Ein Sieb für Cocktailshaker ist ein Barwerkzeug, das verwendet wird, um Eis und andere feste Zutaten aus Mixgetränken abzuseihen, während der flüssige Teil des Cocktails in ein Servierglas gegossen wird. Er besteht aus Metall und hat eine flache, perforierte Scheibe, die über die Öffnung des Shakers passt. Das Sieb wird an Ort und Stelle gehalten, indem man einen Finger über den kleinen, griffartigen Vorsprung auf einer Seite der Scheibe legt, während man die Flüssigkeit durch die größere Öffnung auf der anderen Seite ausgießt. Die perforierte Scheibe hilft dabei, kleine Eis- oder Fruchtstücke herauszufiltern, die in der Mischung zurückbleiben könnten, was zu einem glatten und raffinierten Cocktail führt. Das Sieb hat auch eine Feder um den Rand der Scheibe, die hilft, es sicher über dem Shaker zu halten und so ein Verschütten oder Tropfen zu verhindern.",
+          "en": undefined,
+          "en-GB": "A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.",
+          "en-US": "A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.",
+          "fr": undefined,
         },
-        {
+        "key": "cocktail-strainer",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Edelstahl
+      - Spülmaschinenfest",
+                "en-GB": "- Stainless steel
+      - Dishwasher safe",
+                "en-US": "- Stainless steel
+      - Dishwasher safe",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 3648,
+                "w": 5472,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_93371908-9q9vrNXx.jpeg",
+            },
+            {
+              "dimensions": {
+                "h": 5472,
+                "w": 3648,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_97174497-F5iWBxGv.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 399,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 399,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 399,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "STRA-095",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Cocktailsieb",
+          "en": undefined,
+          "en-GB": "Cocktail Strainer",
+          "en-US": "Cocktail Strainer",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Stainless steel\n- Dishwasher safe","de-DE":"- Edelstahl\n- Spülmaschinenfest","en-US":"- Stainless steel\n- Dishwasher safe"}},{"name":"product-description","value":{"en-GB":"A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.","en-US":"A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.","de-DE":"Ein Sieb für Cocktailshaker ist ein Barwerkzeug, das verwendet wird, um Eis und andere feste Zutaten aus Mixgetränken abzuseihen, während der flüssige Teil des Cocktails in ein Servierglas gegossen wird. Er besteht aus Metall und hat eine flache, perforierte Scheibe, die über die Öffnung des Shakers passt. Das Sieb wird an Ort und Stelle gehalten, indem man einen Finger über den kleinen, griffartigen Vorsprung auf einer Seite der Scheibe legt, während man die Flüssigkeit durch die größere Öffnung auf der anderen Seite ausgießt. Die perforierte Scheibe hilft dabei, kleine Eis- oder Fruchtstücke herauszufiltern, die in der Mischung zurückbleiben könnten, was zu einem glatten und raffinierten Cocktail führt. Das Sieb hat auch eine Feder um den Rand der Scheibe, die hilft, es sicher über dem Shaker zu halten und so ein Verschütten oder Tropfen zu verhindern."}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "cocktailsieb",
+          "en": undefined,
+          "en-GB": "cocktail-strainer",
+          "en-US": "cocktail-strainer",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-strainer.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-strainer.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const cocktailStrainerProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAccessories()
   .build<TCategoryDraft>();
 
-const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAndGlassware()
   .build<TCategoryDraft>();
 
-const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore
   .kitchen()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const cocktailStrainer = (): TProductDraftBuilder =>
         ['en-GB']('Cocktail Strainer')
         ['de-DE']('Cocktailsieb')
         ['en-US']('Cocktail Strainer')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.'
+        )
+        ['de-DE'](
+          'Ein Sieb für Cocktailshaker ist ein Barwerkzeug, das verwendet wird, um Eis und andere feste Zutaten aus Mixgetränken abzuseihen, während der flüssige Teil des Cocktails in ein Servierglas gegossen wird. Er besteht aus Metall und hat eine flache, perforierte Scheibe, die über die Öffnung des Shakers passt. Das Sieb wird an Ort und Stelle gehalten, indem man einen Finger über den kleinen, griffartigen Vorsprung auf einer Seite der Scheibe legt, während man die Flüssigkeit durch die größere Öffnung auf der anderen Seite ausgießt. Die perforierte Scheibe hilft dabei, kleine Eis- oder Fruchtstücke herauszufiltern, die in der Mischung zurückbleiben könnten, was zu einem glatten und raffinierten Cocktail führt. Das Sieb hat auch eine Feder um den Rand der Scheibe, die hilft, es sicher über dem Shaker zu halten und so ein Verschütten oder Tropfen zu verhindern.'
+        )
+        ['en-US'](
+          'A strainer for cocktail shakers is a bar tool used to strain ice and other solid ingredients from mixed drinks, while pouring the liquid portion of the cocktail into a serving glass. It is made of metal, with a flat, perforated disc that fits over the mouth of the shaker. The strainer is held in place by placing a finger over the small, handle-like protrusion on one side of the disc, while pouring the liquid out through the larger opening on the other side. The perforated disc helps to filter out any small bits of ice or fruit that might be left in the mixture, resulting in a smooth and refined cocktail. The strainer also has a spring around the edge of the disc that helps to hold it securely in place over the shaker, preventing any spills or drips.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const cocktailStrainer = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.cocktailStrainer01()
+      ProductVariantDraft.presets.sampleDataGoodStore.cocktailStrainer01()
     )
     .categories([
       KeyReference.presets.category().key(barAccessoriesDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-strainer.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocktail-strainer.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const cocktailStrainerProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAccessories()
+  .build<TCategoryDraft>();
+
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAndGlassware()
+  .build<TCategoryDraft>();
+
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+  .kitchen()
+  .build<TCategoryDraft>();
+
+const cocktailStrainer = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('cocktail-strainer')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Cocktail Strainer')
+        ['de-DE']('Cocktailsieb')
+        ['en-US']('Cocktail Strainer')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('cocktail-strainer')
+        ['de-DE']('cocktailsieb')
+        ['en-US']('cocktail-strainer')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(cocktailStrainerProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.cocktailStrainer01()
+    )
+    .categories([
+      KeyReference.presets.category().key(barAccessoriesDraft.key!),
+      KeyReference.presets.category().key(barAndGlasswareDraft.key!),
+      KeyReference.presets.category().key(kitchenDraft.key!),
+    ]);
+
+export default cocktailStrainer;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocoa-pillow-cover.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocoa-pillow-cover.spec.ts
@@ -13,47 +13,152 @@ describe(`with cocoaPillowCover preset`, () => {
           {
             "key": "home-decor",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "cocoa-pillow-cover",
-      "name": {
-            "de-DE": "Kakao-Kissenbezug",
-            "en-GB": "Cocoa Pillow Cover",
-            "en-US": "Cocoa Pillow Cover"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "kakao-kissenbezug",
-            "en-GB": "cocoa-pillow-cover",
-            "en-US": "cocoa-pillow-cover"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Ein quadratischer Kissenbezug aus Leinen ist eine Art Textilbezug für ein quadratisches Kissen, das normalerweise verwendet wird, um einem Raum visuelles Interesse und Textur zu verleihen. Es besteht aus einem natürlichen Leinenstoff, der für seine Haltbarkeit, Atmungsaktivität und seinen klassischen Look bekannt ist.  Der Kissenbezug ist so konzipiert, dass er über ein quadratisches Kissen in Standardgröße passt, normalerweise etwa 18 Zoll im Quadrat.  Der Leinenstoff hat eine weiche und leicht strukturierte Oberfläche, die dem Kissen ein gemütliches und einladendes Gefühl verleiht. Die Kanten des Kissenbezugs sind mit einem sauberen Saum oder einer Paspelierung versehen, was dem Gesamtdesign einen eleganten Look verleiht.  Der Kissenbezug wird verwendet, um einem Raum einen Hauch von Wärme und natürlicher Eleganz zu verleihen, egal ob er auf einem Bett, einem Sofa oder einem Akzentstuhl platziert wird. Es kann alleine verwendet oder mit anderen dekorativen Kissen in verschiedenen Formen und Farben kombiniert werden, um einen mehrschichtigen und zusammenhängenden Look zu schaffen.  Insgesamt ist ein quadratischer Kissenbezug aus Leinen ein vielseitiges und zeitloses Akzentstück, das den Komfort und Stil jedes Raums im Haus verbessern kann.",
+          "en": undefined,
+          "en-GB": "A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.",
+          "en-US": "A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.",
+          "fr": undefined,
         },
-        {
+        "key": "cocoa-pillow-cover",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Waschmaschinenfest
+      - Kissen nicht im Lieferumfang enthalten",
+                "en-GB": "- Machine washable
+      - Pillow not included",
+                "en-US": "- Machine washable
+      - Pillow not included",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#808080",
+                "label": {
+                  "de-DE": "Grau",
+                  "en-GB": "Gray",
+                  "en-US": "Gray",
+                },
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "de-DE": "#A1947C ",
+                "en-GB": "#A1947C ",
+                "en-US": "#A1947C ",
+              },
+            },
+            {
+              "name": "colorlabel",
+              "value": {
+                "de-DE": "Tweed",
+                "en-GB": "Tweed",
+                "en-US": "Tweed",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 4160,
+                "w": 6240,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Cocoa%20Pillow%20Cover-W9ZgnFgU.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1099,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1099,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1099,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "BLPC-09",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Kakao-Kissenbezug",
+          "en": undefined,
+          "en-GB": "Cocoa Pillow Cover",
+          "en-US": "Cocoa Pillow Cover",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- Pillow not included","de-DE":"- Waschmaschinenfest\n- Kissen nicht im Lieferumfang enthalten","en-US":"- Machine washable\n- Pillow not included"}},{"name":"product-description","value":{"en-GB":"A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.","en-US":"A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.","de-DE":"Ein quadratischer Kissenbezug aus Leinen ist eine Art Textilbezug für ein quadratisches Kissen, das normalerweise verwendet wird, um einem Raum visuelles Interesse und Textur zu verleihen. Es besteht aus einem natürlichen Leinenstoff, der für seine Haltbarkeit, Atmungsaktivität und seinen klassischen Look bekannt ist.  Der Kissenbezug ist so konzipiert, dass er über ein quadratisches Kissen in Standardgröße passt, normalerweise etwa 18 Zoll im Quadrat.  Der Leinenstoff hat eine weiche und leicht strukturierte Oberfläche, die dem Kissen ein gemütliches und einladendes Gefühl verleiht. Die Kanten des Kissenbezugs sind mit einem sauberen Saum oder einer Paspelierung versehen, was dem Gesamtdesign einen eleganten Look verleiht.  Der Kissenbezug wird verwendet, um einem Raum einen Hauch von Wärme und natürlicher Eleganz zu verleihen, egal ob er auf einem Bett, einem Sofa oder einem Akzentstuhl platziert wird. Es kann alleine verwendet oder mit anderen dekorativen Kissen in verschiedenen Formen und Farben kombiniert werden, um einen mehrschichtigen und zusammenhängenden Look zu schaffen.  Insgesamt ist ein quadratischer Kissenbezug aus Leinen ein vielseitiges und zeitloses Akzentstück, das den Komfort und Stil jedes Raums im Haus verbessern kann."}},{"name":"color-filter","value":{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}},{"name":"color","value":{"en-GB":"#A1947C ","de-DE":"#A1947C ","en-US":"#A1947C "}},{"name":"colorlabel","value":{"en-GB":"Tweed","de-DE":"Tweed","en-US":"Tweed"}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "kakao-kissenbezug",
+          "en": undefined,
+          "en-GB": "cocoa-pillow-cover",
+          "en-US": "cocoa-pillow-cover",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocoa-pillow-cover.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocoa-pillow-cover.spec.ts
@@ -1,0 +1,60 @@
+import type { TProductDraft } from '../../../types';
+import cocoaPillowCover from './cocoa-pillow-cover';
+describe(`with cocoaPillowCover preset`, () => {
+  it('should return a sample cocoaPillowCover product preset', () => {
+    const cocoaPillowCoverPreset = cocoaPillowCover().build<TProductDraft>();
+    expect(cocoaPillowCoverPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "bedding",
+            "typeId": "category",
+          },
+          {
+            "key": "home-decor",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "cocoa-pillow-cover",
+      "name": {
+            "de-DE": "Kakao-Kissenbezug",
+            "en-GB": "Cocoa Pillow Cover",
+            "en-US": "Cocoa Pillow Cover"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "kakao-kissenbezug",
+            "en-GB": "cocoa-pillow-cover",
+            "en-US": "cocoa-pillow-cover"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- Pillow not included","de-DE":"- Waschmaschinenfest\n- Kissen nicht im Lieferumfang enthalten","en-US":"- Machine washable\n- Pillow not included"}},{"name":"product-description","value":{"en-GB":"A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.","en-US":"A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.","de-DE":"Ein quadratischer Kissenbezug aus Leinen ist eine Art Textilbezug für ein quadratisches Kissen, das normalerweise verwendet wird, um einem Raum visuelles Interesse und Textur zu verleihen. Es besteht aus einem natürlichen Leinenstoff, der für seine Haltbarkeit, Atmungsaktivität und seinen klassischen Look bekannt ist.  Der Kissenbezug ist so konzipiert, dass er über ein quadratisches Kissen in Standardgröße passt, normalerweise etwa 18 Zoll im Quadrat.  Der Leinenstoff hat eine weiche und leicht strukturierte Oberfläche, die dem Kissen ein gemütliches und einladendes Gefühl verleiht. Die Kanten des Kissenbezugs sind mit einem sauberen Saum oder einer Paspelierung versehen, was dem Gesamtdesign einen eleganten Look verleiht.  Der Kissenbezug wird verwendet, um einem Raum einen Hauch von Wärme und natürlicher Eleganz zu verleihen, egal ob er auf einem Bett, einem Sofa oder einem Akzentstuhl platziert wird. Es kann alleine verwendet oder mit anderen dekorativen Kissen in verschiedenen Formen und Farben kombiniert werden, um einen mehrschichtigen und zusammenhängenden Look zu schaffen.  Insgesamt ist ein quadratischer Kissenbezug aus Leinen ein vielseitiges und zeitloses Akzentstück, das den Komfort und Stil jedes Raums im Haus verbessern kann."}},{"name":"color-filter","value":{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}},{"name":"color","value":{"en-GB":"#A1947C ","de-DE":"#A1947C ","en-US":"#A1947C "}},{"name":"colorlabel","value":{"en-GB":"Tweed","de-DE":"Tweed","en-US":"Tweed"}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocoa-pillow-cover.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocoa-pillow-cover.ts
@@ -1,0 +1,73 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const cocoaPillowCoverProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const beddingDraft = CategoryDraft.presets.sampleDataGoodstore
+  .bedding()
+  .build<TCategoryDraft>();
+
+const homeDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+  .homeDecor()
+  .build<TCategoryDraft>();
+
+const cocoaPillowCover = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('cocoa-pillow-cover')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Cocoa Pillow Cover')
+        ['de-DE']('Kakao-Kissenbezug')
+        ['en-US']('Cocoa Pillow Cover')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('cocoa-pillow-cover')
+        ['de-DE']('kakao-kissenbezug')
+        ['en-US']('cocoa-pillow-cover')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(cocoaPillowCoverProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.cocoaPillowCover01()
+    )
+    .categories([
+      KeyReference.presets.category().key(beddingDraft.key!),
+      KeyReference.presets.category().key(homeDecorDraft.key!),
+    ]);
+
+export default cocoaPillowCover;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cocoa-pillow-cover.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cocoa-pillow-cover.ts
@@ -10,28 +10,28 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const cocoaPillowCoverProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const beddingDraft = CategoryDraft.presets.sampleDataGoodstore
+const beddingDraft = CategoryDraft.presets.sampleDataGoodStore
   .bedding()
   .build<TCategoryDraft>();
 
-const homeDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+const homeDecorDraft = CategoryDraft.presets.sampleDataGoodStore
   .homeDecor()
   .build<TCategoryDraft>();
 
@@ -45,6 +45,19 @@ const cocoaPillowCover = (): TProductDraftBuilder =>
         ['en-GB']('Cocoa Pillow Cover')
         ['de-DE']('Kakao-Kissenbezug')
         ['en-US']('Cocoa Pillow Cover')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.'
+        )
+        ['de-DE'](
+          'Ein quadratischer Kissenbezug aus Leinen ist eine Art Textilbezug für ein quadratisches Kissen, das normalerweise verwendet wird, um einem Raum visuelles Interesse und Textur zu verleihen. Es besteht aus einem natürlichen Leinenstoff, der für seine Haltbarkeit, Atmungsaktivität und seinen klassischen Look bekannt ist.  Der Kissenbezug ist so konzipiert, dass er über ein quadratisches Kissen in Standardgröße passt, normalerweise etwa 18 Zoll im Quadrat.  Der Leinenstoff hat eine weiche und leicht strukturierte Oberfläche, die dem Kissen ein gemütliches und einladendes Gefühl verleiht. Die Kanten des Kissenbezugs sind mit einem sauberen Saum oder einer Paspelierung versehen, was dem Gesamtdesign einen eleganten Look verleiht.  Der Kissenbezug wird verwendet, um einem Raum einen Hauch von Wärme und natürlicher Eleganz zu verleihen, egal ob er auf einem Bett, einem Sofa oder einem Akzentstuhl platziert wird. Es kann alleine verwendet oder mit anderen dekorativen Kissen in verschiedenen Formen und Farben kombiniert werden, um einen mehrschichtigen und zusammenhängenden Look zu schaffen.  Insgesamt ist ein quadratischer Kissenbezug aus Leinen ein vielseitiges und zeitloses Akzentstück, das den Komfort und Stil jedes Raums im Haus verbessern kann.'
+        )
+        ['en-US'](
+          'A square linen pillowcase is a type of textile covering for a square-shaped pillow that is typically used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size square pillow, usually around 18 inches square.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are finished with a neat hem or piping, which adds a polished look to the overall design.  The pillowcase is used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a square linen pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -60,10 +73,10 @@ const cocoaPillowCover = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.cocoaPillowCover01()
+      ProductVariantDraft.presets.sampleDataGoodStore.cocoaPillowCover01()
     )
     .categories([
       KeyReference.presets.category().key(beddingDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/comfort-coffee-mug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/comfort-coffee-mug.spec.ts
@@ -17,47 +17,152 @@ describe(`with comfortCoffeeMug preset`, () => {
           {
             "key": "kitchen",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "comfort-coffee-mug",
-      "name": {
-            "de-DE": "Komfort-Kaffeetasse",
-            "en-GB": "Comfort Coffee Mug",
-            "en-US": "Comfort Coffee Mug"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "komfort-kaffeetasse",
-            "en-GB": "comfort-coffee-mug",
-            "en-US": "comfort-coffee-mug"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Der Comfort Coffee Mug ist aus Keramik gefertigt. Das Design des Bechers soll das Halten und Trinken erleichtern, mit einem Griff auf einer Seite für bequemen Halt.  Der Becher ist schlicht, aber sein grundlegendes Design ist im Allgemeinen einfach und funktional. Der Körper des Bechers hat oft glatte Seiten und eine breite Öffnung, die das Eingießen und Trinken von Kaffee erleichtert.  Der Comfort Coffee Mug ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist der Comfort Coffee Mug ein praktisches und funktionelles Trinkgefäß, das sich ideal für den Kaffeegenuss zu Hause oder am Arbeitsplatz eignet. Sein einfaches Design und seine Benutzerfreundlichkeit machen ihn zu einer beliebten Wahl für Kaffeeliebhaber aller Art.",
+          "en": undefined,
+          "en-GB": "The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.",
+          "en-US": "The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.",
+          "fr": undefined,
         },
-        {
+        "key": "comfort-coffee-mug",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Enthält 1 Tasse
+      - Spülmaschinen- und mikrowellengeeignet",
+                "en-GB": "- Includes 1 mug
+      - Dishwasher and microwave safe",
+                "en-US": "- Includes 1 mug
+      - Dishwasher and microwave safe",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#FFF",
+                "label": {
+                  "de-DE": "Weiss",
+                  "en-GB": "White",
+                  "en-US": "White",
+                },
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "de-DE": "#FFF",
+                "en-GB": "#FFF",
+                "en-US": "#FFF",
+              },
+            },
+            {
+              "name": "colorlabel",
+              "value": {
+                "de-DE": "Weiß",
+                "en-GB": "White",
+                "en-US": "White",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 2256,
+                "w": 2340,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Comfort%20Coffee%20Mug-G7JxJ2T_.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 199,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 199,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 199,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "CCM-089",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Komfort-Kaffeetasse",
+          "en": undefined,
+          "en-GB": "Comfort Coffee Mug",
+          "en-US": "Comfort Coffee Mug",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Includes 1 mug\n- Dishwasher and microwave safe","de-DE":"- Enthält 1 Tasse\n- Spülmaschinen- und mikrowellengeeignet","en-US":"- Includes 1 mug\n- Dishwasher and microwave safe"}},{"name":"product-description","value":{"en-GB":"The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.","en-US":"The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.","de-DE":"Der Comfort Coffee Mug ist aus Keramik gefertigt. Das Design des Bechers soll das Halten und Trinken erleichtern, mit einem Griff auf einer Seite für bequemen Halt.  Der Becher ist schlicht, aber sein grundlegendes Design ist im Allgemeinen einfach und funktional. Der Körper des Bechers hat oft glatte Seiten und eine breite Öffnung, die das Eingießen und Trinken von Kaffee erleichtert.  Der Comfort Coffee Mug ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist der Comfort Coffee Mug ein praktisches und funktionelles Trinkgefäß, das sich ideal für den Kaffeegenuss zu Hause oder am Arbeitsplatz eignet. Sein einfaches Design und seine Benutzerfreundlichkeit machen ihn zu einer beliebten Wahl für Kaffeeliebhaber aller Art."}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "komfort-kaffeetasse",
+          "en": undefined,
+          "en-GB": "comfort-coffee-mug",
+          "en-US": "comfort-coffee-mug",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/comfort-coffee-mug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/comfort-coffee-mug.spec.ts
@@ -1,0 +1,64 @@
+import type { TProductDraft } from '../../../types';
+import comfortCoffeeMug from './comfort-coffee-mug';
+describe(`with comfortCoffeeMug preset`, () => {
+  it('should return a sample comfortCoffeeMug product preset', () => {
+    const comfortCoffeeMugPreset = comfortCoffeeMug().build<TProductDraft>();
+    expect(comfortCoffeeMugPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "glassware",
+            "typeId": "category",
+          },
+          {
+            "key": "bar-and-glassware",
+            "typeId": "category",
+          },
+          {
+            "key": "kitchen",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "comfort-coffee-mug",
+      "name": {
+            "de-DE": "Komfort-Kaffeetasse",
+            "en-GB": "Comfort Coffee Mug",
+            "en-US": "Comfort Coffee Mug"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "komfort-kaffeetasse",
+            "en-GB": "comfort-coffee-mug",
+            "en-US": "comfort-coffee-mug"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Includes 1 mug\n- Dishwasher and microwave safe","de-DE":"- Enthält 1 Tasse\n- Spülmaschinen- und mikrowellengeeignet","en-US":"- Includes 1 mug\n- Dishwasher and microwave safe"}},{"name":"product-description","value":{"en-GB":"The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.","en-US":"The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.","de-DE":"Der Comfort Coffee Mug ist aus Keramik gefertigt. Das Design des Bechers soll das Halten und Trinken erleichtern, mit einem Griff auf einer Seite für bequemen Halt.  Der Becher ist schlicht, aber sein grundlegendes Design ist im Allgemeinen einfach und funktional. Der Körper des Bechers hat oft glatte Seiten und eine breite Öffnung, die das Eingießen und Trinken von Kaffee erleichtert.  Der Comfort Coffee Mug ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist der Comfort Coffee Mug ein praktisches und funktionelles Trinkgefäß, das sich ideal für den Kaffeegenuss zu Hause oder am Arbeitsplatz eignet. Sein einfaches Design und seine Benutzerfreundlichkeit machen ihn zu einer beliebten Wahl für Kaffeeliebhaber aller Art."}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/comfort-coffee-mug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/comfort-coffee-mug.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const comfortCoffeeMugProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const glasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .glassware()
+  .build<TCategoryDraft>();
+
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAndGlassware()
+  .build<TCategoryDraft>();
+
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+  .kitchen()
+  .build<TCategoryDraft>();
+
+const comfortCoffeeMug = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('comfort-coffee-mug')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Comfort Coffee Mug')
+        ['de-DE']('Komfort-Kaffeetasse')
+        ['en-US']('Comfort Coffee Mug')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('comfort-coffee-mug')
+        ['de-DE']('komfort-kaffeetasse')
+        ['en-US']('comfort-coffee-mug')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(comfortCoffeeMugProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.comfortCoffeeMug01()
+    )
+    .categories([
+      KeyReference.presets.category().key(glasswareDraft.key!),
+      KeyReference.presets.category().key(barAndGlasswareDraft.key!),
+      KeyReference.presets.category().key(kitchenDraft.key!),
+    ]);
+
+export default comfortCoffeeMug;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/comfort-coffee-mug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/comfort-coffee-mug.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const comfortCoffeeMugProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const glasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+const glasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .glassware()
   .build<TCategoryDraft>();
 
-const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAndGlassware()
   .build<TCategoryDraft>();
 
-const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore
   .kitchen()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const comfortCoffeeMug = (): TProductDraftBuilder =>
         ['en-GB']('Comfort Coffee Mug')
         ['de-DE']('Komfort-Kaffeetasse')
         ['en-US']('Comfort Coffee Mug')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.'
+        )
+        ['de-DE'](
+          'Der Comfort Coffee Mug ist aus Keramik gefertigt. Das Design des Bechers soll das Halten und Trinken erleichtern, mit einem Griff auf einer Seite für bequemen Halt.  Der Becher ist schlicht, aber sein grundlegendes Design ist im Allgemeinen einfach und funktional. Der Körper des Bechers hat oft glatte Seiten und eine breite Öffnung, die das Eingießen und Trinken von Kaffee erleichtert.  Der Comfort Coffee Mug ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist der Comfort Coffee Mug ein praktisches und funktionelles Trinkgefäß, das sich ideal für den Kaffeegenuss zu Hause oder am Arbeitsplatz eignet. Sein einfaches Design und seine Benutzerfreundlichkeit machen ihn zu einer beliebten Wahl für Kaffeeliebhaber aller Art.'
+        )
+        ['en-US'](
+          'The Comfort Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Comfort Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Comfort Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const comfortCoffeeMug = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.comfortCoffeeMug01()
+      ProductVariantDraft.presets.sampleDataGoodStore.comfortCoffeeMug01()
     )
     .categories([
       KeyReference.presets.category().key(glasswareDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.spec.ts
@@ -14,110 +14,1078 @@ describe(`with cottonSilkBedsheet preset`, () => {
           {
             "key": "home-decor",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "cotton-silk-bedsheet",
-      "name": {
-            "de-DE": "Bettwäsche aus Baumwollseide",
-            "en-GB": "Cotton Silk Bedsheet",
-            "en-US": "Cotton Silk Bedsheet"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "bettwsche-aus-baumwollseide",
-            "en-GB": "cotton-silk-bedsheet",
-            "en-US": "cotton-silk-bedsheet"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.",
+          "en": undefined,
+          "en-GB": "Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious.",
+          "en-US": "Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious.",
+          "fr": undefined,
         },
-        {
+        "key": "cotton-silk-bedsheet",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+              },
+            },
+            {
+              "name": "colorlabel",
+              "value": {
+                "de-DE": "Weiß",
+                "en-GB": "White",
+                "en-US": "White",
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "de-DE": "#FFF",
+                "en-GB": "#FFF",
+                "en-US": "#FFF",
+              },
+            },
+            {
+              "name": "new-arrival",
+              "value": "false",
+            },
+            {
+              "name": "size",
+              "value": {
+                "en-GB": "Queen",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#FFF",
+                "label": {
+                  "de-DE": "Weiss",
+                  "en-GB": "White",
+                  "en-US": "White",
+                },
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 4500,
+                "w": 7500,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-L0ubiJAn.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1599,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1599,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1599,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "CSKW-093",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Bettwäsche aus Baumwollseide",
+          "en": undefined,
+          "en-GB": "Cotton Silk Bedsheet",
+          "en-US": "Cotton Silk Bedsheet",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"new-arrival","value":false},{"name":"size","value":{"en-GB":"Queen"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "bettwsche-aus-baumwollseide",
+          "en": undefined,
+          "en-GB": "cotton-silk-bedsheet",
+          "en-US": "cotton-silk-bedsheet",
+          "fr": undefined,
+        },
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
         },
         "variants": [
-        {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}},{"name":"size","value":{"en-GB":"Twin"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}}],
-        },
-        {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}},{"name":"size","value":{"en-GB":"King"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}}],
-        },
-        {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"colorlabel","value":{"en-GB":"Salmon","de-DE":"Lachs","en-US":"Salmon"}},{"name":"color","value":{"en-GB":"#ffc0cb","de-DE":"#ffc0cb","en-US":"#ffc0cb"}},{"name":"size","value":{"en-GB":"Twin"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFC0CB","label":{"de-DE":"Rosa","en-GB":"Pink","en-US":"Pink"}}}],
-        },
-        {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#ffc0cb","de-DE":"#ffc0cb","en-US":"#ffc0cb"}},{"name":"colorlabel","value":{"en-GB":"Salmon","de-DE":"Lachs","en-US":"Salmon"}},{"name":"size","value":{"en-GB":"Queen"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFC0CB","label":{"de-DE":"Rosa","en-GB":"Pink","en-US":"Pink"}}}],
-        },
-        {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#ffc0cb","de-DE":"#ffc0cb","en-US":"#ffc0cb"}},{"name":"colorlabel","value":{"en-GB":"Salmon","de-DE":"Lachs","en-US":"Salmon"}},{"name":"size","value":{"en-GB":"King"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFC0CB","label":{"de-DE":"Rosa","en-GB":"Pink","en-US":"Pink"}}}],
-        },
-        {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#bcbcbc","de-DE":"#bcbcbc","en-US":"#bcbcbc"}},{"name":"colorlabel","value":{"en-GB":"Gray","de-DE":"Grau","en-US":"Gray"}},{"name":"size","value":{"en-GB":"Twin"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}}],
-        },
-        {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#bcbcbc","de-DE":"#bcbcbc","en-US":"#bcbcbc"}},{"name":"colorlabel","value":{"en-GB":"Gray","de-DE":"Grau","en-US":"Gray"}},{"name":"size","value":{"en-GB":"Queen"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}}],
-        },
-        {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#bcbcbc","de-DE":"#bcbcbc","en-US":"#bcbcbc"}},{"name":"colorlabel","value":{"en-GB":"Gray","de-DE":"Grau","en-US":"Gray"}},{"name":"size","value":{"en-GB":"King"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}}],
-        }
-       ]
+          {
+            "assets": undefined,
+            "attributes": [
+              {
+                "name": "productspec",
+                "value": {
+                  "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "de-DE": "#FFF",
+                  "en-GB": "#FFF",
+                  "en-US": "#FFF",
+                },
+              },
+              {
+                "name": "colorlabel",
+                "value": {
+                  "de-DE": "Weiß",
+                  "en-GB": "White",
+                  "en-US": "White",
+                },
+              },
+              {
+                "name": "size",
+                "value": {
+                  "en-GB": "Twin",
+                },
+              },
+              {
+                "name": "color-filter",
+                "value": {
+                  "key": "#FFF",
+                  "label": {
+                    "de-DE": "Weiss",
+                    "en-GB": "White",
+                    "en-US": "White",
+                  },
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 4500,
+                  "w": 7500,
+                },
+                "label": undefined,
+                "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-spHghd9J.jpeg",
+              },
+            ],
+            "key": undefined,
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1299,
+                  "currencyCode": "EUR",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "GB",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1299,
+                  "currencyCode": "GBP",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1299,
+                  "currencyCode": "USD",
+                },
+              },
+            ],
+            "sku": "CSKW-0922",
+          },
+          {
+            "assets": undefined,
+            "attributes": [
+              {
+                "name": "productspec",
+                "value": {
+                  "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "de-DE": "#FFF",
+                  "en-GB": "#FFF",
+                  "en-US": "#FFF",
+                },
+              },
+              {
+                "name": "colorlabel",
+                "value": {
+                  "de-DE": "Weiß",
+                  "en-GB": "White",
+                  "en-US": "White",
+                },
+              },
+              {
+                "name": "size",
+                "value": {
+                  "en-GB": "King",
+                },
+              },
+              {
+                "name": "color-filter",
+                "value": {
+                  "key": "#FFF",
+                  "label": {
+                    "de-DE": "Weiss",
+                    "en-GB": "White",
+                    "en-US": "White",
+                  },
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 4500,
+                  "w": 7500,
+                },
+                "label": undefined,
+                "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_452514843-RXVUnvih.jpeg",
+              },
+            ],
+            "key": undefined,
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1899,
+                  "currencyCode": "EUR",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "GB",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1899,
+                  "currencyCode": "GBP",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1899,
+                  "currencyCode": "USD",
+                },
+              },
+            ],
+            "sku": "CSKW-9822",
+          },
+          {
+            "assets": undefined,
+            "attributes": [
+              {
+                "name": "productspec",
+                "value": {
+                  "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                },
+              },
+              {
+                "name": "colorlabel",
+                "value": {
+                  "de-DE": "Lachs",
+                  "en-GB": "Salmon",
+                  "en-US": "Salmon",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "de-DE": "#ffc0cb",
+                  "en-GB": "#ffc0cb",
+                  "en-US": "#ffc0cb",
+                },
+              },
+              {
+                "name": "size",
+                "value": {
+                  "en-GB": "Twin",
+                },
+              },
+              {
+                "name": "color-filter",
+                "value": {
+                  "key": "#FFC0CB",
+                  "label": {
+                    "de-DE": "Rosa",
+                    "en-GB": "Pink",
+                    "en-US": "Pink",
+                  },
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 3627,
+                  "w": 5589,
+                },
+                "label": undefined,
+                "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-SYnKs_os.jpeg",
+              },
+              {
+                "dimensions": {
+                  "h": 3228,
+                  "w": 5216,
+                },
+                "label": undefined,
+                "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-SqkvdFES.jpeg",
+              },
+            ],
+            "key": undefined,
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1299,
+                  "currencyCode": "EUR",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "GB",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1299,
+                  "currencyCode": "GBP",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1299,
+                  "currencyCode": "USD",
+                },
+              },
+            ],
+            "sku": "CSKP-0934",
+          },
+          {
+            "assets": undefined,
+            "attributes": [
+              {
+                "name": "productspec",
+                "value": {
+                  "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "de-DE": "#ffc0cb",
+                  "en-GB": "#ffc0cb",
+                  "en-US": "#ffc0cb",
+                },
+              },
+              {
+                "name": "colorlabel",
+                "value": {
+                  "de-DE": "Lachs",
+                  "en-GB": "Salmon",
+                  "en-US": "Salmon",
+                },
+              },
+              {
+                "name": "size",
+                "value": {
+                  "en-GB": "Queen",
+                },
+              },
+              {
+                "name": "color-filter",
+                "value": {
+                  "key": "#FFC0CB",
+                  "label": {
+                    "de-DE": "Rosa",
+                    "en-GB": "Pink",
+                    "en-US": "Pink",
+                  },
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 3627,
+                  "w": 5589,
+                },
+                "label": undefined,
+                "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-YYm1GR3y.jpeg",
+              },
+              {
+                "dimensions": {
+                  "h": 3228,
+                  "w": 5216,
+                },
+                "label": undefined,
+                "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-8eeyUKq9.jpeg",
+              },
+            ],
+            "key": undefined,
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1599,
+                  "currencyCode": "EUR",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "GB",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1599,
+                  "currencyCode": "GBP",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1599,
+                  "currencyCode": "USD",
+                },
+              },
+            ],
+            "sku": "CSKP-0932",
+          },
+          {
+            "assets": undefined,
+            "attributes": [
+              {
+                "name": "productspec",
+                "value": {
+                  "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "de-DE": "#ffc0cb",
+                  "en-GB": "#ffc0cb",
+                  "en-US": "#ffc0cb",
+                },
+              },
+              {
+                "name": "colorlabel",
+                "value": {
+                  "de-DE": "Lachs",
+                  "en-GB": "Salmon",
+                  "en-US": "Salmon",
+                },
+              },
+              {
+                "name": "size",
+                "value": {
+                  "en-GB": "King",
+                },
+              },
+              {
+                "name": "color-filter",
+                "value": {
+                  "key": "#FFC0CB",
+                  "label": {
+                    "de-DE": "Rosa",
+                    "en-GB": "Pink",
+                    "en-US": "Pink",
+                  },
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 3627,
+                  "w": 5589,
+                },
+                "label": undefined,
+                "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_342052824-bUbU_TKg.jpeg",
+              },
+              {
+                "dimensions": {
+                  "h": 3228,
+                  "w": 5216,
+                },
+                "label": undefined,
+                "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_369728670-I0XNqDPK.jpeg",
+              },
+            ],
+            "key": undefined,
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1899,
+                  "currencyCode": "EUR",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "GB",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1899,
+                  "currencyCode": "GBP",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1899,
+                  "currencyCode": "USD",
+                },
+              },
+            ],
+            "sku": "CSKP-083",
+          },
+          {
+            "assets": undefined,
+            "attributes": [
+              {
+                "name": "productspec",
+                "value": {
+                  "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "de-DE": "#bcbcbc",
+                  "en-GB": "#bcbcbc",
+                  "en-US": "#bcbcbc",
+                },
+              },
+              {
+                "name": "colorlabel",
+                "value": {
+                  "de-DE": "Grau",
+                  "en-GB": "Gray",
+                  "en-US": "Gray",
+                },
+              },
+              {
+                "name": "size",
+                "value": {
+                  "en-GB": "Twin",
+                },
+              },
+              {
+                "name": "color-filter",
+                "value": {
+                  "key": "#808080",
+                  "label": {
+                    "de-DE": "Grau",
+                    "en-GB": "Gray",
+                    "en-US": "Gray",
+                  },
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 3848,
+                  "w": 6016,
+                },
+                "label": undefined,
+                "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-qnDiKfx7.jpeg",
+              },
+            ],
+            "key": undefined,
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1299,
+                  "currencyCode": "EUR",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "GB",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1299,
+                  "currencyCode": "GBP",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1299,
+                  "currencyCode": "USD",
+                },
+              },
+            ],
+            "sku": "CSKG-92",
+          },
+          {
+            "assets": undefined,
+            "attributes": [
+              {
+                "name": "productspec",
+                "value": {
+                  "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "de-DE": "#bcbcbc",
+                  "en-GB": "#bcbcbc",
+                  "en-US": "#bcbcbc",
+                },
+              },
+              {
+                "name": "colorlabel",
+                "value": {
+                  "de-DE": "Grau",
+                  "en-GB": "Gray",
+                  "en-US": "Gray",
+                },
+              },
+              {
+                "name": "size",
+                "value": {
+                  "en-GB": "Queen",
+                },
+              },
+              {
+                "name": "color-filter",
+                "value": {
+                  "key": "#808080",
+                  "label": {
+                    "de-DE": "Grau",
+                    "en-GB": "Gray",
+                    "en-US": "Gray",
+                  },
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 3848,
+                  "w": 6016,
+                },
+                "label": undefined,
+                "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-BPilhC_x.jpeg",
+              },
+            ],
+            "key": undefined,
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1599,
+                  "currencyCode": "EUR",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "GB",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1599,
+                  "currencyCode": "GBP",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1599,
+                  "currencyCode": "USD",
+                },
+              },
+            ],
+            "sku": "CSKG-023",
+          },
+          {
+            "assets": undefined,
+            "attributes": [
+              {
+                "name": "productspec",
+                "value": {
+                  "de-DE": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-GB": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                  "en-US": "- Machine washable
+      - 600 thread count
+      - Includes 1 fitted sheet",
+                },
+              },
+              {
+                "name": "color",
+                "value": {
+                  "de-DE": "#bcbcbc",
+                  "en-GB": "#bcbcbc",
+                  "en-US": "#bcbcbc",
+                },
+              },
+              {
+                "name": "colorlabel",
+                "value": {
+                  "de-DE": "Grau",
+                  "en-GB": "Gray",
+                  "en-US": "Gray",
+                },
+              },
+              {
+                "name": "size",
+                "value": {
+                  "en-GB": "King",
+                },
+              },
+              {
+                "name": "color-filter",
+                "value": {
+                  "key": "#808080",
+                  "label": {
+                    "de-DE": "Grau",
+                    "en-GB": "Gray",
+                    "en-US": "Gray",
+                  },
+                },
+              },
+            ],
+            "images": [
+              {
+                "dimensions": {
+                  "h": 3848,
+                  "w": 6016,
+                },
+                "label": undefined,
+                "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_387796655-KFchHtXM.jpeg",
+              },
+            ],
+            "key": undefined,
+            "prices": [
+              {
+                "channel": undefined,
+                "country": "DE",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1899,
+                  "currencyCode": "EUR",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "GB",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1899,
+                  "currencyCode": "GBP",
+                },
+              },
+              {
+                "channel": undefined,
+                "country": "US",
+                "custom": undefined,
+                "customerGroup": undefined,
+                "discounted": undefined,
+                "key": undefined,
+                "tiers": undefined,
+                "validFrom": undefined,
+                "validUntil": undefined,
+                "value": {
+                  "centAmount": 1899,
+                  "currencyCode": "USD",
+                },
+              },
+            ],
+            "sku": "CSKG-2345",
+          },
+        ],
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.spec.ts
@@ -1,0 +1,124 @@
+import type { TProductDraft } from '../../../types';
+import cottonSilkBedsheet from './cotton-silk-bedsheet';
+describe(`with cottonSilkBedsheet preset`, () => {
+  it('should return a sample cottonSilkBedsheet product preset', () => {
+    const cottonSilkBedsheetPreset =
+      cottonSilkBedsheet().build<TProductDraft>();
+    expect(cottonSilkBedsheetPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "bedding",
+            "typeId": "category",
+          },
+          {
+            "key": "home-decor",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "cotton-silk-bedsheet",
+      "name": {
+            "de-DE": "Bettwäsche aus Baumwollseide",
+            "en-GB": "Cotton Silk Bedsheet",
+            "en-US": "Cotton Silk Bedsheet"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "bettwsche-aus-baumwollseide",
+            "en-GB": "cotton-silk-bedsheet",
+            "en-US": "cotton-silk-bedsheet"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"new-arrival","value":false},{"name":"size","value":{"en-GB":"Queen"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}}],
+        },
+        "variants": [
+        {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}},{"name":"size","value":{"en-GB":"Twin"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}}],
+        },
+        {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}},{"name":"size","value":{"en-GB":"King"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}}],
+        },
+        {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"colorlabel","value":{"en-GB":"Salmon","de-DE":"Lachs","en-US":"Salmon"}},{"name":"color","value":{"en-GB":"#ffc0cb","de-DE":"#ffc0cb","en-US":"#ffc0cb"}},{"name":"size","value":{"en-GB":"Twin"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFC0CB","label":{"de-DE":"Rosa","en-GB":"Pink","en-US":"Pink"}}}],
+        },
+        {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#ffc0cb","de-DE":"#ffc0cb","en-US":"#ffc0cb"}},{"name":"colorlabel","value":{"en-GB":"Salmon","de-DE":"Lachs","en-US":"Salmon"}},{"name":"size","value":{"en-GB":"Queen"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFC0CB","label":{"de-DE":"Rosa","en-GB":"Pink","en-US":"Pink"}}}],
+        },
+        {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#ffc0cb","de-DE":"#ffc0cb","en-US":"#ffc0cb"}},{"name":"colorlabel","value":{"en-GB":"Salmon","de-DE":"Lachs","en-US":"Salmon"}},{"name":"size","value":{"en-GB":"King"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#FFC0CB","label":{"de-DE":"Rosa","en-GB":"Pink","en-US":"Pink"}}}],
+        },
+        {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#bcbcbc","de-DE":"#bcbcbc","en-US":"#bcbcbc"}},{"name":"colorlabel","value":{"en-GB":"Gray","de-DE":"Grau","en-US":"Gray"}},{"name":"size","value":{"en-GB":"Twin"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}}],
+        },
+        {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#bcbcbc","de-DE":"#bcbcbc","en-US":"#bcbcbc"}},{"name":"colorlabel","value":{"en-GB":"Gray","de-DE":"Grau","en-US":"Gray"}},{"name":"size","value":{"en-GB":"Queen"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}}],
+        },
+        {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","en-US":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet","de-DE":"- Machine washable\n- 600 thread count\n- Includes 1 fitted sheet"}},{"name":"color","value":{"en-GB":"#bcbcbc","de-DE":"#bcbcbc","en-US":"#bcbcbc"}},{"name":"colorlabel","value":{"en-GB":"Gray","de-DE":"Grau","en-US":"Gray"}},{"name":"size","value":{"en-GB":"King"}},{"name":"product-description","value":{"en-GB":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","en-US":"Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious. ","de-DE":"Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt."}},{"name":"color-filter","value":{"key":"#808080","label":{"de-DE":"Grau","en-GB":"Gray","en-US":"Gray"}}}],
+        }
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.ts
@@ -18,7 +18,7 @@ import {
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodStore
   .vatStandardEu()
   .build<TTaxCategoryDraft>();
 
@@ -63,17 +63,17 @@ const cottonSilkBedsheet = (): TProductDraftBuilder =>
       KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01()
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01()
     )
     .variants([
-      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
-      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
-      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
-      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
-      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
-      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
-      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
-      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet02(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet03(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet04(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01(),
     ])
     .categories([
       KeyReference.presets.category().key(beddingDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.ts
@@ -1,0 +1,83 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const cottonSilkBedsheetProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const beddingDraft = CategoryDraft.presets.sampleDataGoodstore
+  .bedding()
+  .build<TCategoryDraft>();
+
+const homeDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+  .homeDecor()
+  .build<TCategoryDraft>();
+
+const cottonSilkBedsheet = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('cotton-silk-bedsheet')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Cotton Silk Bedsheet')
+        ['de-DE']('Bettwäsche aus Baumwollseide')
+        ['en-US']('Cotton Silk Bedsheet')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('cotton-silk-bedsheet')
+        ['de-DE']('bettwsche-aus-baumwollseide')
+        ['en-US']('cotton-silk-bedsheet')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(cottonSilkBedsheetProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01()
+    )
+    .variants([
+      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodstore.cottonSilkBedsheet01(),
+    ])
+    .categories([
+      KeyReference.presets.category().key(beddingDraft.key!),
+      KeyReference.presets.category().key(homeDecorDraft.key!),
+    ]);
+
+export default cottonSilkBedsheet;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.ts
@@ -10,28 +10,28 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodStore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const cottonSilkBedsheetProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const beddingDraft = CategoryDraft.presets.sampleDataGoodstore
+const beddingDraft = CategoryDraft.presets.sampleDataGoodStore
   .bedding()
   .build<TCategoryDraft>();
 
-const homeDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+const homeDecorDraft = CategoryDraft.presets.sampleDataGoodStore
   .homeDecor()
   .build<TCategoryDraft>();
 
@@ -45,6 +45,19 @@ const cottonSilkBedsheet = (): TProductDraftBuilder =>
         ['en-GB']('Cotton Silk Bedsheet')
         ['de-DE']('Bettwäsche aus Baumwollseide')
         ['en-US']('Cotton Silk Bedsheet')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious.'
+        )
+        ['de-DE'](
+          'Bettwäsche aus Baumwollseide besteht aus einer Mischung aus Baumwoll- und Seidenfasern. Baumwolle ist für ihre Strapazierfähigkeit, Atmungsaktivität und Pflegeleichtigkeit bekannt. Seide hingegen ist bekannt für ihre Geschmeidigkeit, ihren strahlenden Glanz und ihr luxuriöses Gefühl. Durch die Kombination beider bieten wir ein Produkt an, das Haltbarkeit, Atmungsaktivität und Luxus in Einklang bringt.  Bettwäsche aus Baumwollseide hat oft einen dezenten Seidenglanz, der sie luxuriöser aussehen lässt.'
+        )
+        ['en-US'](
+          'Cotton silk bed sheets are made from a blend of cotton and silk fibers. Cotton is known for its durability, breathability, and ease of care. Silk, on the other hand, is renowned for its smoothness, lustrous sheen, and luxurious feel. By combining the two, we offer a product that balances durability, breathability, and luxury.  Cotton silk bed sheets often have a subtle sheen from the silk, making them look more luxurious.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -60,7 +73,7 @@ const cottonSilkBedsheet = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
       ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01()
@@ -69,11 +82,11 @@ const cottonSilkBedsheet = (): TProductDraftBuilder =>
       ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet02(),
       ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet03(),
       ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet04(),
-      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01(),
-      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01(),
-      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01(),
-      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01(),
-      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet01(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet05(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet06(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet07(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet08(),
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonSilkBedsheet09(),
     ])
     .categories([
       KeyReference.presets.category().key(beddingDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-two-seater-sofa.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-two-seater-sofa.spec.ts
@@ -1,0 +1,65 @@
+import type { TProductDraft } from '../../../types';
+import cottonTwoSeaterSofa from './cotton-two-seater-sofa';
+describe(`with cottonTwoSeaterSofa preset`, () => {
+  it('should return a sample cottonTwoSeaterSofa product preset', () => {
+    const cottonTwoSeaterSofaPreset =
+      cottonTwoSeaterSofa().build<TProductDraft>();
+    expect(cottonTwoSeaterSofaPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "sofas",
+            "typeId": "category",
+          },
+          {
+            "key": "furniture",
+            "typeId": "category",
+          },
+          {
+            "key": "living-room-furniture",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "cotton-two-seater-sofa",
+      "name": {
+            "de-DE": "Zweisitzer-Sofa aus Baumwolle",
+            "en-GB": "Cotton Two-Seater Sofa",
+            "en-US": "Cotton Two-Seater Sofa"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "zweisitzer-sofa-aus-baumwolle",
+            "en-GB": "cotton-two-seater-sofa",
+            "en-US": "cotton-two-seater-sofa"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"product-description","value":{"en-GB":"The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room.","en-US":"The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room.","de-DE":"Das 2-Sitzer-Baumwollsofa ist eine gemütliche und bequeme Sitzgelegenheit für jedes Zuhause. Aus weichem, hochwertigem Baumwollstoff gefertigt, ist dieses Sofa sanft zur Haut und pflegeleicht. Die beiden Sitzkissen sind weich und stützend und bieten ein komfortables Sitzerlebnis. Die Rückenlehne des Sofas ist gut gepolstert und bietet reichlich Rückenunterstützung, während die Armlehnen für ein bequemes und entspanntes Gefühl sanft abgerundet sind. Der Holzrahmen des Sofas ist robust und langlebig, sodass er viele Jahre hält. Mit einer neutralen Farbe fügt sich dieses Sofa nahtlos in jeden Einrichtungsstil ein, während das schlichte und elegante Design jedem Raum einen Hauch von Raffinesse verleiht."}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-two-seater-sofa.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-two-seater-sofa.spec.ts
@@ -18,47 +18,157 @@ describe(`with cottonTwoSeaterSofa preset`, () => {
           {
             "key": "living-room-furniture",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "cotton-two-seater-sofa",
-      "name": {
-            "de-DE": "Zweisitzer-Sofa aus Baumwolle",
-            "en-GB": "Cotton Two-Seater Sofa",
-            "en-US": "Cotton Two-Seater Sofa"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "zweisitzer-sofa-aus-baumwolle",
-            "en-GB": "cotton-two-seater-sofa",
-            "en-US": "cotton-two-seater-sofa"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Das 2-Sitzer-Baumwollsofa ist eine gemütliche und bequeme Sitzgelegenheit für jedes Zuhause. Aus weichem, hochwertigem Baumwollstoff gefertigt, ist dieses Sofa sanft zur Haut und pflegeleicht. Die beiden Sitzkissen sind weich und stützend und bieten ein komfortables Sitzerlebnis. Die Rückenlehne des Sofas ist gut gepolstert und bietet reichlich Rückenunterstützung, während die Armlehnen für ein bequemes und entspanntes Gefühl sanft abgerundet sind. Der Holzrahmen des Sofas ist robust und langlebig, sodass er viele Jahre hält. Mit einer neutralen Farbe fügt sich dieses Sofa nahtlos in jeden Einrichtungsstil ein, während das schlichte und elegante Design jedem Raum einen Hauch von Raffinesse verleiht.",
+          "en": undefined,
+          "en-GB": "The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room.",
+          "en-US": "The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room.",
+          "fr": undefined,
         },
-        {
+        "key": "cotton-two-seater-sofa",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "color",
+              "value": {
+                "de-DE": "#FFF",
+                "en-GB": "#FFF",
+                "en-US": "#FFF",
+              },
+            },
+            {
+              "name": "colorlabel",
+              "value": {
+                "de-DE": "Weiß",
+                "en-GB": "White",
+                "en-US": "White",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#FFF",
+                "label": {
+                  "de-DE": "Weiss",
+                  "en-GB": "White",
+                  "en-US": "White",
+                },
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 2969,
+                "w": 5035,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_225174101-6XExeL2D.jpeg",
+            },
+            {
+              "dimensions": {
+                "h": 637,
+                "w": 1000,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_202436963-ZB2HxGeB.jpeg",
+            },
+            {
+              "dimensions": {
+                "h": 3840,
+                "w": 5760,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377510554-dyXzuIQC.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 54900,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 54900,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 54900,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "CTSS-0983",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Zweisitzer-Sofa aus Baumwolle",
+          "en": undefined,
+          "en-GB": "Cotton Two-Seater Sofa",
+          "en-US": "Cotton Two-Seater Sofa",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"product-description","value":{"en-GB":"The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room.","en-US":"The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room.","de-DE":"Das 2-Sitzer-Baumwollsofa ist eine gemütliche und bequeme Sitzgelegenheit für jedes Zuhause. Aus weichem, hochwertigem Baumwollstoff gefertigt, ist dieses Sofa sanft zur Haut und pflegeleicht. Die beiden Sitzkissen sind weich und stützend und bieten ein komfortables Sitzerlebnis. Die Rückenlehne des Sofas ist gut gepolstert und bietet reichlich Rückenunterstützung, während die Armlehnen für ein bequemes und entspanntes Gefühl sanft abgerundet sind. Der Holzrahmen des Sofas ist robust und langlebig, sodass er viele Jahre hält. Mit einer neutralen Farbe fügt sich dieses Sofa nahtlos in jeden Einrichtungsstil ein, während das schlichte und elegante Design jedem Raum einen Hauch von Raffinesse verleiht."}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "zweisitzer-sofa-aus-baumwolle",
+          "en": undefined,
+          "en-GB": "cotton-two-seater-sofa",
+          "en-US": "cotton-two-seater-sofa",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-two-seater-sofa.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-two-seater-sofa.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const cottonTwoSeaterSofaProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const sofasDraft = CategoryDraft.presets.sampleDataGoodstore
+  .sofas()
+  .build<TCategoryDraft>();
+
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .furniture()
+  .build<TCategoryDraft>();
+
+const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .livingRoomFurniture()
+  .build<TCategoryDraft>();
+
+const cottonTwoSeaterSofa = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('cotton-two-seater-sofa')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Cotton Two-Seater Sofa')
+        ['de-DE']('Zweisitzer-Sofa aus Baumwolle')
+        ['en-US']('Cotton Two-Seater Sofa')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('cotton-two-seater-sofa')
+        ['de-DE']('zweisitzer-sofa-aus-baumwolle')
+        ['en-US']('cotton-two-seater-sofa')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(cottonTwoSeaterSofaProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.cottonTwoSeaterSofa01()
+    )
+    .categories([
+      KeyReference.presets.category().key(sofasDraft.key!),
+      KeyReference.presets.category().key(furnitureDraft.key!),
+      KeyReference.presets.category().key(livingRoomFurnitureDraft.key!),
+    ]);
+
+export default cottonTwoSeaterSofa;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-two-seater-sofa.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-two-seater-sofa.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const cottonTwoSeaterSofaProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const sofasDraft = CategoryDraft.presets.sampleDataGoodstore
+const sofasDraft = CategoryDraft.presets.sampleDataGoodStore
   .sofas()
   .build<TCategoryDraft>();
 
-const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .furniture()
   .build<TCategoryDraft>();
 
-const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .livingRoomFurniture()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const cottonTwoSeaterSofa = (): TProductDraftBuilder =>
         ['en-GB']('Cotton Two-Seater Sofa')
         ['de-DE']('Zweisitzer-Sofa aus Baumwolle')
         ['en-US']('Cotton Two-Seater Sofa')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          "The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room."
+        )
+        ['de-DE'](
+          'Das 2-Sitzer-Baumwollsofa ist eine gemütliche und bequeme Sitzgelegenheit für jedes Zuhause. Aus weichem, hochwertigem Baumwollstoff gefertigt, ist dieses Sofa sanft zur Haut und pflegeleicht. Die beiden Sitzkissen sind weich und stützend und bieten ein komfortables Sitzerlebnis. Die Rückenlehne des Sofas ist gut gepolstert und bietet reichlich Rückenunterstützung, während die Armlehnen für ein bequemes und entspanntes Gefühl sanft abgerundet sind. Der Holzrahmen des Sofas ist robust und langlebig, sodass er viele Jahre hält. Mit einer neutralen Farbe fügt sich dieses Sofa nahtlos in jeden Einrichtungsstil ein, während das schlichte und elegante Design jedem Raum einen Hauch von Raffinesse verleiht.'
+        )
+        ['en-US'](
+          "The 2-seater cotton sofa is a cozy and comfortable seating option for any home. Made from soft, high-quality cotton fabric, this sofa is gentle on the skin and easy to maintain. The two seat cushions are plush and supportive, providing a comfortable seating experience. The sofa's backrest is well-padded, providing ample back support, while the armrests are gently rounded for a comfortable and relaxed feel. The wooden frame of the sofa is sturdy and durable, ensuring it will last for years to come. With a neutral color, this sofa can blend seamlessly into any interior design style, while the simple and elegant design adds a touch of sophistication to any room."
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const cottonTwoSeaterSofa = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.cottonTwoSeaterSofa01()
+      ProductVariantDraft.presets.sampleDataGoodStore.cottonTwoSeaterSofa01()
     )
     .categories([
       KeyReference.presets.category().key(sofasDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/crystal-drinking-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/crystal-drinking-glass.spec.ts
@@ -1,0 +1,65 @@
+import type { TProductDraft } from '../../../types';
+import crystalDrinkingGlass from './crystal-drinking-glass';
+describe(`with crystalDrinkingGlass preset`, () => {
+  it('should return a sample crystalDrinkingGlass product preset', () => {
+    const crystalDrinkingGlassPreset =
+      crystalDrinkingGlass().build<TProductDraft>();
+    expect(crystalDrinkingGlassPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "glassware",
+            "typeId": "category",
+          },
+          {
+            "key": "bar-and-glassware",
+            "typeId": "category",
+          },
+          {
+            "key": "kitchen",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "crystal-drinking-glass",
+      "name": {
+            "de-DE": "Kristall-Trinkglas",
+            "en-GB": "Crystal Drinking Glass",
+            "en-US": "Crystal Drinking Glass"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "kristall-trinkglas",
+            "en-GB": "crystal-drinking-glass",
+            "en-US": "crystal-drinking-glass"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Set includes 6 glasses","de-DE":"- Das Set enthält 6 Gläser","en-US":"- Set includes 6 glasses"}},{"name":"product-description","value":{"en-GB":"This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.","en-US":"This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.","de-DE":"Dieses Kristall-Trinkglas besteht aus hochwertigem, bleifreiem Kristallglas, das dünn und zart, aber dennoch stark und langlebig ist. Das Kristallmaterial des Longdrinkglases wertet das Getränk auf und lässt es funkelnder und farbenfroher erscheinen. Es verbessert auch das Aroma und den Geschmack des Getränks und ermöglicht es dem Trinker, die Komplexität der Zutaten voll zu schätzen.  Das Design des Glases soll die Zugabe von Eis, Soda oder anderen Mixern ermöglichen und dennoch viel Platz für das Getränk selbst lassen. Die weite Öffnung des Glases lässt den Trinker das Aroma des Getränks riechen, während die geraden Seiten und die glatte Oberfläche das Trinken und Genießen erleichtern.  Das Kristall-Highballglas ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist das Highball-Glas aus Kristall ein stilvolles und elegantes Glasgeschirr, das sich perfekt zum Servieren von großen Mixgetränken eignet. Sein zartes Kristallmaterial und sein kompliziertes Design machen es zu einer beliebten Wahl für besondere Anlässe und gehobene Speiseerlebnisse."}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/crystal-drinking-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/crystal-drinking-glass.spec.ts
@@ -18,47 +18,122 @@ describe(`with crystalDrinkingGlass preset`, () => {
           {
             "key": "kitchen",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "crystal-drinking-glass",
-      "name": {
-            "de-DE": "Kristall-Trinkglas",
-            "en-GB": "Crystal Drinking Glass",
-            "en-US": "Crystal Drinking Glass"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "kristall-trinkglas",
-            "en-GB": "crystal-drinking-glass",
-            "en-US": "crystal-drinking-glass"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Dieses Kristall-Trinkglas besteht aus hochwertigem, bleifreiem Kristallglas, das dünn und zart, aber dennoch stark und langlebig ist. Das Kristallmaterial des Longdrinkglases wertet das Getränk auf und lässt es funkelnder und farbenfroher erscheinen. Es verbessert auch das Aroma und den Geschmack des Getränks und ermöglicht es dem Trinker, die Komplexität der Zutaten voll zu schätzen.  Das Design des Glases soll die Zugabe von Eis, Soda oder anderen Mixern ermöglichen und dennoch viel Platz für das Getränk selbst lassen. Die weite Öffnung des Glases lässt den Trinker das Aroma des Getränks riechen, während die geraden Seiten und die glatte Oberfläche das Trinken und Genießen erleichtern.  Das Kristall-Highballglas ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist das Highball-Glas aus Kristall ein stilvolles und elegantes Glasgeschirr, das sich perfekt zum Servieren von großen Mixgetränken eignet. Sein zartes Kristallmaterial und sein kompliziertes Design machen es zu einer beliebten Wahl für besondere Anlässe und gehobene Speiseerlebnisse.",
+          "en": undefined,
+          "en-GB": "This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.",
+          "en-US": "This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.",
+          "fr": undefined,
         },
-        {
+        "key": "crystal-drinking-glass",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Das Set enthält 6 Gläser",
+                "en-GB": "- Set includes 6 glasses",
+                "en-US": "- Set includes 6 glasses",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 3000,
+                "w": 3000,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Crystal%20Drinking%20Gla-8ynxF_aM.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 3499,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 3499,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 3499,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "CDG-09",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Kristall-Trinkglas",
+          "en": undefined,
+          "en-GB": "Crystal Drinking Glass",
+          "en-US": "Crystal Drinking Glass",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Set includes 6 glasses","de-DE":"- Das Set enthält 6 Gläser","en-US":"- Set includes 6 glasses"}},{"name":"product-description","value":{"en-GB":"This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.","en-US":"This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.","de-DE":"Dieses Kristall-Trinkglas besteht aus hochwertigem, bleifreiem Kristallglas, das dünn und zart, aber dennoch stark und langlebig ist. Das Kristallmaterial des Longdrinkglases wertet das Getränk auf und lässt es funkelnder und farbenfroher erscheinen. Es verbessert auch das Aroma und den Geschmack des Getränks und ermöglicht es dem Trinker, die Komplexität der Zutaten voll zu schätzen.  Das Design des Glases soll die Zugabe von Eis, Soda oder anderen Mixern ermöglichen und dennoch viel Platz für das Getränk selbst lassen. Die weite Öffnung des Glases lässt den Trinker das Aroma des Getränks riechen, während die geraden Seiten und die glatte Oberfläche das Trinken und Genießen erleichtern.  Das Kristall-Highballglas ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist das Highball-Glas aus Kristall ein stilvolles und elegantes Glasgeschirr, das sich perfekt zum Servieren von großen Mixgetränken eignet. Sein zartes Kristallmaterial und sein kompliziertes Design machen es zu einer beliebten Wahl für besondere Anlässe und gehobene Speiseerlebnisse."}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "kristall-trinkglas",
+          "en": undefined,
+          "en-GB": "crystal-drinking-glass",
+          "en-US": "crystal-drinking-glass",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/crystal-drinking-glass.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/crystal-drinking-glass.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const crystalDrinkingGlassProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const glasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .glassware()
+  .build<TCategoryDraft>();
+
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAndGlassware()
+  .build<TCategoryDraft>();
+
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+  .kitchen()
+  .build<TCategoryDraft>();
+
+const crystalDrinkingGlass = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('crystal-drinking-glass')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Crystal Drinking Glass')
+        ['de-DE']('Kristall-Trinkglas')
+        ['en-US']('Crystal Drinking Glass')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('crystal-drinking-glass')
+        ['de-DE']('kristall-trinkglas')
+        ['en-US']('crystal-drinking-glass')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(crystalDrinkingGlassProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.crystalDrinkingGlass01()
+    )
+    .categories([
+      KeyReference.presets.category().key(glasswareDraft.key!),
+      KeyReference.presets.category().key(barAndGlasswareDraft.key!),
+      KeyReference.presets.category().key(kitchenDraft.key!),
+    ]);
+
+export default crystalDrinkingGlass;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/crystal-drinking-glass.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/crystal-drinking-glass.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const crystalDrinkingGlassProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const glasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+const glasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .glassware()
   .build<TCategoryDraft>();
 
-const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAndGlassware()
   .build<TCategoryDraft>();
 
-const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore
   .kitchen()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const crystalDrinkingGlass = (): TProductDraftBuilder =>
         ['en-GB']('Crystal Drinking Glass')
         ['de-DE']('Kristall-Trinkglas')
         ['en-US']('Crystal Drinking Glass')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.'
+        )
+        ['de-DE'](
+          'Dieses Kristall-Trinkglas besteht aus hochwertigem, bleifreiem Kristallglas, das dünn und zart, aber dennoch stark und langlebig ist. Das Kristallmaterial des Longdrinkglases wertet das Getränk auf und lässt es funkelnder und farbenfroher erscheinen. Es verbessert auch das Aroma und den Geschmack des Getränks und ermöglicht es dem Trinker, die Komplexität der Zutaten voll zu schätzen.  Das Design des Glases soll die Zugabe von Eis, Soda oder anderen Mixern ermöglichen und dennoch viel Platz für das Getränk selbst lassen. Die weite Öffnung des Glases lässt den Trinker das Aroma des Getränks riechen, während die geraden Seiten und die glatte Oberfläche das Trinken und Genießen erleichtern.  Das Kristall-Highballglas ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Insgesamt ist das Highball-Glas aus Kristall ein stilvolles und elegantes Glasgeschirr, das sich perfekt zum Servieren von großen Mixgetränken eignet. Sein zartes Kristallmaterial und sein kompliziertes Design machen es zu einer beliebten Wahl für besondere Anlässe und gehobene Speiseerlebnisse.'
+        )
+        ['en-US'](
+          'This Crystal Drinking Glass is made of high-quality, lead-free crystal glass that is thin and delicate, yet strong and durable. The crystal material of the highball glass enhances the appearance of the drink, making it appear more sparkling and colorful. It also enhances the aroma and flavor of the drink, allowing the drinker to fully appreciate the complexity of the ingredients.  The design of the glass is intended to accommodate the addition of ice, soda, or other mixers, while still leaving plenty of room for the drink itself. The wide mouth of the glass allows the drinker to smell the aroma of the drink, while the straight sides and smooth surface make it easy to sip and enjoy.  The crystal highball glass is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the crystal highball glass is a stylish and elegant piece of glassware that is perfect for serving tall, mixed drinks. Its delicate crystal material and intricate design make it a popular choice for special occasions and fine dining experiences.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const crystalDrinkingGlass = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.crystalDrinkingGlass01()
+      ProductVariantDraft.presets.sampleDataGoodStore.crystalDrinkingGlass01()
     )
     .categories([
       KeyReference.presets.category().key(glasswareDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cube-jute-basket.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cube-jute-basket.spec.ts
@@ -17,47 +17,155 @@ describe(`with cubeJuteBasket preset`, () => {
           {
             "key": "home-decor",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "cube-jute-basket",
-      "name": {
-            "de-DE": "Würfel Jutekorb",
-            "en-GB": "Cube Jute Basket",
-            "en-US": "Cube Jute Basket"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "wrfel-jutekorb",
-            "en-GB": "cube-jute-basket",
-            "en-US": "cube-jute-basket"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Ein Würfel-Jutekorb für das Wohnzimmer ist eine praktische und stilvolle Aufbewahrungslösung, die dem Raum Wärme und Struktur verleiht. Der Korb besteht aus natürlichen Jutefasern, die eng miteinander verwoben sind, um eine robuste und langlebige Struktur zu schaffen.  Die Würfelform des Korbs eignet sich perfekt zur Aufbewahrung einer Vielzahl von Gegenständen wie Decken, Zeitschriften, Fernbedienungen oder sogar kleinen Pflanzen. Die offene Oberseite des Korbs ermöglicht einen einfachen Zugriff auf den Inhalt, während die Seiten eine sichere Barriere bieten, um alles ordentlich zu verstauen.  Die neutrale Farbe der Jutefasern ergänzt eine Vielzahl von Einrichtungsstilen, von böhmisch über küstennah bis rustikal. Der Korb kann auf den Boden oder in ein Regal gestellt werden und lässt sich dank seiner kompakten Größe bei Bedarf leicht bewegen.",
+          "en": undefined,
+          "en-GB": "A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.",
+          "en-US": "A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.",
+          "fr": undefined,
         },
-        {
+        "key": "cube-jute-basket",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Jute
+      - Vormontiert
+      - 1 Fuß x 1 Fuß x 1 Fuß",
+                "en-GB": "- Jute
+      - Preassembled
+      - 1ft x 1ft x 1ft",
+                "en-US": "- Jute
+      - Preassembled
+      - 1ft x 1ft x 1ft",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#D2B48C",
+                "label": {
+                  "de-DE": "Bräunen",
+                  "en-GB": "Tan",
+                  "en-US": "Tan",
+                },
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "de-DE": "#EEB348",
+                "en-GB": "#EEB348",
+                "en-US": "#EEB348",
+              },
+            },
+            {
+              "name": "colorlabel",
+              "value": {
+                "de-DE": "Jute",
+                "en-GB": "Jute",
+                "en-US": "Jute",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 3564,
+                "w": 4684,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_355946576-nRxA5NAP.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1299,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1299,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1299,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "CJB-01",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Würfel Jutekorb",
+          "en": undefined,
+          "en-GB": "Cube Jute Basket",
+          "en-US": "Cube Jute Basket",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Jute\n- Preassembled\n- 1ft x 1ft x 1ft","de-DE":"- Jute\n- Vormontiert\n- 1 Fuß x 1 Fuß x 1 Fuß","en-US":"- Jute\n- Preassembled\n- 1ft x 1ft x 1ft"}},{"name":"product-description","value":{"en-GB":"A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.","en-US":"A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.","de-DE":"Ein Würfel-Jutekorb für das Wohnzimmer ist eine praktische und stilvolle Aufbewahrungslösung, die dem Raum Wärme und Struktur verleiht. Der Korb besteht aus natürlichen Jutefasern, die eng miteinander verwoben sind, um eine robuste und langlebige Struktur zu schaffen.  Die Würfelform des Korbs eignet sich perfekt zur Aufbewahrung einer Vielzahl von Gegenständen wie Decken, Zeitschriften, Fernbedienungen oder sogar kleinen Pflanzen. Die offene Oberseite des Korbs ermöglicht einen einfachen Zugriff auf den Inhalt, während die Seiten eine sichere Barriere bieten, um alles ordentlich zu verstauen.  Die neutrale Farbe der Jutefasern ergänzt eine Vielzahl von Einrichtungsstilen, von böhmisch über küstennah bis rustikal. Der Korb kann auf den Boden oder in ein Regal gestellt werden und lässt sich dank seiner kompakten Größe bei Bedarf leicht bewegen."}},{"name":"color-filter","value":{"key":"#D2B48C","label":{"de-DE":"Bräunen","en-GB":"Tan","en-US":"Tan"}}},{"name":"color","value":{"en-GB":"#EEB348","de-DE":"#EEB348","en-US":"#EEB348"}},{"name":"colorlabel","value":{"en-GB":"Jute","de-DE":"Jute","en-US":"Jute"}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "wrfel-jutekorb",
+          "en": undefined,
+          "en-GB": "cube-jute-basket",
+          "en-US": "cube-jute-basket",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cube-jute-basket.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cube-jute-basket.spec.ts
@@ -1,0 +1,64 @@
+import type { TProductDraft } from '../../../types';
+import cubeJuteBasket from './cube-jute-basket';
+describe(`with cubeJuteBasket preset`, () => {
+  it('should return a sample cubeJuteBasket product preset', () => {
+    const cubeJuteBasketPreset = cubeJuteBasket().build<TProductDraft>();
+    expect(cubeJuteBasketPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "home-accents",
+            "typeId": "category",
+          },
+          {
+            "key": "room-decor",
+            "typeId": "category",
+          },
+          {
+            "key": "home-decor",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "cube-jute-basket",
+      "name": {
+            "de-DE": "Würfel Jutekorb",
+            "en-GB": "Cube Jute Basket",
+            "en-US": "Cube Jute Basket"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "wrfel-jutekorb",
+            "en-GB": "cube-jute-basket",
+            "en-US": "cube-jute-basket"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Jute\n- Preassembled\n- 1ft x 1ft x 1ft","de-DE":"- Jute\n- Vormontiert\n- 1 Fuß x 1 Fuß x 1 Fuß","en-US":"- Jute\n- Preassembled\n- 1ft x 1ft x 1ft"}},{"name":"product-description","value":{"en-GB":"A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.","en-US":"A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.","de-DE":"Ein Würfel-Jutekorb für das Wohnzimmer ist eine praktische und stilvolle Aufbewahrungslösung, die dem Raum Wärme und Struktur verleiht. Der Korb besteht aus natürlichen Jutefasern, die eng miteinander verwoben sind, um eine robuste und langlebige Struktur zu schaffen.  Die Würfelform des Korbs eignet sich perfekt zur Aufbewahrung einer Vielzahl von Gegenständen wie Decken, Zeitschriften, Fernbedienungen oder sogar kleinen Pflanzen. Die offene Oberseite des Korbs ermöglicht einen einfachen Zugriff auf den Inhalt, während die Seiten eine sichere Barriere bieten, um alles ordentlich zu verstauen.  Die neutrale Farbe der Jutefasern ergänzt eine Vielzahl von Einrichtungsstilen, von böhmisch über küstennah bis rustikal. Der Korb kann auf den Boden oder in ein Regal gestellt werden und lässt sich dank seiner kompakten Größe bei Bedarf leicht bewegen."}},{"name":"color-filter","value":{"key":"#D2B48C","label":{"de-DE":"Bräunen","en-GB":"Tan","en-US":"Tan"}}},{"name":"color","value":{"en-GB":"#EEB348","de-DE":"#EEB348","en-US":"#EEB348"}},{"name":"colorlabel","value":{"en-GB":"Jute","de-DE":"Jute","en-US":"Jute"}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cube-jute-basket.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cube-jute-basket.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const cubeJuteBasketProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const homeAccentsDraft = CategoryDraft.presets.sampleDataGoodstore
+const homeAccentsDraft = CategoryDraft.presets.sampleDataGoodStore
   .homeAccents()
   .build<TCategoryDraft>();
 
-const roomDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+const roomDecorDraft = CategoryDraft.presets.sampleDataGoodStore
   .roomDecor()
   .build<TCategoryDraft>();
 
-const homeDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+const homeDecorDraft = CategoryDraft.presets.sampleDataGoodStore
   .homeDecor()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const cubeJuteBasket = (): TProductDraftBuilder =>
         ['en-GB']('Cube Jute Basket')
         ['de-DE']('Würfel Jutekorb')
         ['en-US']('Cube Jute Basket')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.'
+        )
+        ['de-DE'](
+          'Ein Würfel-Jutekorb für das Wohnzimmer ist eine praktische und stilvolle Aufbewahrungslösung, die dem Raum Wärme und Struktur verleiht. Der Korb besteht aus natürlichen Jutefasern, die eng miteinander verwoben sind, um eine robuste und langlebige Struktur zu schaffen.  Die Würfelform des Korbs eignet sich perfekt zur Aufbewahrung einer Vielzahl von Gegenständen wie Decken, Zeitschriften, Fernbedienungen oder sogar kleinen Pflanzen. Die offene Oberseite des Korbs ermöglicht einen einfachen Zugriff auf den Inhalt, während die Seiten eine sichere Barriere bieten, um alles ordentlich zu verstauen.  Die neutrale Farbe der Jutefasern ergänzt eine Vielzahl von Einrichtungsstilen, von böhmisch über küstennah bis rustikal. Der Korb kann auf den Boden oder in ein Regal gestellt werden und lässt sich dank seiner kompakten Größe bei Bedarf leicht bewegen.'
+        )
+        ['en-US'](
+          'A cube jute basket for the living room is a practical and stylish storage solution that adds warmth and texture to the space. The basket is made from natural jute fibers, which are tightly woven together to create a sturdy and durable structure.  The cube shape of the basket is perfect for storing a variety of items, such as blankets, magazines, remote controls, or even small plants. The open top of the basket allows for easy access to its contents, while the sides provide a secure barrier to keep everything neatly contained.  The neutral color of the jute fibers complements a variety of decor styles, from bohemian to coastal to rustic. The basket can be placed on the floor or on a shelf, and its compact size makes it easy to move around as needed.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const cubeJuteBasket = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.cubeJuteBasket01()
+      ProductVariantDraft.presets.sampleDataGoodStore.cubeJuteBasket01()
     )
     .categories([
       KeyReference.presets.category().key(homeAccentsDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cube-jute-basket.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cube-jute-basket.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const cubeJuteBasketProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const homeAccentsDraft = CategoryDraft.presets.sampleDataGoodstore
+  .homeAccents()
+  .build<TCategoryDraft>();
+
+const roomDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+  .roomDecor()
+  .build<TCategoryDraft>();
+
+const homeDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+  .homeDecor()
+  .build<TCategoryDraft>();
+
+const cubeJuteBasket = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('cube-jute-basket')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Cube Jute Basket')
+        ['de-DE']('Würfel Jutekorb')
+        ['en-US']('Cube Jute Basket')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('cube-jute-basket')
+        ['de-DE']('wrfel-jutekorb')
+        ['en-US']('cube-jute-basket')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(cubeJuteBasketProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.cubeJuteBasket01()
+    )
+    .categories([
+      KeyReference.presets.category().key(homeAccentsDraft.key!),
+      KeyReference.presets.category().key(roomDecorDraft.key!),
+      KeyReference.presets.category().key(homeDecorDraft.key!),
+    ]);
+
+export default cubeJuteBasket;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/double-sided-shot-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/double-sided-shot-glass.spec.ts
@@ -18,47 +18,125 @@ describe(`with doubleSidedShotGlass preset`, () => {
           {
             "key": "kitchen",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "double-sided-shot-glass",
-      "name": {
-            "de-DE": "Doppelseitiges Schnapsglas",
-            "en-GB": "Double-sided Shot Glass",
-            "en-US": "Double-sided Shot Glass"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "doppelseitiges-schnapsglas",
-            "en-GB": "double-sided-shot-glass",
-            "en-US": "double-sided-shot-glass"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Dieses Stahlschnapsglas besteht aus Stahl und hat zwei Enden, eines zum Messen eines Standardschnapses und das andere zum Messen eines größeren Doppelschnapses. Die Enden sind wie kleine Tassen mit abgerundeten Kanten zum einfachen Ausgießen geformt. Die Stahlkonstruktion macht es langlebig und verschleißfest und bietet gleichzeitig ein elegantes und modernes Erscheinungsbild.",
+          "en": undefined,
+          "en-GB": "This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.",
+          "en-US": "This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.",
+          "fr": undefined,
         },
-        {
+        "key": "double-sided-shot-glass",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Edelstahl
+      - Spülmaschinenfest",
+                "en-GB": "- Stainless steel
+      - Dishwasher safe",
+                "en-US": "- Stainless steel
+      - Dishwasher safe",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 5472,
+                "w": 3648,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_95721248-5HSKgKgr.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 299,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 299,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 299,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "SHOT-095",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Doppelseitiges Schnapsglas",
+          "en": undefined,
+          "en-GB": "Double-sided Shot Glass",
+          "en-US": "Double-sided Shot Glass",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Stainless steel\n- Dishwasher safe","de-DE":"- Edelstahl\n- Spülmaschinenfest","en-US":"- Stainless steel\n- Dishwasher safe"}},{"name":"product-description","value":{"en-GB":"This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.","en-US":"This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.","de-DE":"Dieses Stahlschnapsglas besteht aus Stahl und hat zwei Enden, eines zum Messen eines Standardschnapses und das andere zum Messen eines größeren Doppelschnapses. Die Enden sind wie kleine Tassen mit abgerundeten Kanten zum einfachen Ausgießen geformt. Die Stahlkonstruktion macht es langlebig und verschleißfest und bietet gleichzeitig ein elegantes und modernes Erscheinungsbild."}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "doppelseitiges-schnapsglas",
+          "en": undefined,
+          "en-GB": "double-sided-shot-glass",
+          "en-US": "double-sided-shot-glass",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/double-sided-shot-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/double-sided-shot-glass.spec.ts
@@ -1,0 +1,65 @@
+import type { TProductDraft } from '../../../types';
+import doubleSidedShotGlass from './double-sided-shot-glass';
+describe(`with doubleSidedShotGlass preset`, () => {
+  it('should return a sample doubleSidedShotGlass product preset', () => {
+    const doubleSidedShotGlassPreset =
+      doubleSidedShotGlass().build<TProductDraft>();
+    expect(doubleSidedShotGlassPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "bar-accessories",
+            "typeId": "category",
+          },
+          {
+            "key": "bar-and-glassware",
+            "typeId": "category",
+          },
+          {
+            "key": "kitchen",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "double-sided-shot-glass",
+      "name": {
+            "de-DE": "Doppelseitiges Schnapsglas",
+            "en-GB": "Double-sided Shot Glass",
+            "en-US": "Double-sided Shot Glass"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "doppelseitiges-schnapsglas",
+            "en-GB": "double-sided-shot-glass",
+            "en-US": "double-sided-shot-glass"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Stainless steel\n- Dishwasher safe","de-DE":"- Edelstahl\n- Spülmaschinenfest","en-US":"- Stainless steel\n- Dishwasher safe"}},{"name":"product-description","value":{"en-GB":"This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.","en-US":"This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.","de-DE":"Dieses Stahlschnapsglas besteht aus Stahl und hat zwei Enden, eines zum Messen eines Standardschnapses und das andere zum Messen eines größeren Doppelschnapses. Die Enden sind wie kleine Tassen mit abgerundeten Kanten zum einfachen Ausgießen geformt. Die Stahlkonstruktion macht es langlebig und verschleißfest und bietet gleichzeitig ein elegantes und modernes Erscheinungsbild."}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/double-sided-shot-glass.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/double-sided-shot-glass.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const doubleSidedShotGlassProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAccessories()
   .build<TCategoryDraft>();
 
-const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAndGlassware()
   .build<TCategoryDraft>();
 
-const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore
   .kitchen()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const doubleSidedShotGlass = (): TProductDraftBuilder =>
         ['en-GB']('Double-sided Shot Glass')
         ['de-DE']('Doppelseitiges Schnapsglas')
         ['en-US']('Double-sided Shot Glass')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.'
+        )
+        ['de-DE'](
+          'Dieses Stahlschnapsglas besteht aus Stahl und hat zwei Enden, eines zum Messen eines Standardschnapses und das andere zum Messen eines größeren Doppelschnapses. Die Enden sind wie kleine Tassen mit abgerundeten Kanten zum einfachen Ausgießen geformt. Die Stahlkonstruktion macht es langlebig und verschleißfest und bietet gleichzeitig ein elegantes und modernes Erscheinungsbild.'
+        )
+        ['en-US'](
+          'This steel shot glass is made of steel and has two ends, one for measuring a standard shot, and the other for measuring a larger double shot. The ends are shaped like small cups with rounded edges for easy pouring. The steel construction makes it durable and resistant to wear and tear, while also providing a sleek and modern appearance.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const doubleSidedShotGlass = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.doubleSidedShotGlass01()
+      ProductVariantDraft.presets.sampleDataGoodStore.doubleSidedShotGlass01()
     )
     .categories([
       KeyReference.presets.category().key(barAccessoriesDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/double-sided-shot-glass.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/double-sided-shot-glass.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const doubleSidedShotGlassProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const barAccessoriesDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAccessories()
+  .build<TCategoryDraft>();
+
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAndGlassware()
+  .build<TCategoryDraft>();
+
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+  .kitchen()
+  .build<TCategoryDraft>();
+
+const doubleSidedShotGlass = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('double-sided-shot-glass')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Double-sided Shot Glass')
+        ['de-DE']('Doppelseitiges Schnapsglas')
+        ['en-US']('Double-sided Shot Glass')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('double-sided-shot-glass')
+        ['de-DE']('doppelseitiges-schnapsglas')
+        ['en-US']('double-sided-shot-glass')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(doubleSidedShotGlassProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.doubleSidedShotGlass01()
+    )
+    .categories([
+      KeyReference.presets.category().key(barAccessoriesDraft.key!),
+      KeyReference.presets.category().key(barAndGlasswareDraft.key!),
+      KeyReference.presets.category().key(kitchenDraft.key!),
+    ]);
+
+export default doubleSidedShotGlass;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/double-walled-espresso-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/double-walled-espresso-glass.spec.ts
@@ -18,47 +18,130 @@ describe(`with doubleWalledEspressoGlass preset`, () => {
           {
             "key": "kitchen",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "double-walled-espresso-glass",
-      "name": {
-            "de-DE": "Doppelwandiges Espressoglas",
-            "en-GB": "Double-walled Espresso Glass",
-            "en-US": "Double-walled Espresso Glass"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "doppelwandiges-espressoglas",
-            "en-GB": "double-walled-espresso-glass",
-            "en-US": "double-walled-espresso-glass"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Eine doppelwandige Espressotasse aus Glas ist eine Art Trinkgefäß, das speziell zum Servieren von Espresso entwickelt wurde. Sie besteht aus Glas und ist doppelwandig aufgebaut, was bedeutet, dass es zwei Glasschichten gibt, die durch einen kleinen Spalt getrennt sind.  Das doppelwandige Design der Espressotasse aus Glas bietet mehrere Vorteile. Erstens hilft es, den Espresso zu isolieren, wodurch er länger heiß bleibt. Zweitens sorgt die doppelwandige Konstruktion dafür, dass sich die Außenseite der Tasse kühl anfühlt, wodurch sie auch bei sehr heißem Espresso angenehm in der Hand liegt.  Die Tasse ist normalerweise klein und hat ein Fassungsvermögen von etwa 2-3 Unzen, was die perfekte Größe für einen Schuss Espresso ist. Das Glas ist außerdem transparent, sodass Sie die satte, dunkle Farbe des Espressos sehen können, wenn er eingeschenkt und getrunken wird.  Die doppelwandige Espressotasse aus Glas wird oft mit einer passenden Untertasse kombiniert, die der Tasse einen stabilen Stand bietet und auch Platz für einen kleinen Löffel oder Keks bietet. Insgesamt ist die doppelwandige Espressotasse aus Glas eine stilvolle und funktionale Möglichkeit, die reichen und komplexen Aromen eines Espressos zu genießen.",
+          "en": undefined,
+          "en-GB": "A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso.",
+          "en-US": "A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso.",
+          "fr": undefined,
         },
-        {
+        "key": "double-walled-espresso-glass",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Das Set enthält 4 Gläser",
+                "en-GB": "- Set includes 4 glasses",
+                "en-US": "- Set includes 4 glasses",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 3098,
+                "w": 3371,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_571236838-yanGZ5gf.jpeg",
+            },
+            {
+              "dimensions": {
+                "h": 1481,
+                "w": 987,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/photo-1585975761152--ZGxY2KXD.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 4299,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 4299,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 4299,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "DWEG-09",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Doppelwandiges Espressoglas",
+          "en": undefined,
+          "en-GB": "Double-walled Espresso Glass",
+          "en-US": "Double-walled Espresso Glass",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"product-description","value":{"de-DE":"Eine doppelwandige Espressotasse aus Glas ist eine Art Trinkgefäß, das speziell zum Servieren von Espresso entwickelt wurde. Sie besteht aus Glas und ist doppelwandig aufgebaut, was bedeutet, dass es zwei Glasschichten gibt, die durch einen kleinen Spalt getrennt sind.  Das doppelwandige Design der Espressotasse aus Glas bietet mehrere Vorteile. Erstens hilft es, den Espresso zu isolieren, wodurch er länger heiß bleibt. Zweitens sorgt die doppelwandige Konstruktion dafür, dass sich die Außenseite der Tasse kühl anfühlt, wodurch sie auch bei sehr heißem Espresso angenehm in der Hand liegt.  Die Tasse ist normalerweise klein und hat ein Fassungsvermögen von etwa 2-3 Unzen, was die perfekte Größe für einen Schuss Espresso ist. Das Glas ist außerdem transparent, sodass Sie die satte, dunkle Farbe des Espressos sehen können, wenn er eingeschenkt und getrunken wird.  Die doppelwandige Espressotasse aus Glas wird oft mit einer passenden Untertasse kombiniert, die der Tasse einen stabilen Stand bietet und auch Platz für einen kleinen Löffel oder Keks bietet. Insgesamt ist die doppelwandige Espressotasse aus Glas eine stilvolle und funktionale Möglichkeit, die reichen und komplexen Aromen eines Espressos zu genießen.","en-GB":"A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso.","en-US":"A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso."}},{"name":"productspec","value":{"en-GB":"- Set includes 4 glasses","de-DE":"- Das Set enthält 4 Gläser","en-US":"- Set includes 4 glasses"}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "doppelwandiges-espressoglas",
+          "en": undefined,
+          "en-GB": "double-walled-espresso-glass",
+          "en-US": "double-walled-espresso-glass",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/double-walled-espresso-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/double-walled-espresso-glass.spec.ts
@@ -1,0 +1,65 @@
+import type { TProductDraft } from '../../../types';
+import doubleWalledEspressoGlass from './double-walled-espresso-glass';
+describe(`with doubleWalledEspressoGlass preset`, () => {
+  it('should return a sample doubleWalledEspressoGlass product preset', () => {
+    const doubleWalledEspressoGlassPreset =
+      doubleWalledEspressoGlass().build<TProductDraft>();
+    expect(doubleWalledEspressoGlassPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "glassware",
+            "typeId": "category",
+          },
+          {
+            "key": "bar-and-glassware",
+            "typeId": "category",
+          },
+          {
+            "key": "kitchen",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "double-walled-espresso-glass",
+      "name": {
+            "de-DE": "Doppelwandiges Espressoglas",
+            "en-GB": "Double-walled Espresso Glass",
+            "en-US": "Double-walled Espresso Glass"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "doppelwandiges-espressoglas",
+            "en-GB": "double-walled-espresso-glass",
+            "en-US": "double-walled-espresso-glass"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"product-description","value":{"de-DE":"Eine doppelwandige Espressotasse aus Glas ist eine Art Trinkgefäß, das speziell zum Servieren von Espresso entwickelt wurde. Sie besteht aus Glas und ist doppelwandig aufgebaut, was bedeutet, dass es zwei Glasschichten gibt, die durch einen kleinen Spalt getrennt sind.  Das doppelwandige Design der Espressotasse aus Glas bietet mehrere Vorteile. Erstens hilft es, den Espresso zu isolieren, wodurch er länger heiß bleibt. Zweitens sorgt die doppelwandige Konstruktion dafür, dass sich die Außenseite der Tasse kühl anfühlt, wodurch sie auch bei sehr heißem Espresso angenehm in der Hand liegt.  Die Tasse ist normalerweise klein und hat ein Fassungsvermögen von etwa 2-3 Unzen, was die perfekte Größe für einen Schuss Espresso ist. Das Glas ist außerdem transparent, sodass Sie die satte, dunkle Farbe des Espressos sehen können, wenn er eingeschenkt und getrunken wird.  Die doppelwandige Espressotasse aus Glas wird oft mit einer passenden Untertasse kombiniert, die der Tasse einen stabilen Stand bietet und auch Platz für einen kleinen Löffel oder Keks bietet. Insgesamt ist die doppelwandige Espressotasse aus Glas eine stilvolle und funktionale Möglichkeit, die reichen und komplexen Aromen eines Espressos zu genießen.","en-GB":"A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso.","en-US":"A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso."}},{"name":"productspec","value":{"en-GB":"- Set includes 4 glasses","de-DE":"- Das Set enthält 4 Gläser","en-US":"- Set includes 4 glasses"}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/double-walled-espresso-glass.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/double-walled-espresso-glass.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const doubleWalledEspressoGlassProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const glasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+const glasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .glassware()
   .build<TCategoryDraft>();
 
-const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodStore
   .barAndGlassware()
   .build<TCategoryDraft>();
 
-const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore
   .kitchen()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const doubleWalledEspressoGlass = (): TProductDraftBuilder =>
         ['en-GB']('Double-walled Espresso Glass')
         ['de-DE']('Doppelwandiges Espressoglas')
         ['en-US']('Double-walled Espresso Glass')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso.'
+        )
+        ['de-DE'](
+          'Eine doppelwandige Espressotasse aus Glas ist eine Art Trinkgefäß, das speziell zum Servieren von Espresso entwickelt wurde. Sie besteht aus Glas und ist doppelwandig aufgebaut, was bedeutet, dass es zwei Glasschichten gibt, die durch einen kleinen Spalt getrennt sind.  Das doppelwandige Design der Espressotasse aus Glas bietet mehrere Vorteile. Erstens hilft es, den Espresso zu isolieren, wodurch er länger heiß bleibt. Zweitens sorgt die doppelwandige Konstruktion dafür, dass sich die Außenseite der Tasse kühl anfühlt, wodurch sie auch bei sehr heißem Espresso angenehm in der Hand liegt.  Die Tasse ist normalerweise klein und hat ein Fassungsvermögen von etwa 2-3 Unzen, was die perfekte Größe für einen Schuss Espresso ist. Das Glas ist außerdem transparent, sodass Sie die satte, dunkle Farbe des Espressos sehen können, wenn er eingeschenkt und getrunken wird.  Die doppelwandige Espressotasse aus Glas wird oft mit einer passenden Untertasse kombiniert, die der Tasse einen stabilen Stand bietet und auch Platz für einen kleinen Löffel oder Keks bietet. Insgesamt ist die doppelwandige Espressotasse aus Glas eine stilvolle und funktionale Möglichkeit, die reichen und komplexen Aromen eines Espressos zu genießen.'
+        )
+        ['en-US'](
+          'A double-walled glass espresso cup is a type of drinking vessel that is specifically designed for serving espresso. It is made of glass and features a double-walled construction, which means that there are two layers of glass that are separated by a small gap.  The double-walled design of the glass espresso cup provides several benefits. First, it helps to insulate the espresso, which keeps it hot for longer periods of time. Second, the double-walled construction keeps the outside of the cup cool to the touch, which makes it comfortable to hold even when the espresso inside is very hot.  The cup is typically small in size, with a capacity of around 2-3 ounces, which is the perfect size for a shot of espresso. The glass is also transparent, which allows you to see the rich, dark color of the espresso as it is poured and consumed.  The double-walled glass espresso cup is often paired with a matching saucer, which provides a stable base for the cup and also provides a place to set a small spoon or biscuit. Overall, the double-walled glass espresso cup is a stylish and functional way to enjoy the rich and complex flavors of a shot of espresso.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const doubleWalledEspressoGlass = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.doubleWalledEspressoGlass01()
+      ProductVariantDraft.presets.sampleDataGoodStore.doubleWalledEspressoGlass01()
     )
     .categories([
       KeyReference.presets.category().key(glasswareDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/double-walled-espresso-glass.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/double-walled-espresso-glass.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const doubleWalledEspressoGlassProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const glasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .glassware()
+  .build<TCategoryDraft>();
+
+const barAndGlasswareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .barAndGlassware()
+  .build<TCategoryDraft>();
+
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+  .kitchen()
+  .build<TCategoryDraft>();
+
+const doubleWalledEspressoGlass = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('double-walled-espresso-glass')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Double-walled Espresso Glass')
+        ['de-DE']('Doppelwandiges Espressoglas')
+        ['en-US']('Double-walled Espresso Glass')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('double-walled-espresso-glass')
+        ['de-DE']('doppelwandiges-espressoglas')
+        ['en-US']('double-walled-espresso-glass')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(doubleWalledEspressoGlassProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.doubleWalledEspressoGlass01()
+    )
+    .categories([
+      KeyReference.presets.category().key(glasswareDraft.key!),
+      KeyReference.presets.category().key(barAndGlasswareDraft.key!),
+      KeyReference.presets.category().key(kitchenDraft.key!),
+    ]);
+
+export default doubleWalledEspressoGlass;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ecru-double-bed.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ecru-double-bed.spec.ts
@@ -1,0 +1,64 @@
+import type { TProductDraft } from '../../../types';
+import ecruDoubleBed from './ecru-double-bed';
+describe(`with ecruDoubleBed preset`, () => {
+  it('should return a sample ecruDoubleBed product preset', () => {
+    const ecruDoubleBedPreset = ecruDoubleBed().build<TProductDraft>();
+    expect(ecruDoubleBedPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "bedroom-furniture",
+            "typeId": "category",
+          },
+          {
+            "key": "furniture",
+            "typeId": "category",
+          },
+          {
+            "key": "beds",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "ecru-double-bed",
+      "name": {
+            "de-DE": "Ecru Doppelbett",
+            "en-GB": "Ecru Double Bed",
+            "en-US": "Ecru Double Bed"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "ecru-doppelbett",
+            "en-GB": "ecru-double-bed",
+            "en-US": "ecru-double-bed"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Comes with pillow-top headboard\n- Assembly included","de-DE":"- Mit gepolstertem Kopfteil\n- Montage inklusive","en-US":"- Comes with pillow-top headboard\n- Assembly included"}},{"name":"product-description","value":{"en-GB":"A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.","en-US":"A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.","de-DE":"Ein Doppelbett mit Sofakopfteil ist ein einzigartiges und vielseitiges Möbelstück, das den Komfort eines Bettes mit der Funktionalität eines Sofas verbindet. Der Bettrahmen ist rechteckig und groß genug, um eine Standard-Doppelmatratze aufzunehmen. Das Kopfteil hat die Form eines Sofas, das oben am Bettrahmen befestigt ist. Das Kopfteil des Sofas bietet eine bequeme Rückenlehne zum Sitzen im Bett, um zu lesen, fernzusehen oder an einem Laptop zu arbeiten. Das Kopfteil des Sofas ist mit einem weichen und strapazierfähigen Stoff bezogen und bietet eine bequeme Sitzfläche. Insgesamt ist ein Queensize-Bett mit Sofa-Kopfteil ein praktisches und stilvolles Möbelstück, das jedem Schlafzimmer sowohl Komfort als auch Funktionalität verleiht."}},{"name":"color-filter","value":{"key":"#F5F5DC","label":{"de-DE":"Beige","en-GB":"Beige","en-US":"Beige"}}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ecru-double-bed.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ecru-double-bed.spec.ts
@@ -17,47 +17,136 @@ describe(`with ecruDoubleBed preset`, () => {
           {
             "key": "beds",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "ecru-double-bed",
-      "name": {
-            "de-DE": "Ecru Doppelbett",
-            "en-GB": "Ecru Double Bed",
-            "en-US": "Ecru Double Bed"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "ecru-doppelbett",
-            "en-GB": "ecru-double-bed",
-            "en-US": "ecru-double-bed"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Ein Doppelbett mit Sofakopfteil ist ein einzigartiges und vielseitiges Möbelstück, das den Komfort eines Bettes mit der Funktionalität eines Sofas verbindet. Der Bettrahmen ist rechteckig und groß genug, um eine Standard-Doppelmatratze aufzunehmen. Das Kopfteil hat die Form eines Sofas, das oben am Bettrahmen befestigt ist. Das Kopfteil des Sofas bietet eine bequeme Rückenlehne zum Sitzen im Bett, um zu lesen, fernzusehen oder an einem Laptop zu arbeiten. Das Kopfteil des Sofas ist mit einem weichen und strapazierfähigen Stoff bezogen und bietet eine bequeme Sitzfläche. Insgesamt ist ein Queensize-Bett mit Sofa-Kopfteil ein praktisches und stilvolles Möbelstück, das jedem Schlafzimmer sowohl Komfort als auch Funktionalität verleiht.",
+          "en": undefined,
+          "en-GB": "A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.",
+          "en-US": "A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.",
+          "fr": undefined,
         },
-        {
+        "key": "ecru-double-bed",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Mit gepolstertem Kopfteil
+      - Montage inklusive",
+                "en-GB": "- Comes with pillow-top headboard
+      - Assembly included",
+                "en-US": "- Comes with pillow-top headboard
+      - Assembly included",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#F5F5DC",
+                "label": {
+                  "de-DE": "Beige",
+                  "en-GB": "Beige",
+                  "en-US": "Beige",
+                },
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 2000,
+                "w": 2000,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Ecru%20Twin%20Bed-q6309G4v.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 89900,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 89900,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 89900,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "SQB-034",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Ecru Doppelbett",
+          "en": undefined,
+          "en-GB": "Ecru Double Bed",
+          "en-US": "Ecru Double Bed",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Comes with pillow-top headboard\n- Assembly included","de-DE":"- Mit gepolstertem Kopfteil\n- Montage inklusive","en-US":"- Comes with pillow-top headboard\n- Assembly included"}},{"name":"product-description","value":{"en-GB":"A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.","en-US":"A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.","de-DE":"Ein Doppelbett mit Sofakopfteil ist ein einzigartiges und vielseitiges Möbelstück, das den Komfort eines Bettes mit der Funktionalität eines Sofas verbindet. Der Bettrahmen ist rechteckig und groß genug, um eine Standard-Doppelmatratze aufzunehmen. Das Kopfteil hat die Form eines Sofas, das oben am Bettrahmen befestigt ist. Das Kopfteil des Sofas bietet eine bequeme Rückenlehne zum Sitzen im Bett, um zu lesen, fernzusehen oder an einem Laptop zu arbeiten. Das Kopfteil des Sofas ist mit einem weichen und strapazierfähigen Stoff bezogen und bietet eine bequeme Sitzfläche. Insgesamt ist ein Queensize-Bett mit Sofa-Kopfteil ein praktisches und stilvolles Möbelstück, das jedem Schlafzimmer sowohl Komfort als auch Funktionalität verleiht."}},{"name":"color-filter","value":{"key":"#F5F5DC","label":{"de-DE":"Beige","en-GB":"Beige","en-US":"Beige"}}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "ecru-doppelbett",
+          "en": undefined,
+          "en-GB": "ecru-double-bed",
+          "en-US": "ecru-double-bed",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ecru-double-bed.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ecru-double-bed.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const ecruDoubleBedProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const bedroomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const bedroomFurnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .bedroomFurniture()
   .build<TCategoryDraft>();
 
-const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .furniture()
   .build<TCategoryDraft>();
 
-const bedsDraft = CategoryDraft.presets.sampleDataGoodstore
+const bedsDraft = CategoryDraft.presets.sampleDataGoodStore
   .beds()
   .build<TCategoryDraft>();
 
@@ -50,6 +50,19 @@ const ecruDoubleBed = (): TProductDraftBuilder =>
         ['de-DE']('Ecru Doppelbett')
         ['en-US']('Ecru Double Bed')
     )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.'
+        )
+        ['de-DE'](
+          'Ein Doppelbett mit Sofakopfteil ist ein einzigartiges und vielseitiges Möbelstück, das den Komfort eines Bettes mit der Funktionalität eines Sofas verbindet. Der Bettrahmen ist rechteckig und groß genug, um eine Standard-Doppelmatratze aufzunehmen. Das Kopfteil hat die Form eines Sofas, das oben am Bettrahmen befestigt ist. Das Kopfteil des Sofas bietet eine bequeme Rückenlehne zum Sitzen im Bett, um zu lesen, fernzusehen oder an einem Laptop zu arbeiten. Das Kopfteil des Sofas ist mit einem weichen und strapazierfähigen Stoff bezogen und bietet eine bequeme Sitzfläche. Insgesamt ist ein Queensize-Bett mit Sofa-Kopfteil ein praktisches und stilvolles Möbelstück, das jedem Schlafzimmer sowohl Komfort als auch Funktionalität verleiht.'
+        )
+        ['en-US'](
+          'A double-sized bed with a sofa headboard is a unique and versatile piece of furniture that combines the comfort of a bed with the functionality of a sofa. The bed frame is rectangular and large enough to accommodate a standard double mattress. The headboard is in the form of a sofa, which is attached to the top of the bed frame. The sofa headboard provides a comfortable backrest for sitting up in bed to read, watch TV, or work on a laptop. The sofa headboard is upholstered in a soft and durable fabric, providing a comfortable seating surface. Overall, a queen bed with a sofa headboard is a practical and stylish piece of furniture that can add both comfort and functionality to any bedroom.'
+        )
+    )
     .slug(
       LocalizedString.presets
         .empty()
@@ -62,10 +75,10 @@ const ecruDoubleBed = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.ecruDoubleBed01()
+      ProductVariantDraft.presets.sampleDataGoodStore.ecruDoubleBed01()
     )
     .categories([
       KeyReference.presets.category().key(bedroomFurnitureDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ecru-double-bed.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ecru-double-bed.ts
@@ -1,0 +1,76 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const ecruDoubleBedProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const bedroomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .bedroomFurniture()
+  .build<TCategoryDraft>();
+
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .furniture()
+  .build<TCategoryDraft>();
+
+const bedsDraft = CategoryDraft.presets.sampleDataGoodstore
+  .beds()
+  .build<TCategoryDraft>();
+
+const ecruDoubleBed = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('ecru-double-bed')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Ecru Double Bed')
+        ['de-DE']('Ecru Doppelbett')
+        ['en-US']('Ecru Double Bed')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('ecru-double-bed')
+        ['de-DE']('ecru-doppelbett')
+        ['en-US']('ecru-double-bed')
+    )
+    .productType(
+      KeyReference.presets.productType().key(ecruDoubleBedProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.ecruDoubleBed01()
+    )
+    .categories([
+      KeyReference.presets.category().key(bedroomFurnitureDraft.key!),
+      KeyReference.presets.category().key(furnitureDraft.key!),
+      KeyReference.presets.category().key(bedsDraft.key!),
+    ]);
+
+export default ecruDoubleBed;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/edgar-armchair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/edgar-armchair.spec.ts
@@ -21,47 +21,165 @@ describe(`with edgarArmchair preset`, () => {
           {
             "key": "living-room-furniture",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "edgar-armchair",
-      "name": {
-            "de-DE": "Edgar Sessel",
-            "en-GB": "Edgar Armchair",
-            "en-US": "Edgar Armchair"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "edgar-sessel",
-            "en-GB": "edgar-armchair",
-            "en-US": "edgar-armchair"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Ein Sessel im abstrakten modernen Stil mit Metallbeinen ist ein einzigartiges Möbelstück, das jedem Raum einen Hauch von Raffinesse verleiht. Der Stuhl ist mit klaren Linien und einem schlanken Profil gestaltet und verfügt über einen niedrigen, breiten Sitz und eine hohe Rückenlehne, die sich sanft um die Seiten des Stuhls krümmt. Der Sitz und die Rückenlehne sind mit einem strukturierten, strapazierfähigen Stoff bezogen, der dem klassischen Sesseldesign eine zeitgemäße Note verleiht. Die Metallbeine sind dünn und konisch zulaufend und bilden eine filigrane und dennoch stabile Basis für den Stuhl. Insgesamt ist dieser Sessel eine perfekte Mischung aus Stil und Komfort, was ihn zu einer großartigen Ergänzung für jeden modernen Wohnraum macht.",
+          "en": undefined,
+          "en-GB": "An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.",
+          "en-US": "An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.",
+          "fr": undefined,
         },
-        {
+        "key": "edgar-armchair",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Montage bei Lieferung",
+                "en-GB": "- Assembly on delivery",
+                "en-US": "- Assembly on delivery",
+              },
+            },
+            {
+              "name": "colorlabel",
+              "value": {
+                "de-DE": "Leichter Salbei",
+                "en-GB": "Light Sage",
+                "en-US": "Light Sage",
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "de-DE": "#B6C9B6",
+                "en-GB": "#B6C9B6",
+                "en-US": "#B6C9B6",
+              },
+            },
+            {
+              "name": "finishlabel",
+              "value": {
+                "de-DE": "Eisen",
+                "en-GB": "Iron",
+                "en-US": "Iron",
+              },
+            },
+            {
+              "name": "finish",
+              "value": {
+                "de-DE": "#000",
+                "en-GB": "#000",
+                "en-US": "#000",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#00FF00",
+                "label": {
+                  "de-DE": "Grün",
+                  "en-GB": "Green",
+                  "en-US": "Green",
+                },
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 4000,
+                "w": 5000,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_438943116-tYXWisJi.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 129900,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 129900,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 129900,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "EARM-04",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Edgar Sessel",
+          "en": undefined,
+          "en-GB": "Edgar Armchair",
+          "en-US": "Edgar Armchair",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Assembly on delivery","de-DE":"- Montage bei Lieferung","en-US":"- Assembly on delivery"}},{"name":"product-description","value":{"en-GB":"An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.","en-US":"An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.","de-DE":"Ein Sessel im abstrakten modernen Stil mit Metallbeinen ist ein einzigartiges Möbelstück, das jedem Raum einen Hauch von Raffinesse verleiht. Der Stuhl ist mit klaren Linien und einem schlanken Profil gestaltet und verfügt über einen niedrigen, breiten Sitz und eine hohe Rückenlehne, die sich sanft um die Seiten des Stuhls krümmt. Der Sitz und die Rückenlehne sind mit einem strukturierten, strapazierfähigen Stoff bezogen, der dem klassischen Sesseldesign eine zeitgemäße Note verleiht. Die Metallbeine sind dünn und konisch zulaufend und bilden eine filigrane und dennoch stabile Basis für den Stuhl. Insgesamt ist dieser Sessel eine perfekte Mischung aus Stil und Komfort, was ihn zu einer großartigen Ergänzung für jeden modernen Wohnraum macht."}},{"name":"colorlabel","value":{"en-GB":"Light Sage","de-DE":"Leichter Salbei","en-US":"Light Sage"}},{"name":"color","value":{"en-GB":"#B6C9B6","de-DE":"#B6C9B6","en-US":"#B6C9B6"}},{"name":"finishlabel","value":{"en-GB":"Iron","de-DE":"Eisen","en-US":"Iron"}},{"name":"finish","value":{"en-GB":"#000","de-DE":"#000","en-US":"#000"}},{"name":"color-filter","value":{"key":"#00FF00","label":{"de-DE":"Grün","en-GB":"Green","en-US":"Green"}}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "edgar-sessel",
+          "en": undefined,
+          "en-GB": "edgar-armchair",
+          "en-US": "edgar-armchair",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/edgar-armchair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/edgar-armchair.spec.ts
@@ -1,0 +1,68 @@
+import type { TProductDraft } from '../../../types';
+import edgarArmchair from './edgar-armchair';
+describe(`with edgarArmchair preset`, () => {
+  it('should return a sample edgarArmchair product preset', () => {
+    const edgarArmchairPreset = edgarArmchair().build<TProductDraft>();
+    expect(edgarArmchairPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "new-arrivals",
+            "typeId": "category",
+          },
+          {
+            "key": "furniture",
+            "typeId": "category",
+          },
+          {
+            "key": "armchairs",
+            "typeId": "category",
+          },
+          {
+            "key": "living-room-furniture",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "edgar-armchair",
+      "name": {
+            "de-DE": "Edgar Sessel",
+            "en-GB": "Edgar Armchair",
+            "en-US": "Edgar Armchair"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "edgar-sessel",
+            "en-GB": "edgar-armchair",
+            "en-US": "edgar-armchair"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Assembly on delivery","de-DE":"- Montage bei Lieferung","en-US":"- Assembly on delivery"}},{"name":"product-description","value":{"en-GB":"An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.","en-US":"An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.","de-DE":"Ein Sessel im abstrakten modernen Stil mit Metallbeinen ist ein einzigartiges Möbelstück, das jedem Raum einen Hauch von Raffinesse verleiht. Der Stuhl ist mit klaren Linien und einem schlanken Profil gestaltet und verfügt über einen niedrigen, breiten Sitz und eine hohe Rückenlehne, die sich sanft um die Seiten des Stuhls krümmt. Der Sitz und die Rückenlehne sind mit einem strukturierten, strapazierfähigen Stoff bezogen, der dem klassischen Sesseldesign eine zeitgemäße Note verleiht. Die Metallbeine sind dünn und konisch zulaufend und bilden eine filigrane und dennoch stabile Basis für den Stuhl. Insgesamt ist dieser Sessel eine perfekte Mischung aus Stil und Komfort, was ihn zu einer großartigen Ergänzung für jeden modernen Wohnraum macht."}},{"name":"colorlabel","value":{"en-GB":"Light Sage","de-DE":"Leichter Salbei","en-US":"Light Sage"}},{"name":"color","value":{"en-GB":"#B6C9B6","de-DE":"#B6C9B6","en-US":"#B6C9B6"}},{"name":"finishlabel","value":{"en-GB":"Iron","de-DE":"Eisen","en-US":"Iron"}},{"name":"finish","value":{"en-GB":"#000","de-DE":"#000","en-US":"#000"}},{"name":"color-filter","value":{"key":"#00FF00","label":{"de-DE":"Grün","en-GB":"Green","en-US":"Green"}}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/edgar-armchair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/edgar-armchair.ts
@@ -1,0 +1,81 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const edgarArmchairProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const newArrivalsDraft = CategoryDraft.presets.sampleDataGoodstore
+  .newArrivals()
+  .build<TCategoryDraft>();
+
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .furniture()
+  .build<TCategoryDraft>();
+
+const armchairsDraft = CategoryDraft.presets.sampleDataGoodstore
+  .armchairs()
+  .build<TCategoryDraft>();
+
+const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .livingRoomFurniture()
+  .build<TCategoryDraft>();
+
+const edgarArmchair = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('edgar-armchair')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Edgar Armchair')
+        ['de-DE']('Edgar Sessel')
+        ['en-US']('Edgar Armchair')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('edgar-armchair')
+        ['de-DE']('edgar-sessel')
+        ['en-US']('edgar-armchair')
+    )
+    .productType(
+      KeyReference.presets.productType().key(edgarArmchairProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.edgarArmchair01()
+    )
+    .categories([
+      KeyReference.presets.category().key(newArrivalsDraft.key!),
+      KeyReference.presets.category().key(furnitureDraft.key!),
+      KeyReference.presets.category().key(armchairsDraft.key!),
+      KeyReference.presets.category().key(livingRoomFurnitureDraft.key!),
+    ]);
+
+export default edgarArmchair;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/edgar-armchair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/edgar-armchair.ts
@@ -10,36 +10,36 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const edgarArmchairProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const newArrivalsDraft = CategoryDraft.presets.sampleDataGoodstore
+const newArrivalsDraft = CategoryDraft.presets.sampleDataGoodStore
   .newArrivals()
   .build<TCategoryDraft>();
 
-const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .furniture()
   .build<TCategoryDraft>();
 
-const armchairsDraft = CategoryDraft.presets.sampleDataGoodstore
+const armchairsDraft = CategoryDraft.presets.sampleDataGoodStore
   .armchairs()
   .build<TCategoryDraft>();
 
-const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .livingRoomFurniture()
   .build<TCategoryDraft>();
 
@@ -54,6 +54,19 @@ const edgarArmchair = (): TProductDraftBuilder =>
         ['de-DE']('Edgar Sessel')
         ['en-US']('Edgar Armchair')
     )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.'
+        )
+        ['de-DE'](
+          'Ein Sessel im abstrakten modernen Stil mit Metallbeinen ist ein einzigartiges Möbelstück, das jedem Raum einen Hauch von Raffinesse verleiht. Der Stuhl ist mit klaren Linien und einem schlanken Profil gestaltet und verfügt über einen niedrigen, breiten Sitz und eine hohe Rückenlehne, die sich sanft um die Seiten des Stuhls krümmt. Der Sitz und die Rückenlehne sind mit einem strukturierten, strapazierfähigen Stoff bezogen, der dem klassischen Sesseldesign eine zeitgemäße Note verleiht. Die Metallbeine sind dünn und konisch zulaufend und bilden eine filigrane und dennoch stabile Basis für den Stuhl. Insgesamt ist dieser Sessel eine perfekte Mischung aus Stil und Komfort, was ihn zu einer großartigen Ergänzung für jeden modernen Wohnraum macht.'
+        )
+        ['en-US'](
+          'An abstract modern style armchair with metal legs is a unique piece of furniture that would add a touch of sophistication to any room. The chair is designed with clean lines and a sleek profile, featuring a low, wide seat and a tall backrest that curves gently around the sides of the chair. The seat and backrest are upholstered in a textured, durable fabric, which adds a contemporary edge to the classic armchair design. The metal legs are thin and tapered, providing a delicate yet sturdy base for the chair. Overall, this armchair is a perfect blend of style and comfort, making it a great addition to any modern living space.'
+        )
+    )
     .slug(
       LocalizedString.presets
         .empty()
@@ -66,10 +79,10 @@ const edgarArmchair = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.edgarArmchair01()
+      ProductVariantDraft.presets.sampleDataGoodStore.edgarArmchair01()
     )
     .categories([
       KeyReference.presets.category().key(newArrivalsDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ella-square-plate.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ella-square-plate.spec.ts
@@ -25,47 +25,157 @@ describe(`with ellaSquarePlate preset`, () => {
           {
             "key": "dinnerware",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "ella-square-plate",
-      "name": {
-            "de-DE": "Ella Quadratische Platte",
-            "en-GB": "Ella Square Plate",
-            "en-US": "Ella Square Plate"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "ella-quadratische-platte",
-            "en-GB": "ella-square-plate",
-            "en-US": "ella-square-plate"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Dieser quadratische Ella-Keramikteller ist eine flache, vierseitige Schale, die sich ideal zum Servieren oder Präsentieren von Speisen eignet. Eine flache quadratische Servierplatte ist ideal zum Servieren einer Vielzahl von Speisen, von Vorspeisen und Hauptgerichten bis hin zu Desserts und Snacks. Es kann sowohl für formelle als auch für ungezwungene Anlässe verwendet werden, und seine Einfachheit und Vielseitigkeit machen es zu einer beliebten Wahl für viele verschiedene Arten von Küchen.  Insgesamt ist ein quadratischer Keramikteller eine funktionale und stilvolle Wahl zum Servieren von Mahlzeiten und kann jedem Speiseerlebnis einen Hauch von Eleganz verleihen.",
+          "en": undefined,
+          "en-GB": "This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience.",
+          "en-US": "This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience.",
+          "fr": undefined,
         },
-        {
+        "key": "ella-square-plate",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Enthält 1 Teller",
+                "en-GB": "- Includes 1 plate",
+                "en-US": "- Includes 1 plate",
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "de-DE": "#FFF",
+                "en-GB": "#FFF",
+                "en-US": "#FFF",
+              },
+            },
+            {
+              "name": "colorlabel",
+              "value": {
+                "de-DE": "Weiß",
+                "en-GB": "White",
+                "en-US": "White",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#FFF",
+                "label": {
+                  "de-DE": "Weiss",
+                  "en-GB": "White",
+                  "en-US": "White",
+                },
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 3412,
+                "w": 5692,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_96107425-uNhRfSVg.jpeg",
+            },
+            {
+              "dimensions": {
+                "h": 4912,
+                "w": 7360,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_297660480-6pQH9vjF.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1599,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1599,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 1599,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "ESP-1",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Ella Quadratische Platte",
+          "en": undefined,
+          "en-GB": "Ella Square Plate",
+          "en-US": "Ella Square Plate",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Includes 1 plate","de-DE":"- Enthält 1 Teller","en-US":"- Includes 1 plate"}},{"name":"product-description","value":{"de-DE":"Dieser quadratische Ella-Keramikteller ist eine flache, vierseitige Schale, die sich ideal zum Servieren oder Präsentieren von Speisen eignet. Eine flache quadratische Servierplatte ist ideal zum Servieren einer Vielzahl von Speisen, von Vorspeisen und Hauptgerichten bis hin zu Desserts und Snacks. Es kann sowohl für formelle als auch für ungezwungene Anlässe verwendet werden, und seine Einfachheit und Vielseitigkeit machen es zu einer beliebten Wahl für viele verschiedene Arten von Küchen.  Insgesamt ist ein quadratischer Keramikteller eine funktionale und stilvolle Wahl zum Servieren von Mahlzeiten und kann jedem Speiseerlebnis einen Hauch von Eleganz verleihen.","en-GB":"This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience.","en-US":"This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience."}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "ella-quadratische-platte",
+          "en": undefined,
+          "en-GB": "ella-square-plate",
+          "en-US": "ella-square-plate",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ella-square-plate.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ella-square-plate.spec.ts
@@ -1,0 +1,72 @@
+import type { TProductDraft } from '../../../types';
+import ellaSquarePlate from './ella-square-plate';
+describe(`with ellaSquarePlate preset`, () => {
+  it('should return a sample ellaSquarePlate product preset', () => {
+    const ellaSquarePlatePreset = ellaSquarePlate().build<TProductDraft>();
+    expect(ellaSquarePlatePreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "plates",
+            "typeId": "category",
+          },
+          {
+            "key": "kitchen",
+            "typeId": "category",
+          },
+          {
+            "key": "serving-platters",
+            "typeId": "category",
+          },
+          {
+            "key": "serveware",
+            "typeId": "category",
+          },
+          {
+            "key": "dinnerware",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "ella-square-plate",
+      "name": {
+            "de-DE": "Ella Quadratische Platte",
+            "en-GB": "Ella Square Plate",
+            "en-US": "Ella Square Plate"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "ella-quadratische-platte",
+            "en-GB": "ella-square-plate",
+            "en-US": "ella-square-plate"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Includes 1 plate","de-DE":"- Enthält 1 Teller","en-US":"- Includes 1 plate"}},{"name":"product-description","value":{"de-DE":"Dieser quadratische Ella-Keramikteller ist eine flache, vierseitige Schale, die sich ideal zum Servieren oder Präsentieren von Speisen eignet. Eine flache quadratische Servierplatte ist ideal zum Servieren einer Vielzahl von Speisen, von Vorspeisen und Hauptgerichten bis hin zu Desserts und Snacks. Es kann sowohl für formelle als auch für ungezwungene Anlässe verwendet werden, und seine Einfachheit und Vielseitigkeit machen es zu einer beliebten Wahl für viele verschiedene Arten von Küchen.  Insgesamt ist ein quadratischer Keramikteller eine funktionale und stilvolle Wahl zum Servieren von Mahlzeiten und kann jedem Speiseerlebnis einen Hauch von Eleganz verleihen.","en-GB":"This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience.","en-US":"This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience."}},{"name":"color","value":{"en-GB":"#FFF","de-DE":"#FFF","en-US":"#FFF"}},{"name":"colorlabel","value":{"en-GB":"White","de-DE":"Weiß","en-US":"White"}},{"name":"color-filter","value":{"key":"#FFF","label":{"de-DE":"Weiss","en-GB":"White","en-US":"White"}}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ella-square-plate.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ella-square-plate.ts
@@ -10,40 +10,40 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const ellaSquarePlateProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const platesDraft = CategoryDraft.presets.sampleDataGoodstore
+const platesDraft = CategoryDraft.presets.sampleDataGoodStore
   .plates()
   .build<TCategoryDraft>();
 
-const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodStore
   .kitchen()
   .build<TCategoryDraft>();
 
-const servingPlattersDraft = CategoryDraft.presets.sampleDataGoodstore
+const servingPlattersDraft = CategoryDraft.presets.sampleDataGoodStore
   .servingPlatters()
   .build<TCategoryDraft>();
 
-const servewareDraft = CategoryDraft.presets.sampleDataGoodstore
+const servewareDraft = CategoryDraft.presets.sampleDataGoodStore
   .serveware()
   .build<TCategoryDraft>();
 
-const dinnerwareDraft = CategoryDraft.presets.sampleDataGoodstore
+const dinnerwareDraft = CategoryDraft.presets.sampleDataGoodStore
   .dinnerware()
   .build<TCategoryDraft>();
 
@@ -57,6 +57,19 @@ const ellaSquarePlate = (): TProductDraftBuilder =>
         ['en-GB']('Ella Square Plate')
         ['de-DE']('Ella Quadratische Platte')
         ['en-US']('Ella Square Plate')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience.'
+        )
+        ['de-DE'](
+          'Dieser quadratische Ella-Keramikteller ist eine flache, vierseitige Schale, die sich ideal zum Servieren oder Präsentieren von Speisen eignet. Eine flache quadratische Servierplatte ist ideal zum Servieren einer Vielzahl von Speisen, von Vorspeisen und Hauptgerichten bis hin zu Desserts und Snacks. Es kann sowohl für formelle als auch für ungezwungene Anlässe verwendet werden, und seine Einfachheit und Vielseitigkeit machen es zu einer beliebten Wahl für viele verschiedene Arten von Küchen.  Insgesamt ist ein quadratischer Keramikteller eine funktionale und stilvolle Wahl zum Servieren von Mahlzeiten und kann jedem Speiseerlebnis einen Hauch von Eleganz verleihen.'
+        )
+        ['en-US'](
+          'This Ella square ceramic plate is a flat, four-sided dish ideal for serving or displaying food. A flat square serving plate is ideal for serving a variety of foods, from appetizers and main courses to desserts and snacks. It can be used for both formal and casual occasions, and its simplicity and versatility make it a popular choice for many different types of cuisines.  Overall, a square ceramic plate is a functional and stylish choice for serving meals and can add a touch of elegance to any dining experience.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -72,10 +85,10 @@ const ellaSquarePlate = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.ellaSquarePlate01()
+      ProductVariantDraft.presets.sampleDataGoodStore.ellaSquarePlate01()
     )
     .categories([
       KeyReference.presets.category().key(platesDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ella-square-plate.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ella-square-plate.ts
@@ -1,0 +1,88 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const ellaSquarePlateProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const platesDraft = CategoryDraft.presets.sampleDataGoodstore
+  .plates()
+  .build<TCategoryDraft>();
+
+const kitchenDraft = CategoryDraft.presets.sampleDataGoodstore
+  .kitchen()
+  .build<TCategoryDraft>();
+
+const servingPlattersDraft = CategoryDraft.presets.sampleDataGoodstore
+  .servingPlatters()
+  .build<TCategoryDraft>();
+
+const servewareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .serveware()
+  .build<TCategoryDraft>();
+
+const dinnerwareDraft = CategoryDraft.presets.sampleDataGoodstore
+  .dinnerware()
+  .build<TCategoryDraft>();
+
+const ellaSquarePlate = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('ella-square-plate')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Ella Square Plate')
+        ['de-DE']('Ella Quadratische Platte')
+        ['en-US']('Ella Square Plate')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('ella-square-plate')
+        ['de-DE']('ella-quadratische-platte')
+        ['en-US']('ella-square-plate')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(ellaSquarePlateProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.ellaSquarePlate01()
+    )
+    .categories([
+      KeyReference.presets.category().key(platesDraft.key!),
+      KeyReference.presets.category().key(kitchenDraft.key!),
+      KeyReference.presets.category().key(servingPlattersDraft.key!),
+      KeyReference.presets.category().key(servewareDraft.key!),
+      KeyReference.presets.category().key(dinnerwareDraft.key!),
+    ]);
+
+export default ellaSquarePlate;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/emerald-velvet-chair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/emerald-velvet-chair.spec.ts
@@ -1,0 +1,65 @@
+import type { TProductDraft } from '../../../types';
+import emeraldVelvetChair from './emerald-velvet-chair';
+describe(`with emeraldVelvetChair preset`, () => {
+  it('should return a sample emeraldVelvetChair product preset', () => {
+    const emeraldVelvetChairPreset =
+      emeraldVelvetChair().build<TProductDraft>();
+    expect(emeraldVelvetChairPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "furniture",
+            "typeId": "category",
+          },
+          {
+            "key": "armchairs",
+            "typeId": "category",
+          },
+          {
+            "key": "living-room-furniture",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "emerald-velvet-chair",
+      "name": {
+            "de-DE": "Smaragdgrüner Samtstuhl",
+            "en-GB": "Emerald Velvet Chair",
+            "en-US": "Emerald Velvet Chair"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "smaragdgrner-samtstuhl",
+            "en-GB": "emerald-velvet-chair",
+            "en-US": "emerald-velvet-chair"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Dry clean only","de-DE":"- Nur chemische Reinigung","en-US":"- Dry clean only"}},{"name":"product-description","value":{"en-GB":"A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.","en-US":"A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.","de-DE":"Ein Samtstuhl mit Messinggestell ist ein elegantes und luxuriöses Möbelstück. Das weiche, plüschige Samtmaterial des Stuhls sorgt für ein bequemes und gemütliches Sitzerlebnis. Die smaragdgrüne Farbe des Samtstoffs ist weich und zart und verleiht dem Gesamtbild des Stuhls einen Hauch von Weiblichkeit.  Der Messingrahmen des Stuhls ist robust und langlebig und bietet eine solide Grundlage für den Sitzbereich. Die Messingfarbe des Gestells verleiht dem Gesamtbild des Stuhls einen Hauch von Wärme und Raffinesse. Die Kombination aus Samt und Messingrahmen schafft einen auffälligen Kontrast und macht diesen Stuhl zu einem Statement-Piece in jedem Raum.  Der Stuhl verfügt über eine hohe Rückenlehne mit geschwungenem Design, die Rücken und Schultern stützt. Der Stuhl ist sowohl auf Stil als auch auf Komfort ausgelegt, was ihn zu einer großartigen Ergänzung für jedes Wohnzimmer, Schlafzimmer oder Büro macht."}},{"name":"colorlabel","value":{"en-GB":"Emerald","de-DE":"Smaragd","en-US":"Emerald"}},{"name":"color","value":{"en-GB":"#219A0E","de-DE":"#219A0E","en-US":"#219A0E"}},{"name":"finishlabel","value":{"en-GB":"Gold","de-DE":"Gold","en-US":"Gold"}},{"name":"finish","value":{"en-GB":"#F8EE18","de-DE":"#F8EE18","en-US":"#F8EE18"}},{"name":"color-filter","value":{"key":"#00FF00","label":{"de-DE":"Grün","en-GB":"Green","en-US":"Green"}}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/emerald-velvet-chair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/emerald-velvet-chair.spec.ts
@@ -18,47 +18,165 @@ describe(`with emeraldVelvetChair preset`, () => {
           {
             "key": "living-room-furniture",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "emerald-velvet-chair",
-      "name": {
-            "de-DE": "Smaragdgrüner Samtstuhl",
-            "en-GB": "Emerald Velvet Chair",
-            "en-US": "Emerald Velvet Chair"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "smaragdgrner-samtstuhl",
-            "en-GB": "emerald-velvet-chair",
-            "en-US": "emerald-velvet-chair"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Ein Samtstuhl mit Messinggestell ist ein elegantes und luxuriöses Möbelstück. Das weiche, plüschige Samtmaterial des Stuhls sorgt für ein bequemes und gemütliches Sitzerlebnis. Die smaragdgrüne Farbe des Samtstoffs ist weich und zart und verleiht dem Gesamtbild des Stuhls einen Hauch von Weiblichkeit.  Der Messingrahmen des Stuhls ist robust und langlebig und bietet eine solide Grundlage für den Sitzbereich. Die Messingfarbe des Gestells verleiht dem Gesamtbild des Stuhls einen Hauch von Wärme und Raffinesse. Die Kombination aus Samt und Messingrahmen schafft einen auffälligen Kontrast und macht diesen Stuhl zu einem Statement-Piece in jedem Raum.  Der Stuhl verfügt über eine hohe Rückenlehne mit geschwungenem Design, die Rücken und Schultern stützt. Der Stuhl ist sowohl auf Stil als auch auf Komfort ausgelegt, was ihn zu einer großartigen Ergänzung für jedes Wohnzimmer, Schlafzimmer oder Büro macht.",
+          "en": undefined,
+          "en-GB": "A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.",
+          "en-US": "A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.",
+          "fr": undefined,
         },
-        {
+        "key": "emerald-velvet-chair",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Nur chemische Reinigung",
+                "en-GB": "- Dry clean only",
+                "en-US": "- Dry clean only",
+              },
+            },
+            {
+              "name": "colorlabel",
+              "value": {
+                "de-DE": "Smaragd",
+                "en-GB": "Emerald",
+                "en-US": "Emerald",
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "de-DE": "#219A0E",
+                "en-GB": "#219A0E",
+                "en-US": "#219A0E",
+              },
+            },
+            {
+              "name": "finishlabel",
+              "value": {
+                "de-DE": "Gold",
+                "en-GB": "Gold",
+                "en-US": "Gold",
+              },
+            },
+            {
+              "name": "finish",
+              "value": {
+                "de-DE": "#F8EE18",
+                "en-GB": "#F8EE18",
+                "en-US": "#F8EE18",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#00FF00",
+                "label": {
+                  "de-DE": "Grün",
+                  "en-GB": "Green",
+                  "en-US": "Green",
+                },
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 4800,
+                "w": 6000,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_298830220-MjoqNbBu.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 39900,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 39900,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 39900,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "VARM-09",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Smaragdgrüner Samtstuhl",
+          "en": undefined,
+          "en-GB": "Emerald Velvet Chair",
+          "en-US": "Emerald Velvet Chair",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Dry clean only","de-DE":"- Nur chemische Reinigung","en-US":"- Dry clean only"}},{"name":"product-description","value":{"en-GB":"A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.","en-US":"A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.","de-DE":"Ein Samtstuhl mit Messinggestell ist ein elegantes und luxuriöses Möbelstück. Das weiche, plüschige Samtmaterial des Stuhls sorgt für ein bequemes und gemütliches Sitzerlebnis. Die smaragdgrüne Farbe des Samtstoffs ist weich und zart und verleiht dem Gesamtbild des Stuhls einen Hauch von Weiblichkeit.  Der Messingrahmen des Stuhls ist robust und langlebig und bietet eine solide Grundlage für den Sitzbereich. Die Messingfarbe des Gestells verleiht dem Gesamtbild des Stuhls einen Hauch von Wärme und Raffinesse. Die Kombination aus Samt und Messingrahmen schafft einen auffälligen Kontrast und macht diesen Stuhl zu einem Statement-Piece in jedem Raum.  Der Stuhl verfügt über eine hohe Rückenlehne mit geschwungenem Design, die Rücken und Schultern stützt. Der Stuhl ist sowohl auf Stil als auch auf Komfort ausgelegt, was ihn zu einer großartigen Ergänzung für jedes Wohnzimmer, Schlafzimmer oder Büro macht."}},{"name":"colorlabel","value":{"en-GB":"Emerald","de-DE":"Smaragd","en-US":"Emerald"}},{"name":"color","value":{"en-GB":"#219A0E","de-DE":"#219A0E","en-US":"#219A0E"}},{"name":"finishlabel","value":{"en-GB":"Gold","de-DE":"Gold","en-US":"Gold"}},{"name":"finish","value":{"en-GB":"#F8EE18","de-DE":"#F8EE18","en-US":"#F8EE18"}},{"name":"color-filter","value":{"key":"#00FF00","label":{"de-DE":"Grün","en-GB":"Green","en-US":"Green"}}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "smaragdgrner-samtstuhl",
+          "en": undefined,
+          "en-GB": "emerald-velvet-chair",
+          "en-US": "emerald-velvet-chair",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/emerald-velvet-chair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/emerald-velvet-chair.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const emeraldVelvetChairProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .furniture()
   .build<TCategoryDraft>();
 
-const armchairsDraft = CategoryDraft.presets.sampleDataGoodstore
+const armchairsDraft = CategoryDraft.presets.sampleDataGoodStore
   .armchairs()
   .build<TCategoryDraft>();
 
-const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .livingRoomFurniture()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const emeraldVelvetChair = (): TProductDraftBuilder =>
         ['en-GB']('Emerald Velvet Chair')
         ['de-DE']('Smaragdgrüner Samtstuhl')
         ['en-US']('Emerald Velvet Chair')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.'
+        )
+        ['de-DE'](
+          'Ein Samtstuhl mit Messinggestell ist ein elegantes und luxuriöses Möbelstück. Das weiche, plüschige Samtmaterial des Stuhls sorgt für ein bequemes und gemütliches Sitzerlebnis. Die smaragdgrüne Farbe des Samtstoffs ist weich und zart und verleiht dem Gesamtbild des Stuhls einen Hauch von Weiblichkeit.  Der Messingrahmen des Stuhls ist robust und langlebig und bietet eine solide Grundlage für den Sitzbereich. Die Messingfarbe des Gestells verleiht dem Gesamtbild des Stuhls einen Hauch von Wärme und Raffinesse. Die Kombination aus Samt und Messingrahmen schafft einen auffälligen Kontrast und macht diesen Stuhl zu einem Statement-Piece in jedem Raum.  Der Stuhl verfügt über eine hohe Rückenlehne mit geschwungenem Design, die Rücken und Schultern stützt. Der Stuhl ist sowohl auf Stil als auch auf Komfort ausgelegt, was ihn zu einer großartigen Ergänzung für jedes Wohnzimmer, Schlafzimmer oder Büro macht.'
+        )
+        ['en-US'](
+          'A velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The emerald color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const emeraldVelvetChair = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.emeraldVelvetChair01()
+      ProductVariantDraft.presets.sampleDataGoodStore.emeraldVelvetChair01()
     )
     .categories([
       KeyReference.presets.category().key(furnitureDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/emerald-velvet-chair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/emerald-velvet-chair.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const emeraldVelvetChairProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .furniture()
+  .build<TCategoryDraft>();
+
+const armchairsDraft = CategoryDraft.presets.sampleDataGoodstore
+  .armchairs()
+  .build<TCategoryDraft>();
+
+const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .livingRoomFurniture()
+  .build<TCategoryDraft>();
+
+const emeraldVelvetChair = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('emerald-velvet-chair')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Emerald Velvet Chair')
+        ['de-DE']('Smaragdgrüner Samtstuhl')
+        ['en-US']('Emerald Velvet Chair')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('emerald-velvet-chair')
+        ['de-DE']('smaragdgrner-samtstuhl')
+        ['en-US']('emerald-velvet-chair')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(emeraldVelvetChairProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.emeraldVelvetChair01()
+    )
+    .categories([
+      KeyReference.presets.category().key(furnitureDraft.key!),
+      KeyReference.presets.category().key(armchairsDraft.key!),
+      KeyReference.presets.category().key(livingRoomFurnitureDraft.key!),
+    ]);
+
+export default emeraldVelvetChair;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/entryway-closet.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/entryway-closet.spec.ts
@@ -1,0 +1,64 @@
+import type { TProductDraft } from '../../../types';
+import entrywayCloset from './entryway-closet';
+describe(`with entrywayCloset preset`, () => {
+  it('should return a sample entrywayCloset product preset', () => {
+    const entrywayClosetPreset = entrywayCloset().build<TProductDraft>();
+    expect(entrywayClosetPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "furniture",
+            "typeId": "category",
+          },
+          {
+            "key": "bedroom-furniture",
+            "typeId": "category",
+          },
+          {
+            "key": "storage--tables",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "entryway-closet",
+      "name": {
+            "de-DE": "Eingangsschrank",
+            "en-GB": "Entryway Closet",
+            "en-US": "Entryway Closet"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "eingangsschrank",
+            "en-GB": "entryway-closet",
+            "en-US": "entryway-closet"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Assembly included in delivery","de-DE":"- Montage im Lieferumfang enthalten","en-US":"- Assembly included in delivery"}},{"name":"product-description","value":{"en-GB":"An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.","en-US":"An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.","de-DE":"Ein Eingangsschrank mit Spiegeln und Leuchten ist ein Einbauschrank, der sich in der Nähe des Eingangs eines Hauses oder einer Wohnung befindet. Der Schrank verfügt über Ganzkörperspiegel, die es den Menschen ermöglichen, ihr Aussehen zu überprüfen, bevor sie das Haus verlassen. Der Schrank verfügt über eine Beleuchtung, die dazu beitragen kann, den Raum aufzuhellen und das Auffinden und Greifen von darin aufbewahrten Gegenständen zu erleichtern. Das Gesamtdesign des Schranks ist von Natur aus minimalistisch, mit klaren Linien und einem einfachen Farbschema, das sich nahtlos in das umgebende Dekor einfügen soll. Zusätzlich zu Spiegeln und Beleuchtung kann der Schrank Haken oder Regale zum Aufbewahren von Jacken, Hüten, Schuhen und anderen Accessoires aufweisen."}},{"name":"finishlabel","value":{"en-GB":"White Oak","de-DE":"weiße Eiche","en-US":"White Oak"}},{"name":"finish","value":{"en-GB":"#EFDBB4","de-DE":"#EFDBB4","en-US":"#EFDBB4"}},{"name":"color-filter","value":{"key":"#F5F5DC","label":{"de-DE":"Beige","en-GB":"Beige","en-US":"Beige"}}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/entryway-closet.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/entryway-closet.spec.ts
@@ -17,47 +17,165 @@ describe(`with entrywayCloset preset`, () => {
           {
             "key": "storage--tables",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "entryway-closet",
-      "name": {
-            "de-DE": "Eingangsschrank",
-            "en-GB": "Entryway Closet",
-            "en-US": "Entryway Closet"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "eingangsschrank",
-            "en-GB": "entryway-closet",
-            "en-US": "entryway-closet"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Ein Eingangsschrank mit Spiegeln und Leuchten ist ein Einbauschrank, der sich in der Nähe des Eingangs eines Hauses oder einer Wohnung befindet. Der Schrank verfügt über Ganzkörperspiegel, die es den Menschen ermöglichen, ihr Aussehen zu überprüfen, bevor sie das Haus verlassen. Der Schrank verfügt über eine Beleuchtung, die dazu beitragen kann, den Raum aufzuhellen und das Auffinden und Greifen von darin aufbewahrten Gegenständen zu erleichtern. Das Gesamtdesign des Schranks ist von Natur aus minimalistisch, mit klaren Linien und einem einfachen Farbschema, das sich nahtlos in das umgebende Dekor einfügen soll. Zusätzlich zu Spiegeln und Beleuchtung kann der Schrank Haken oder Regale zum Aufbewahren von Jacken, Hüten, Schuhen und anderen Accessoires aufweisen.",
+          "en": undefined,
+          "en-GB": "An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.",
+          "en-US": "An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.",
+          "fr": undefined,
         },
-        {
+        "key": "entryway-closet",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Montage im Lieferumfang enthalten",
+                "en-GB": "- Assembly included in delivery",
+                "en-US": "- Assembly included in delivery",
+              },
+            },
+            {
+              "name": "finishlabel",
+              "value": {
+                "de-DE": "weiße Eiche",
+                "en-GB": "White Oak",
+                "en-US": "White Oak",
+              },
+            },
+            {
+              "name": "finish",
+              "value": {
+                "de-DE": "#EFDBB4",
+                "en-GB": "#EFDBB4",
+                "en-US": "#EFDBB4",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#F5F5DC",
+                "label": {
+                  "de-DE": "Beige",
+                  "en-GB": "Beige",
+                  "en-US": "Beige",
+                },
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 4125,
+                "w": 5500,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072189-VkrMZMom.jpeg",
+            },
+            {
+              "dimensions": {
+                "h": 4512,
+                "w": 4700,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072356-yRaYUH0J.jpeg",
+            },
+            {
+              "dimensions": {
+                "h": 4125,
+                "w": 5500,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_377072850-w10HxuUM.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 259900,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 259900,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 259900,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "EWC-07",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Eingangsschrank",
+          "en": undefined,
+          "en-GB": "Entryway Closet",
+          "en-US": "Entryway Closet",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Assembly included in delivery","de-DE":"- Montage im Lieferumfang enthalten","en-US":"- Assembly included in delivery"}},{"name":"product-description","value":{"en-GB":"An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.","en-US":"An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.","de-DE":"Ein Eingangsschrank mit Spiegeln und Leuchten ist ein Einbauschrank, der sich in der Nähe des Eingangs eines Hauses oder einer Wohnung befindet. Der Schrank verfügt über Ganzkörperspiegel, die es den Menschen ermöglichen, ihr Aussehen zu überprüfen, bevor sie das Haus verlassen. Der Schrank verfügt über eine Beleuchtung, die dazu beitragen kann, den Raum aufzuhellen und das Auffinden und Greifen von darin aufbewahrten Gegenständen zu erleichtern. Das Gesamtdesign des Schranks ist von Natur aus minimalistisch, mit klaren Linien und einem einfachen Farbschema, das sich nahtlos in das umgebende Dekor einfügen soll. Zusätzlich zu Spiegeln und Beleuchtung kann der Schrank Haken oder Regale zum Aufbewahren von Jacken, Hüten, Schuhen und anderen Accessoires aufweisen."}},{"name":"finishlabel","value":{"en-GB":"White Oak","de-DE":"weiße Eiche","en-US":"White Oak"}},{"name":"finish","value":{"en-GB":"#EFDBB4","de-DE":"#EFDBB4","en-US":"#EFDBB4"}},{"name":"color-filter","value":{"key":"#F5F5DC","label":{"de-DE":"Beige","en-GB":"Beige","en-US":"Beige"}}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "eingangsschrank",
+          "en": undefined,
+          "en-GB": "entryway-closet",
+          "en-US": "entryway-closet",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/entryway-closet.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/entryway-closet.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const entrywayClosetProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .furniture()
+  .build<TCategoryDraft>();
+
+const bedroomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .bedroomFurniture()
+  .build<TCategoryDraft>();
+
+const storageTablesDraft = CategoryDraft.presets.sampleDataGoodstore
+  .storageTables()
+  .build<TCategoryDraft>();
+
+const entrywayCloset = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('entryway-closet')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Entryway Closet')
+        ['de-DE']('Eingangsschrank')
+        ['en-US']('Entryway Closet')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('entryway-closet')
+        ['de-DE']('eingangsschrank')
+        ['en-US']('entryway-closet')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(entrywayClosetProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.entrywayCloset01()
+    )
+    .categories([
+      KeyReference.presets.category().key(furnitureDraft.key!),
+      KeyReference.presets.category().key(bedroomFurnitureDraft.key!),
+      KeyReference.presets.category().key(storageTablesDraft.key!),
+    ]);
+
+export default entrywayCloset;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/entryway-closet.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/entryway-closet.ts
@@ -10,33 +10,33 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const entrywayClosetProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .furniture()
   .build<TCategoryDraft>();
 
-const bedroomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const bedroomFurnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .bedroomFurniture()
   .build<TCategoryDraft>();
 
-const storageTablesDraft = CategoryDraft.presets.sampleDataGoodstore
-  .storageTables()
+const storageTablesDraft = CategoryDraft.presets.sampleDataGoodStore
+  .dressers()
   .build<TCategoryDraft>();
 
 const entrywayCloset = (): TProductDraftBuilder =>
@@ -49,6 +49,19 @@ const entrywayCloset = (): TProductDraftBuilder =>
         ['en-GB']('Entryway Closet')
         ['de-DE']('Eingangsschrank')
         ['en-US']('Entryway Closet')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.'
+        )
+        ['de-DE'](
+          'Ein Eingangsschrank mit Spiegeln und Leuchten ist ein Einbauschrank, der sich in der Nähe des Eingangs eines Hauses oder einer Wohnung befindet. Der Schrank verfügt über Ganzkörperspiegel, die es den Menschen ermöglichen, ihr Aussehen zu überprüfen, bevor sie das Haus verlassen. Der Schrank verfügt über eine Beleuchtung, die dazu beitragen kann, den Raum aufzuhellen und das Auffinden und Greifen von darin aufbewahrten Gegenständen zu erleichtern. Das Gesamtdesign des Schranks ist von Natur aus minimalistisch, mit klaren Linien und einem einfachen Farbschema, das sich nahtlos in das umgebende Dekor einfügen soll. Zusätzlich zu Spiegeln und Beleuchtung kann der Schrank Haken oder Regale zum Aufbewahren von Jacken, Hüten, Schuhen und anderen Accessoires aufweisen.'
+        )
+        ['en-US'](
+          'An entryway closet with mirrors and lights is a built-in closet that is situated near the entrance of a house or apartment. The closet features full-length mirrors, which are designed to allow people to check their appearance before leaving the house. The closet has lighting installed, which can help to brighten the space and make it easier to find and grab items stored within. The overall design of the closet is minimalist in nature, with clean lines and a simple color scheme that is meant to blend seamlessly with the surrounding decor. In addition to mirrors and lighting, the closet may feature hooks or shelves for storing jackets, hats, shoes, and other accessories.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const entrywayCloset = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.entrywayCloset01()
+      ProductVariantDraft.presets.sampleDataGoodStore.entrywayCloset01()
     )
     .categories([
       KeyReference.presets.category().key(furnitureDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/evergreen-candle.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/evergreen-candle.spec.ts
@@ -1,0 +1,64 @@
+import type { TProductDraft } from '../../../types';
+import evergreenCandle from './evergreen-candle';
+describe(`with evergreenCandle preset`, () => {
+  it('should return a sample evergreenCandle product preset', () => {
+    const evergreenCandlePreset = evergreenCandle().build<TProductDraft>();
+    expect(evergreenCandlePreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "home-accents",
+            "typeId": "category",
+          },
+          {
+            "key": "room-decor",
+            "typeId": "category",
+          },
+          {
+            "key": "home-decor",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "evergreen-candle",
+      "name": {
+            "de-DE": "Immergrüne Kerze",
+            "en-GB": "Evergreen Candle",
+            "en-US": "Evergreen Candle"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "immergrne-kerze",
+            "en-GB": "evergreen-candle",
+            "en-US": "evergreen-candle"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"product-description","value":{"en-GB":"The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.","en-US":"The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.","de-DE":"Der Kerzenhalter hat ein schlichtes, rustikales Design mit einer hohen, schlanken Form, die an einen Baumstamm erinnert. Es kann auch mit kleinen immergrünen Zweigen, Beeren und Tannenzapfen dekoriert werden, um ein natürlicheres und organischeres Aussehen zu schaffen.  Wenn die Kerze angezündet wird, wirft sie einen warmen und gemütlichen Schein und schafft eine festliche und einladende Atmosphäre in jedem Raum. Der immergrüne Duft des Kerzenhalters kann auch durch die Wärme der Kerze verstärkt werden und erfüllt den Raum mit dem natürlichen Duft von Kiefer und Holz.  Insgesamt ist ein immergrüner Kerzenhalter während der Ferienzeit eine charmante und rustikale Ergänzung für jedes Zuhause. Seine natürlichen Materialien und Erdtöne können dazu beitragen, eine warme und einladende Atmosphäre zu schaffen, während sein einfaches, aber elegantes Design jedem Raum einen Hauch von Natur verleiht."}},{"name":"color-filter","value":{"key":"#00FF00","label":{"de-DE":"Grün","en-GB":"Green","en-US":"Green"}}},{"name":"colorlabel","value":{"en-GB":"Evergreen","de-DE":"Immergrün","en-US":"Evergreen"}},{"name":"color","value":{"en-GB":"#156F29","de-DE":"#156F29","en-US":"#156F29"}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/evergreen-candle.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/evergreen-candle.spec.ts
@@ -17,47 +17,157 @@ describe(`with evergreenCandle preset`, () => {
           {
             "key": "home-decor",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "evergreen-candle",
-      "name": {
-            "de-DE": "Immergrüne Kerze",
-            "en-GB": "Evergreen Candle",
-            "en-US": "Evergreen Candle"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "immergrne-kerze",
-            "en-GB": "evergreen-candle",
-            "en-US": "evergreen-candle"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Der Kerzenhalter hat ein schlichtes, rustikales Design mit einer hohen, schlanken Form, die an einen Baumstamm erinnert. Es kann auch mit kleinen immergrünen Zweigen, Beeren und Tannenzapfen dekoriert werden, um ein natürlicheres und organischeres Aussehen zu schaffen.  Wenn die Kerze angezündet wird, wirft sie einen warmen und gemütlichen Schein und schafft eine festliche und einladende Atmosphäre in jedem Raum. Der immergrüne Duft des Kerzenhalters kann auch durch die Wärme der Kerze verstärkt werden und erfüllt den Raum mit dem natürlichen Duft von Kiefer und Holz.  Insgesamt ist ein immergrüner Kerzenhalter während der Ferienzeit eine charmante und rustikale Ergänzung für jedes Zuhause. Seine natürlichen Materialien und Erdtöne können dazu beitragen, eine warme und einladende Atmosphäre zu schaffen, während sein einfaches, aber elegantes Design jedem Raum einen Hauch von Natur verleiht.",
+          "en": undefined,
+          "en-GB": "The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.",
+          "en-US": "The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.",
+          "fr": undefined,
         },
-        {
+        "key": "evergreen-candle",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#00FF00",
+                "label": {
+                  "de-DE": "Grün",
+                  "en-GB": "Green",
+                  "en-US": "Green",
+                },
+              },
+            },
+            {
+              "name": "colorlabel",
+              "value": {
+                "de-DE": "Immergrün",
+                "en-GB": "Evergreen",
+                "en-US": "Evergreen",
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "de-DE": "#156F29",
+                "en-GB": "#156F29",
+                "en-US": "#156F29",
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 2160,
+                "w": 3840,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_537837949-oKQ-Kd3Q.jpeg",
+            },
+            {
+              "dimensions": {
+                "h": 2160,
+                "w": 3840,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_537917105-H0lwB1x2.jpeg",
+            },
+            {
+              "dimensions": {
+                "h": 6720,
+                "w": 4480,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/AdobeStock_485090921-6JFeqs-M.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 299,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 299,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 299,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "EC-0993",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Immergrüne Kerze",
+          "en": undefined,
+          "en-GB": "Evergreen Candle",
+          "en-US": "Evergreen Candle",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"product-description","value":{"en-GB":"The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.","en-US":"The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.","de-DE":"Der Kerzenhalter hat ein schlichtes, rustikales Design mit einer hohen, schlanken Form, die an einen Baumstamm erinnert. Es kann auch mit kleinen immergrünen Zweigen, Beeren und Tannenzapfen dekoriert werden, um ein natürlicheres und organischeres Aussehen zu schaffen.  Wenn die Kerze angezündet wird, wirft sie einen warmen und gemütlichen Schein und schafft eine festliche und einladende Atmosphäre in jedem Raum. Der immergrüne Duft des Kerzenhalters kann auch durch die Wärme der Kerze verstärkt werden und erfüllt den Raum mit dem natürlichen Duft von Kiefer und Holz.  Insgesamt ist ein immergrüner Kerzenhalter während der Ferienzeit eine charmante und rustikale Ergänzung für jedes Zuhause. Seine natürlichen Materialien und Erdtöne können dazu beitragen, eine warme und einladende Atmosphäre zu schaffen, während sein einfaches, aber elegantes Design jedem Raum einen Hauch von Natur verleiht."}},{"name":"color-filter","value":{"key":"#00FF00","label":{"de-DE":"Grün","en-GB":"Green","en-US":"Green"}}},{"name":"colorlabel","value":{"en-GB":"Evergreen","de-DE":"Immergrün","en-US":"Evergreen"}},{"name":"color","value":{"en-GB":"#156F29","de-DE":"#156F29","en-US":"#156F29"}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "immergrne-kerze",
+          "en": undefined,
+          "en-GB": "evergreen-candle",
+          "en-US": "evergreen-candle",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/evergreen-candle.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/evergreen-candle.ts
@@ -1,0 +1,78 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const evergreenCandleProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const homeAccentsDraft = CategoryDraft.presets.sampleDataGoodstore
+  .homeAccents()
+  .build<TCategoryDraft>();
+
+const roomDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+  .roomDecor()
+  .build<TCategoryDraft>();
+
+const homeDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+  .homeDecor()
+  .build<TCategoryDraft>();
+
+const evergreenCandle = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('evergreen-candle')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Evergreen Candle')
+        ['de-DE']('Immergrüne Kerze')
+        ['en-US']('Evergreen Candle')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('evergreen-candle')
+        ['de-DE']('immergrne-kerze')
+        ['en-US']('evergreen-candle')
+    )
+    .productType(
+      KeyReference.presets
+        .productType()
+        .key(evergreenCandleProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.evergreenCandle01()
+    )
+    .categories([
+      KeyReference.presets.category().key(homeAccentsDraft.key!),
+      KeyReference.presets.category().key(roomDecorDraft.key!),
+      KeyReference.presets.category().key(homeDecorDraft.key!),
+    ]);
+
+export default evergreenCandle;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/evergreen-candle.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/evergreen-candle.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const evergreenCandleProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const homeAccentsDraft = CategoryDraft.presets.sampleDataGoodstore
+const homeAccentsDraft = CategoryDraft.presets.sampleDataGoodStore
   .homeAccents()
   .build<TCategoryDraft>();
 
-const roomDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+const roomDecorDraft = CategoryDraft.presets.sampleDataGoodStore
   .roomDecor()
   .build<TCategoryDraft>();
 
-const homeDecorDraft = CategoryDraft.presets.sampleDataGoodstore
+const homeDecorDraft = CategoryDraft.presets.sampleDataGoodStore
   .homeDecor()
   .build<TCategoryDraft>();
 
@@ -49,6 +49,19 @@ const evergreenCandle = (): TProductDraftBuilder =>
         ['en-GB']('Evergreen Candle')
         ['de-DE']('Immergrüne Kerze')
         ['en-US']('Evergreen Candle')
+    )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          'The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.'
+        )
+        ['de-DE'](
+          'Der Kerzenhalter hat ein schlichtes, rustikales Design mit einer hohen, schlanken Form, die an einen Baumstamm erinnert. Es kann auch mit kleinen immergrünen Zweigen, Beeren und Tannenzapfen dekoriert werden, um ein natürlicheres und organischeres Aussehen zu schaffen.  Wenn die Kerze angezündet wird, wirft sie einen warmen und gemütlichen Schein und schafft eine festliche und einladende Atmosphäre in jedem Raum. Der immergrüne Duft des Kerzenhalters kann auch durch die Wärme der Kerze verstärkt werden und erfüllt den Raum mit dem natürlichen Duft von Kiefer und Holz.  Insgesamt ist ein immergrüner Kerzenhalter während der Ferienzeit eine charmante und rustikale Ergänzung für jedes Zuhause. Seine natürlichen Materialien und Erdtöne können dazu beitragen, eine warme und einladende Atmosphäre zu schaffen, während sein einfaches, aber elegantes Design jedem Raum einen Hauch von Natur verleiht.'
+        )
+        ['en-US'](
+          'The candlestick features a simple, rustic design with a tall, slender shape that is reminiscent of a tree trunk. It may also be decorated with small evergreen branches, berries, and pinecones to create a more natural and organic look.  When the candle is lit, it will cast a warm and cozy glow, creating a festive and inviting atmosphere in any room. The evergreen scent of the candlestick may also be enhanced by the heat of the candle, filling the room with the natural fragrance of pine and wood.  Overall, an evergreen candle stick is a charming and rustic addition to any home during the holiday season. Its natural materials and earthy tones can help to create a warm and inviting atmosphere, while its simple yet elegant design can add a touch of nature to any room.'
+        )
     )
     .slug(
       LocalizedString.presets
@@ -64,10 +77,10 @@ const evergreenCandle = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.evergreenCandle01()
+      ProductVariantDraft.presets.sampleDataGoodStore.evergreenCandle01()
     )
     .categories([
       KeyReference.presets.category().key(homeAccentsDraft.key!),

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/fawn-armchair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/fawn-armchair.spec.ts
@@ -1,0 +1,64 @@
+import type { TProductDraft } from '../../../types';
+import fawnArmchair from './fawn-armchair';
+describe(`with fawnArmchair preset`, () => {
+  it('should return a sample fawnArmchair product preset', () => {
+    const fawnArmchairPreset = fawnArmchair().build<TProductDraft>();
+    expect(fawnArmchairPreset).toMatchInlineSnapshot(`
+      {
+        "categories": [
+          {
+            "key": "furniture",
+            "typeId": "category",
+          },
+          {
+            "key": "armchairs",
+            "typeId": "category",
+          },
+          {
+            "key": "living-room-furniture",
+            "typeId": "category",
+          }
+        ],
+      "categoryOrderHints": {},
+      "key": "fawn-armchair",
+      "name": {
+            "de-DE": "Fawn Sessel",
+            "en-GB": "Fawn Armchair",
+            "en-US": "Fawn Armchair"
+          },
+      "metaTitle": {
+            "de-DE": "",
+            "en-GB": "",
+            "en-US": ""
+          },
+      "searchKeywords": {},
+      "slug": {
+            "de-DE": "fawn-sessel",
+            "en-GB": "fawn-armchair",
+            "en-US": "fawn-armchair"
+          },
+      "publish": true,
+      "priceMode": undefined,
+        {
+          "key": "vat-standard-eu",
+          "typeId": "tax-category",
+        },
+        {
+          "key": "furniture-and-decor",
+          "typeId": "product-type",
+        },
+        "masterVariant": {
+          "assets": undefined,
+          "sku": undefined,
+          "images": undefined,
+          "key": undefined,
+          "prices": undefined,
+          "attributes": [{"name":"productspec","value":{"en-GB":"- Leather requires special care","de-DE":"- Leder erfordert besondere Pflege","en-US":"- Leather requires special care"}},{"name":"product-description","value":{"en-GB":"An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room.","en-US":"An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room.","de-DE":"Ein Art-Deco-Lederstuhl mit Ebenholzbeinen hat ein schlankes, stromlinienförmiges Design, das Raffinesse und Eleganz ausstrahlt. Der Stuhl hat einen bequem gepolsterten Sitz und eine Rückenlehne, wobei die Lederpolsterung ein weiches und luxuriöses Gefühl vermittelt. Die Beine aus Ebenholz sind lang und konisch zulaufend, mit einer glatten Oberfläche, die den modernen Stil des Stuhls betont. Der Stuhl weist auch markante Art-Deco-Elemente wie eckige Formen, kräftige Linien und geometrische Muster auf. Insgesamt wäre dieser Stuhl ein markantes Möbelstück, das jedem Raum sowohl Stil als auch Komfort verleiht."}},{"name":"color","value":{"en-GB":"#FFF8ED","de-DE":"#FFF8ED","en-US":"#FFF8ED"}},{"name":"colorlabel","value":{"en-GB":"White Leather","de-DE":"Weißes Leder","en-US":"White Leather"}},{"name":"finishlabel","value":{"en-GB":"Chestnut","de-DE":"Kastanie","en-US":"Chestnut"}},{"name":"finish","value":{"en-GB":"#1B1101","de-DE":"#1B1101","en-US":"#1B1101"}},{"name":"color-filter","value":{"key":"#F5F5DC","label":{"de-DE":"Beige","en-GB":"Beige","en-US":"Beige"}}}],
+        },
+        "variants": [
+
+       ]
+      }
+    `);
+  });
+});

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/fawn-armchair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/fawn-armchair.spec.ts
@@ -17,47 +17,165 @@ describe(`with fawnArmchair preset`, () => {
           {
             "key": "living-room-furniture",
             "typeId": "category",
-          }
+          },
         ],
-      "categoryOrderHints": {},
-      "key": "fawn-armchair",
-      "name": {
-            "de-DE": "Fawn Sessel",
-            "en-GB": "Fawn Armchair",
-            "en-US": "Fawn Armchair"
-          },
-      "metaTitle": {
-            "de-DE": "",
-            "en-GB": "",
-            "en-US": ""
-          },
-      "searchKeywords": {},
-      "slug": {
-            "de-DE": "fawn-sessel",
-            "en-GB": "fawn-armchair",
-            "en-US": "fawn-armchair"
-          },
-      "publish": true,
-      "priceMode": undefined,
-        {
-          "key": "vat-standard-eu",
-          "typeId": "tax-category",
+        "categoryOrderHints": undefined,
+        "description": {
+          "de": undefined,
+          "de-DE": "Ein Art-Deco-Lederstuhl mit Ebenholzbeinen hat ein schlankes, stromlinienförmiges Design, das Raffinesse und Eleganz ausstrahlt. Der Stuhl hat einen bequem gepolsterten Sitz und eine Rückenlehne, wobei die Lederpolsterung ein weiches und luxuriöses Gefühl vermittelt. Die Beine aus Ebenholz sind lang und konisch zulaufend, mit einer glatten Oberfläche, die den modernen Stil des Stuhls betont. Der Stuhl weist auch markante Art-Deco-Elemente wie eckige Formen, kräftige Linien und geometrische Muster auf. Insgesamt wäre dieser Stuhl ein markantes Möbelstück, das jedem Raum sowohl Stil als auch Komfort verleiht.",
+          "en": undefined,
+          "en-GB": "An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room.",
+          "en-US": "An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room.",
+          "fr": undefined,
         },
-        {
+        "key": "fawn-armchair",
+        "masterVariant": {
+          "assets": undefined,
+          "attributes": [
+            {
+              "name": "productspec",
+              "value": {
+                "de-DE": "- Leder erfordert besondere Pflege",
+                "en-GB": "- Leather requires special care",
+                "en-US": "- Leather requires special care",
+              },
+            },
+            {
+              "name": "color",
+              "value": {
+                "de-DE": "#FFF8ED",
+                "en-GB": "#FFF8ED",
+                "en-US": "#FFF8ED",
+              },
+            },
+            {
+              "name": "colorlabel",
+              "value": {
+                "de-DE": "Weißes Leder",
+                "en-GB": "White Leather",
+                "en-US": "White Leather",
+              },
+            },
+            {
+              "name": "finishlabel",
+              "value": {
+                "de-DE": "Kastanie",
+                "en-GB": "Chestnut",
+                "en-US": "Chestnut",
+              },
+            },
+            {
+              "name": "finish",
+              "value": {
+                "de-DE": "#1B1101",
+                "en-GB": "#1B1101",
+                "en-US": "#1B1101",
+              },
+            },
+            {
+              "name": "color-filter",
+              "value": {
+                "key": "#F5F5DC",
+                "label": {
+                  "de-DE": "Beige",
+                  "en-GB": "Beige",
+                  "en-US": "Beige",
+                },
+              },
+            },
+          ],
+          "images": [
+            {
+              "dimensions": {
+                "h": 3200,
+                "w": 2400,
+              },
+              "label": undefined,
+              "url": "https://2eca75039cf911b9bbe5-79bfd3e36f011d786971804e873c4354.ssl.cf3.rackcdn.com/Fawn%20Armchair-aPr3Rbhn.jpeg",
+            },
+          ],
+          "key": undefined,
+          "prices": [
+            {
+              "channel": undefined,
+              "country": "DE",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 59900,
+                "currencyCode": "EUR",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "GB",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 59900,
+                "currencyCode": "GBP",
+              },
+            },
+            {
+              "channel": undefined,
+              "country": "US",
+              "custom": undefined,
+              "customerGroup": undefined,
+              "discounted": undefined,
+              "key": undefined,
+              "tiers": undefined,
+              "validFrom": undefined,
+              "validUntil": undefined,
+              "value": {
+                "centAmount": 59900,
+                "currencyCode": "USD",
+              },
+            },
+          ],
+          "sku": "FARM-05",
+        },
+        "metaDescription": undefined,
+        "metaKeywords": undefined,
+        "metaTitle": undefined,
+        "name": {
+          "de": undefined,
+          "de-DE": "Fawn Sessel",
+          "en": undefined,
+          "en-GB": "Fawn Armchair",
+          "en-US": "Fawn Armchair",
+          "fr": undefined,
+        },
+        "priceMode": undefined,
+        "productType": {
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
-        "masterVariant": {
-          "assets": undefined,
-          "sku": undefined,
-          "images": undefined,
-          "key": undefined,
-          "prices": undefined,
-          "attributes": [{"name":"productspec","value":{"en-GB":"- Leather requires special care","de-DE":"- Leder erfordert besondere Pflege","en-US":"- Leather requires special care"}},{"name":"product-description","value":{"en-GB":"An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room.","en-US":"An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room.","de-DE":"Ein Art-Deco-Lederstuhl mit Ebenholzbeinen hat ein schlankes, stromlinienförmiges Design, das Raffinesse und Eleganz ausstrahlt. Der Stuhl hat einen bequem gepolsterten Sitz und eine Rückenlehne, wobei die Lederpolsterung ein weiches und luxuriöses Gefühl vermittelt. Die Beine aus Ebenholz sind lang und konisch zulaufend, mit einer glatten Oberfläche, die den modernen Stil des Stuhls betont. Der Stuhl weist auch markante Art-Deco-Elemente wie eckige Formen, kräftige Linien und geometrische Muster auf. Insgesamt wäre dieser Stuhl ein markantes Möbelstück, das jedem Raum sowohl Stil als auch Komfort verleiht."}},{"name":"color","value":{"en-GB":"#FFF8ED","de-DE":"#FFF8ED","en-US":"#FFF8ED"}},{"name":"colorlabel","value":{"en-GB":"White Leather","de-DE":"Weißes Leder","en-US":"White Leather"}},{"name":"finishlabel","value":{"en-GB":"Chestnut","de-DE":"Kastanie","en-US":"Chestnut"}},{"name":"finish","value":{"en-GB":"#1B1101","de-DE":"#1B1101","en-US":"#1B1101"}},{"name":"color-filter","value":{"key":"#F5F5DC","label":{"de-DE":"Beige","en-GB":"Beige","en-US":"Beige"}}}],
+        "publish": true,
+        "searchKeywords": undefined,
+        "slug": {
+          "de": undefined,
+          "de-DE": "fawn-sessel",
+          "en": undefined,
+          "en-GB": "fawn-armchair",
+          "en-US": "fawn-armchair",
+          "fr": undefined,
         },
-        "variants": [
-
-       ]
+        "state": undefined,
+        "taxCategory": {
+          "key": "standard-tax",
+          "typeId": "tax-category",
+        },
+        "variants": undefined,
       }
     `);
   });

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/fawn-armchair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/fawn-armchair.ts
@@ -1,0 +1,76 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  type TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
+import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
+import {
+  TaxCategoryDraft,
+  type TTaxCategoryDraft,
+} from '@commercetools-test-data/tax-category';
+import * as ProductDraft from '../../../product-draft';
+import type { TProductDraftBuilder } from '../../../types';
+
+const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
+  .vatStandardEu()
+  .build<TTaxCategoryDraft>();
+
+const fawnArmchairProductTypeDraft =
+  ProductTypeDraft.presets.sampleDataGoodstore
+    .furnitureAndDecor()
+    .build<TProductTypeDraft>();
+
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .furniture()
+  .build<TCategoryDraft>();
+
+const armchairsDraft = CategoryDraft.presets.sampleDataGoodstore
+  .armchairs()
+  .build<TCategoryDraft>();
+
+const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+  .livingRoomFurniture()
+  .build<TCategoryDraft>();
+
+const fawnArmchair = (): TProductDraftBuilder =>
+  ProductDraft.presets
+    .empty()
+    .key('fawn-armchair')
+    .name(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('Fawn Armchair')
+        ['de-DE']('Fawn Sessel')
+        ['en-US']('Fawn Armchair')
+    )
+    .slug(
+      LocalizedString.presets
+        .empty()
+        ['en-GB']('fawn-armchair')
+        ['de-DE']('fawn-sessel')
+        ['en-US']('fawn-armchair')
+    )
+    .productType(
+      KeyReference.presets.productType().key(fawnArmchairProductTypeDraft.key!)
+    )
+    .publish(true)
+    .taxCategory(
+      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+    )
+    .masterVariant(
+      ProductVariantDraft.presets.sampleDataGoodstore.fawnArmchair01()
+    )
+    .categories([
+      KeyReference.presets.category().key(furnitureDraft.key!),
+      KeyReference.presets.category().key(armchairsDraft.key!),
+      KeyReference.presets.category().key(livingRoomFurnitureDraft.key!),
+    ]);
+
+export default fawnArmchair;

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/fawn-armchair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/fawn-armchair.ts
@@ -10,32 +10,32 @@ import {
   ProductTypeDraft,
   type TProductTypeDraft,
 } from '@commercetools-test-data/product-type';
-import { ProductVariantDraft } from '@commercetools-test-data/product-variant';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
+import * as ProductVariantDraft from '../../../../product-variant/product-variant-draft';
 import * as ProductDraft from '../../../product-draft';
 import type { TProductDraftBuilder } from '../../../types';
 
-const vatStandardEuDraft = TaxCategoryDraft.presets.sampleDataGoodstore
-  .vatStandardEu()
+const standardTaxCategoryDraft = TaxCategoryDraft.presets.sampleDataGoodStore
+  .standardTaxCategory()
   .build<TTaxCategoryDraft>();
 
 const fawnArmchairProductTypeDraft =
-  ProductTypeDraft.presets.sampleDataGoodstore
+  ProductTypeDraft.presets.sampleDataGoodStore
     .furnitureAndDecor()
     .build<TProductTypeDraft>();
 
-const furnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const furnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .furniture()
   .build<TCategoryDraft>();
 
-const armchairsDraft = CategoryDraft.presets.sampleDataGoodstore
+const armchairsDraft = CategoryDraft.presets.sampleDataGoodStore
   .armchairs()
   .build<TCategoryDraft>();
 
-const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodstore
+const livingRoomFurnitureDraft = CategoryDraft.presets.sampleDataGoodStore
   .livingRoomFurniture()
   .build<TCategoryDraft>();
 
@@ -50,6 +50,19 @@ const fawnArmchair = (): TProductDraftBuilder =>
         ['de-DE']('Fawn Sessel')
         ['en-US']('Fawn Armchair')
     )
+    .description(
+      LocalizedString.presets
+        .empty()
+        ['en-GB'](
+          "An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room."
+        )
+        ['de-DE'](
+          'Ein Art-Deco-Lederstuhl mit Ebenholzbeinen hat ein schlankes, stromlinienförmiges Design, das Raffinesse und Eleganz ausstrahlt. Der Stuhl hat einen bequem gepolsterten Sitz und eine Rückenlehne, wobei die Lederpolsterung ein weiches und luxuriöses Gefühl vermittelt. Die Beine aus Ebenholz sind lang und konisch zulaufend, mit einer glatten Oberfläche, die den modernen Stil des Stuhls betont. Der Stuhl weist auch markante Art-Deco-Elemente wie eckige Formen, kräftige Linien und geometrische Muster auf. Insgesamt wäre dieser Stuhl ein markantes Möbelstück, das jedem Raum sowohl Stil als auch Komfort verleiht.'
+        )
+        ['en-US'](
+          "An art deco leather chair with ebony legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with the leather upholstery providing a soft and luxurious feel. The ebony legs are long and tapered, with a smooth finish that accentuates the chair's modern style. The chair also features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair would be a striking piece of furniture that adds both style and comfort to any room."
+        )
+    )
     .slug(
       LocalizedString.presets
         .empty()
@@ -62,10 +75,10 @@ const fawnArmchair = (): TProductDraftBuilder =>
     )
     .publish(true)
     .taxCategory(
-      KeyReference.presets.taxCategory().key(vatStandardEuDraft.key!)
+      KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )
     .masterVariant(
-      ProductVariantDraft.presets.sampleDataGoodstore.fawnArmchair01()
+      ProductVariantDraft.presets.sampleDataGoodStore.fawnArmchair01()
     )
     .categories([
       KeyReference.presets.category().key(furnitureDraft.key!),


### PR DESCRIPTION
This PR creates the second 20 product presets for our GoodStore dataset. 

As with the [PR for the first 20 presets](https://github.com/commercetools/test-data/pull/372), most of this work was brought in from [this PR](https://github.com/commercetools/test-data/pull/347/files#diff-74e0b28415fb07d7bfcc2af3383910528dff740e76388e431aa29630540144d3) and massaged, with tests added.

Again, product descriptions were brought into `ProductDraft.description` rather than as an attribute in the `ProductVariantDraft`.