### PR TITLE
fix(test-data): use Money over CentPrecisionMoney in shipping rate drafts

### DIFF
--- a/.changeset/hip-seals-sell.md
+++ b/.changeset/hip-seals-sell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/shipping-method': patch
+---
+
+Use Money over CentPrecisionMoney in Good Store shipping rate drafts

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/express.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/express.spec.ts
@@ -26,8 +26,6 @@ describe('Shipping Method with express preset', () => {
                 "price": {
                   "centAmount": 50000,
                   "currencyCode": "EUR",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },
@@ -36,8 +34,6 @@ describe('Shipping Method with express preset', () => {
                 "price": {
                   "centAmount": 50000,
                   "currencyCode": "GBP",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },
@@ -75,22 +71,16 @@ describe('Shipping Method with express preset', () => {
               {
                 "freeAbove": undefined,
                 "price": {
-                  "__typename": "Money",
                   "centAmount": 50000,
                   "currencyCode": "EUR",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },
               {
                 "freeAbove": undefined,
                 "price": {
-                  "__typename": "Money",
                   "centAmount": 50000,
                   "currencyCode": "GBP",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/standard.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/standard.spec.ts
@@ -26,8 +26,6 @@ describe('Shipping Method with standard preset', () => {
                 "price": {
                   "centAmount": 10000,
                   "currencyCode": "EUR",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },
@@ -36,8 +34,6 @@ describe('Shipping Method with standard preset', () => {
                 "price": {
                   "centAmount": 10000,
                   "currencyCode": "GBP",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },
@@ -54,8 +50,6 @@ describe('Shipping Method with standard preset', () => {
                 "price": {
                   "centAmount": 10000,
                   "currencyCode": "GBP",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },
@@ -64,8 +58,6 @@ describe('Shipping Method with standard preset', () => {
                 "price": {
                   "centAmount": 10000,
                   "currencyCode": "EUR",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },
@@ -103,22 +95,16 @@ describe('Shipping Method with standard preset', () => {
               {
                 "freeAbove": undefined,
                 "price": {
-                  "__typename": "Money",
                   "centAmount": 10000,
                   "currencyCode": "EUR",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },
               {
                 "freeAbove": undefined,
                 "price": {
-                  "__typename": "Money",
                   "centAmount": 10000,
                   "currencyCode": "GBP",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },
@@ -134,22 +120,16 @@ describe('Shipping Method with standard preset', () => {
               {
                 "freeAbove": undefined,
                 "price": {
-                  "__typename": "Money",
                   "centAmount": 10000,
                   "currencyCode": "GBP",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },
               {
                 "freeAbove": undefined,
                 "price": {
-                  "__typename": "Money",
                   "centAmount": 10000,
                   "currencyCode": "EUR",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": [],
               },

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/usa.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/usa.spec.ts
@@ -25,14 +25,10 @@ describe('Shipping Method with USA preset', () => {
                 "freeAbove": {
                   "centAmount": 100000,
                   "currencyCode": "USD",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "price": {
                   "centAmount": 5000,
                   "currencyCode": "USD",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": undefined,
               },
@@ -69,18 +65,12 @@ describe('Shipping Method with USA preset', () => {
             "shippingRates": [
               {
                 "freeAbove": {
-                  "__typename": "Money",
                   "centAmount": 100000,
                   "currencyCode": "USD",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "price": {
-                  "__typename": "Money",
                   "centAmount": 5000,
                   "currencyCode": "USD",
-                  "fractionDigits": 2,
-                  "type": "centPrecision",
                 },
                 "tiers": undefined,
               },

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/eur-10000.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/eur-10000.ts
@@ -1,10 +1,10 @@
-import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import { Money } from '@commercetools-test-data/commons';
 import { ShippingRateDraft } from '../../..';
 
 const eur10000 = () =>
   ShippingRateDraft.presets
     .empty()
-    .price(CentPrecisionMoney.random().currencyCode('EUR').centAmount(10000))
+    .price(Money.presets.withCent().currencyCode('EUR').centAmount(10000))
     .tiers([]);
 
 export default eur10000;

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/eur-50000.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/eur-50000.ts
@@ -1,10 +1,10 @@
-import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import { Money } from '@commercetools-test-data/commons';
 import { ShippingRateDraft } from '../../..';
 
 const eur50000 = () =>
   ShippingRateDraft.presets
     .empty()
-    .price(CentPrecisionMoney.random().currencyCode('EUR').centAmount(50000))
+    .price(Money.presets.withCent().currencyCode('EUR').centAmount(50000))
     .tiers([]);
 
 export default eur50000;

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/gbp-10000.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/gbp-10000.ts
@@ -1,10 +1,10 @@
-import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import { Money } from '@commercetools-test-data/commons';
 import { ShippingRateDraft } from '../../..';
 
 const gbp10000 = () =>
   ShippingRateDraft.presets
     .empty()
-    .price(CentPrecisionMoney.random().currencyCode('GBP').centAmount(10000))
+    .price(Money.presets.withCent().currencyCode('GBP').centAmount(10000))
     .tiers([]);
 
 export default gbp10000;

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/gbp-50000.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/gbp-50000.ts
@@ -1,10 +1,10 @@
-import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import { Money } from '@commercetools-test-data/commons';
 import { ShippingRateDraft } from '../../..';
 
 const gbp50000 = () =>
   ShippingRateDraft.presets
     .empty()
-    .price(CentPrecisionMoney.random().currencyCode('GBP').centAmount(50000))
+    .price(Money.presets.withCent().currencyCode('GBP').centAmount(50000))
     .tiers([]);
 
 export default gbp50000;

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/usd-5000.spec.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/usd-5000.spec.ts
@@ -12,14 +12,10 @@ describe('with usd5000 preset', () => {
         "freeAbove": {
           "centAmount": 100000,
           "currencyCode": "USD",
-          "fractionDigits": 2,
-          "type": "centPrecision",
         },
         "price": {
           "centAmount": 5000,
           "currencyCode": "USD",
-          "fractionDigits": 2,
-          "type": "centPrecision",
         },
         "tiers": undefined,
       }
@@ -32,18 +28,12 @@ describe('with usd5000 preset', () => {
     expect(usd5000PresetGraphql).toMatchInlineSnapshot(`
       {
         "freeAbove": {
-          "__typename": "Money",
           "centAmount": 100000,
           "currencyCode": "USD",
-          "fractionDigits": 2,
-          "type": "centPrecision",
         },
         "price": {
-          "__typename": "Money",
           "centAmount": 5000,
           "currencyCode": "USD",
-          "fractionDigits": 2,
-          "type": "centPrecision",
         },
         "tiers": undefined,
       }

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/usd-5000.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/usd-5000.ts
@@ -1,13 +1,11 @@
-import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import { Money } from '@commercetools-test-data/commons';
 import type { TShippingRateDraftBuilder } from '../../../types';
 import * as ShippingRateDraft from '../../index';
 
 const usd5000 = (): TShippingRateDraftBuilder =>
   ShippingRateDraft.presets
     .empty()
-    .price(CentPrecisionMoney.random().currencyCode('USD').centAmount(5000))
-    .freeAbove(
-      CentPrecisionMoney.random().currencyCode('USD').centAmount(100000)
-    );
+    .price(Money.presets.withCent().currencyCode('USD').centAmount(5000))
+    .freeAbove(Money.presets.withCent().currencyCode('USD').centAmount(100000));
 
 export default usd5000;

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-goodstore/europe-express.spec.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-goodstore/europe-express.spec.ts
@@ -12,8 +12,6 @@ describe('with europeExpress preset', () => {
             "price": {
               "centAmount": 50000,
               "currencyCode": "EUR",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },
@@ -22,8 +20,6 @@ describe('with europeExpress preset', () => {
             "price": {
               "centAmount": 50000,
               "currencyCode": "GBP",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },
@@ -45,22 +41,16 @@ describe('with europeExpress preset', () => {
           {
             "freeAbove": undefined,
             "price": {
-              "__typename": "Money",
               "centAmount": 50000,
               "currencyCode": "EUR",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },
           {
             "freeAbove": undefined,
             "price": {
-              "__typename": "Money",
               "centAmount": 50000,
               "currencyCode": "GBP",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-goodstore/europe.spec.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-goodstore/europe.spec.ts
@@ -12,8 +12,6 @@ describe('with europe preset', () => {
             "price": {
               "centAmount": 10000,
               "currencyCode": "EUR",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },
@@ -22,8 +20,6 @@ describe('with europe preset', () => {
             "price": {
               "centAmount": 10000,
               "currencyCode": "GBP",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },
@@ -44,22 +40,16 @@ describe('with europe preset', () => {
           {
             "freeAbove": undefined,
             "price": {
-              "__typename": "Money",
               "centAmount": 10000,
               "currencyCode": "EUR",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },
           {
             "freeAbove": undefined,
             "price": {
-              "__typename": "Money",
               "centAmount": 10000,
               "currencyCode": "GBP",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-goodstore/united-kingdom.spec.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-goodstore/united-kingdom.spec.ts
@@ -12,8 +12,6 @@ describe('with unitedKingdom preset', () => {
             "price": {
               "centAmount": 10000,
               "currencyCode": "GBP",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },
@@ -22,8 +20,6 @@ describe('with unitedKingdom preset', () => {
             "price": {
               "centAmount": 10000,
               "currencyCode": "EUR",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },
@@ -45,22 +41,16 @@ describe('with unitedKingdom preset', () => {
           {
             "freeAbove": undefined,
             "price": {
-              "__typename": "Money",
               "centAmount": 10000,
               "currencyCode": "GBP",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },
           {
             "freeAbove": undefined,
             "price": {
-              "__typename": "Money",
               "centAmount": 10000,
               "currencyCode": "EUR",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": [],
           },

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-goodstore/usa.spec.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-goodstore/usa.spec.ts
@@ -11,14 +11,10 @@ describe('with usa preset', () => {
             "freeAbove": {
               "centAmount": 100000,
               "currencyCode": "USD",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "price": {
               "centAmount": 5000,
               "currencyCode": "USD",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": undefined,
           },
@@ -38,18 +34,12 @@ describe('with usa preset', () => {
         "shippingRates": [
           {
             "freeAbove": {
-              "__typename": "Money",
               "centAmount": 100000,
               "currencyCode": "USD",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "price": {
-              "__typename": "Money",
               "centAmount": 5000,
               "currencyCode": "USD",
-              "fractionDigits": 2,
-              "type": "centPrecision",
             },
             "tiers": undefined,
           },


### PR DESCRIPTION
## Summary

This is a fix identified from an ongoing integration effort