### PR TITLE
chore(test-data): unstub shims in goodstore data

### DIFF
--- a/.changeset/great-actors-sort.md
+++ b/.changeset/great-actors-sort.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/product-discount': patch
+'@commercetools-test-data/cart-discount': patch
+---
+
+refactors to goodstore presets

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/furniture-bogo.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/furniture-bogo.spec.ts
@@ -34,7 +34,7 @@ describe('with the preset `furnitureBogo`', () => {
         "target": {
           "discountedQuantity": 1,
           "maxOccurrence": undefined,
-          "predicate": "productType.key = "placeholder"",
+          "predicate": "productType.key = "furniture-and-decor"",
           "selectionMode": "Cheapest",
           "triggerQuantity": 2,
           "type": "multiBuyLineItems",
@@ -90,7 +90,7 @@ describe('with the preset `furnitureBogo`', () => {
           "multiBuyLineItems": {
             "discountedQuantity": 1,
             "maxOccurrence": undefined,
-            "predicate": "productType.key = "placeholder"",
+            "predicate": "productType.key = "furniture-and-decor"",
             "selectionMode": "Cheapest",
             "triggerQuantity": 2,
           },

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/furniture-bogo.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/furniture-bogo.ts
@@ -1,10 +1,8 @@
 import { LocalizedString } from '@commercetools-test-data/commons';
-// @unstub
-// TODO: Import when available
-// import {
-//   ProductTypeDraft,
-//   TProductTypeDraft,
-// } from '@commercetools-test-data/product-type';
+import {
+  ProductTypeDraft,
+  TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
 import {
   CartDiscountMultiBuyLineItemsTargetDraft,
   CartDiscountValueRelativeDraft,
@@ -14,11 +12,9 @@ import { stackingMode } from '../../../constants';
 import type { TCartDiscountDraftBuilder } from '../../../types';
 import * as CartDiscountDraft from '../../index';
 
-// @unstub
-// TODO: Need product type draft to be created
-// const productTypeDraft = ProductTypeDraft.presets.sampleDataGoodStore
-//   .furniture()
-//   .build<TProductTypeDraft>();
+const productTypeDraft = ProductTypeDraft.presets.sampleDataGoodStore
+  .furnitureAndDecor()
+  .build<TProductTypeDraft>();
 
 const furnitureBogo = (): TCartDiscountDraftBuilder =>
   CartDiscountDraft.presets
@@ -27,10 +23,7 @@ const furnitureBogo = (): TCartDiscountDraftBuilder =>
     .cartPredicate('1 = 1')
     .target(
       CartDiscountMultiBuyLineItemsTargetDraft.random()
-        // @unstub
-        // TODO: insert when available
-        // .predicate(`productType.key = "${productTypeDraft.key}"`)
-        .predicate(`productType.key = "placeholder"`)
+        .predicate(`productType.key = "${productTypeDraft.key}"`)
         .triggerQuantity(2)
         .discountedQuantity(1)
         .selectionMode(selectionMode.Cheapest)

--- a/models/product-discount/package.json
+++ b/models/product-discount/package.json
@@ -22,6 +22,8 @@
     "@commercetools-test-data/commons": "6.0.0",
     "@commercetools-test-data/core": "6.0.0",
     "@commercetools-test-data/utils": "6.0.0",
+    "@commercetools-test-data/category": "6.0.0",
+    "@commercetools-test-data/product-type": "6.0.0",
     "@commercetools/platform-sdk": "^4.11.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-bakeware.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-bakeware.ts
@@ -1,7 +1,15 @@
+import {
+  CategoryDraft,
+  TCategoryDraft,
+} from '@commercetools-test-data/category';
 import { LocalizedString, Money } from '@commercetools-test-data/commons';
 import { ProductDiscountValueAbsoluteDraft } from '../../../../index';
 import type { TProductDiscountDraftBuilder } from '../../../types';
 import * as ProductDiscountDraft from '../../index';
+
+const categoryTypeDraft = CategoryDraft.presets.sampleDataGoodStore
+  .bakeware()
+  .build<TCategoryDraft>();
 
 const discountBakeware = (): TProductDiscountDraftBuilder =>
   ProductDiscountDraft.presets
@@ -11,8 +19,7 @@ const discountBakeware = (): TProductDiscountDraftBuilder =>
         Money.random().currencyCode('EUR').centAmount(500),
       ])
     )
-    // TODO: integrate product type keys
-    .predicate('categories.key contains "bakeware"')
+    .predicate(`categories.key contains "${categoryTypeDraft.key}"`)
     .name(
       LocalizedString.presets
         .empty()

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-furniture-and-decor.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-furniture-and-decor.ts
@@ -1,7 +1,15 @@
 import { LocalizedString, Money } from '@commercetools-test-data/commons';
+import {
+  ProductTypeDraft,
+  TProductTypeDraft,
+} from '@commercetools-test-data/product-type';
 import { ProductDiscountValueAbsoluteDraft } from '../../../../index';
 import type { TProductDiscountDraftBuilder } from '../../../types';
 import * as ProductDiscountDraft from '../../index';
+
+const productTypeDraft = ProductTypeDraft.presets.sampleDataGoodStore
+  .furnitureAndDecor()
+  .build<TProductTypeDraft>();
 
 const discountFurnitureAndDecor = (): TProductDiscountDraftBuilder =>
   ProductDiscountDraft.presets
@@ -11,8 +19,7 @@ const discountFurnitureAndDecor = (): TProductDiscountDraftBuilder =>
         Money.random().currencyCode('USD').centAmount(1000),
       ])
     )
-    // TODO: integrate product type keys
-    .predicate('productType.key = "furniture-and-decor"')
+    .predicate(`productType.key = "${productTypeDraft.key}"`)
     .name(
       LocalizedString.presets
         .empty()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,12 +494,18 @@ importers:
       '@babel/runtime-corejs3':
         specifier: ^7.17.9
         version: 7.19.4
+      '@commercetools-test-data/category':
+        specifier: 6.0.0
+        version: link:../category
       '@commercetools-test-data/commons':
         specifier: 6.0.0
         version: link:../commons
       '@commercetools-test-data/core':
         specifier: 6.0.0
         version: link:../../core
+      '@commercetools-test-data/product-type':
+        specifier: 6.0.0
+        version: link:../product-type
       '@commercetools-test-data/utils':
         specifier: 6.0.0
         version: link:../../utils


### PR DESCRIPTION
## Summary

This PR gets rid of shims we had previously used in goodstore data presets.