### PR TITLE
chore(test-data): create `AttributeLocalizableTextTypeDraft` model

### DIFF
--- a/.changeset/spotty-maps-hug.md
+++ b/.changeset/spotty-maps-hug.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product-type': patch
+---
+
+create AttributeLocalizableTextTypeDraft model and integrate in goodstore presets

--- a/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/builder.spec.ts
+++ b/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/builder.spec.ts
@@ -1,0 +1,38 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import {
+  TAttributeLocalizableTextTypeDraft,
+  TAttributeLocalizableTextTypeDraftGraphql,
+} from '../types';
+import * as AttributeLocalizableTextTypeDraft from './index';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<
+      TAttributeLocalizableTextTypeDraft,
+      TAttributeLocalizableTextTypeDraft
+    >(
+      'default',
+      AttributeLocalizableTextTypeDraft.random(),
+      expect.objectContaining({
+        name: expect.any(String),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<
+      TAttributeLocalizableTextTypeDraft,
+      TAttributeLocalizableTextTypeDraftGraphql
+    >(
+      'graphql',
+      AttributeLocalizableTextTypeDraft.random(),
+      expect.objectContaining({
+        ltext: {
+          dummy: null,
+        },
+      })
+    )
+  );
+});

--- a/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/builder.ts
+++ b/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import {
+  TAttributeLocalizableTextTypeDraft,
+  TCreateAttributeLocalizableTextTypeDraftBuilder,
+} from '../types';
+import { generator } from './generator';
+import transformers from './transformers';
+
+const Model: TCreateAttributeLocalizableTextTypeDraftBuilder = () =>
+  Builder<TAttributeLocalizableTextTypeDraft>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/generator.ts
+++ b/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/generator.ts
@@ -1,0 +1,10 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TAttributeLocalizableTextTypeDraft } from '../types';
+
+// https://docs.commercetools.com/api/projects/productTypes#attributelocalizabletexttype
+
+export const generator = Generator<TAttributeLocalizableTextTypeDraft>({
+  fields: {
+    name: 'ltext',
+  },
+});

--- a/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/index.ts
+++ b/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/presets/index.ts
+++ b/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/transformers.ts
+++ b/models/product-type/src/attribute-localizable-text-type/attribute-localized-text-type-draft/transformers.ts
@@ -1,0 +1,27 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TAttributeLocalizableTextTypeDraft,
+  TAttributeLocalizableTextTypeDraftGraphql,
+} from '../types';
+
+const transformers = {
+  default: Transformer<
+    TAttributeLocalizableTextTypeDraft,
+    TAttributeLocalizableTextTypeDraft
+  >('default', {
+    buildFields: [],
+  }),
+  graphql: Transformer<
+    TAttributeLocalizableTextTypeDraft,
+    TAttributeLocalizableTextTypeDraftGraphql
+  >('graphql', {
+    buildFields: [],
+    replaceFields: ({ fields }) => ({
+      [fields.name]: {
+        dummy: null,
+      },
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/product-type/src/attribute-localizable-text-type/types.ts
+++ b/models/product-type/src/attribute-localizable-text-type/types.ts
@@ -2,14 +2,25 @@ import { AttributeLocalizableTextType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TAttributeLocalizableTextType = AttributeLocalizableTextType;
+export type TAttributeLocalizableTextTypeDraft = AttributeLocalizableTextType;
 
 export type TAttributeLocalizableTextTypeGraphql =
   TAttributeLocalizableTextType & {
     __typename: 'LocalizableTextAttributeDefinitionType';
   };
 
+export type TAttributeLocalizableTextTypeDraftGraphql = {
+  ltext: {
+    dummy: string | null;
+  };
+};
+
 export type TAttributeLocalizableTextTypeBuilder =
   TBuilder<TAttributeLocalizableTextType>;
+export type TAttributeLocalizableTextTypeDraftBuilder =
+  TBuilder<TAttributeLocalizableTextTypeDraft>;
 
 export type TCreateAttributeLocalizableTextTypeBuilder =
   () => TAttributeLocalizableTextTypeBuilder;
+export type TCreateAttributeLocalizableTextTypeDraftBuilder =
+  () => TAttributeLocalizableTextTypeDraftBuilder;

--- a/models/product-type/src/index.ts
+++ b/models/product-type/src/index.ts
@@ -24,7 +24,7 @@ export * as AttributeLocalizedEnumTypeDraft from './attribute-localized-enum-typ
 export * as AttributeLocalizedEnumValue from './attribute-localized-enum-value';
 export * as AttributeLocalizedEnumValueDraft from './attribute-localized-enum-value/attribute-localized-enum-value-draft';
 export * as AttributeLocalizableTextType from './attribute-localizable-text-type';
-export * as AttributeLocalizableTextDraft from './attribute-localizable-text-type/attribute-localized-text-type-draft';
+export * as AttributeLocalizableTextTypeDraft from './attribute-localizable-text-type/attribute-localized-text-type-draft';
 export * as AttributeSetType from './attribute-set-type';
 export * as AttributeSetTypeDraft from './attribute-set-type/attribute-set-type-draft';
 export * as AttributeReferenceType from './attribute-reference-type';

--- a/models/product-type/src/index.ts
+++ b/models/product-type/src/index.ts
@@ -24,6 +24,7 @@ export * as AttributeLocalizedEnumTypeDraft from './attribute-localized-enum-typ
 export * as AttributeLocalizedEnumValue from './attribute-localized-enum-value';
 export * as AttributeLocalizedEnumValueDraft from './attribute-localized-enum-value/attribute-localized-enum-value-draft';
 export * as AttributeLocalizableTextType from './attribute-localizable-text-type';
+export * as AttributeLocalizableTextDraft from './attribute-localizable-text-type/attribute-localized-text-type-draft';
 export * as AttributeSetType from './attribute-set-type';
 export * as AttributeSetTypeDraft from './attribute-set-type/attribute-set-type-draft';
 export * as AttributeReferenceType from './attribute-reference-type';

--- a/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/bedding-bundle.spec.ts
+++ b/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/bedding-bundle.spec.ts
@@ -120,8 +120,9 @@ describe(`with beddingBundle preset`, () => {
             ],
             "name": "product-description",
             "type": {
-              "__typename": "LocalizableTextAttributeDefinitionType",
-              "name": "ltext",
+              "ltext": {
+                "dummy": null,
+              },
             },
           },
           {
@@ -144,8 +145,9 @@ describe(`with beddingBundle preset`, () => {
             ],
             "name": "product-spec",
             "type": {
-              "__typename": "LocalizableTextAttributeDefinitionType",
-              "name": "ltext",
+              "ltext": {
+                "dummy": null,
+              },
             },
           },
           {

--- a/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/bedding-bundle.ts
+++ b/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/bedding-bundle.ts
@@ -6,7 +6,7 @@ import {
 import { attributeReferenceTypeId } from '../../../../attribute-reference-type/constants';
 import {
   AttributeDefinitionDraft,
-  AttributeLocalizableTextType,
+  AttributeLocalizableTextTypeDraft,
   AttributeReferenceTypeDraft,
   AttributeSetTypeDraft,
 } from '../../../../index';
@@ -23,7 +23,7 @@ const beddingBundle = (): TProductTypeDraftBuilder =>
       AttributeDefinitionDraft.presets
         .empty()
         .name('product-description')
-        .type(AttributeLocalizableTextType.random())
+        .type(AttributeLocalizableTextTypeDraft.random())
         .label(
           LocalizedString.presets
             .empty()
@@ -44,7 +44,7 @@ const beddingBundle = (): TProductTypeDraftBuilder =>
       AttributeDefinitionDraft.presets
         .empty()
         .name('product-spec')
-        .type(AttributeLocalizableTextType.random())
+        .type(AttributeLocalizableTextTypeDraft.random())
         .label(
           LocalizedString.presets
             .empty()

--- a/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/furniture-and-decor.spec.ts
+++ b/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/furniture-and-decor.spec.ts
@@ -421,8 +421,9 @@ describe(`with furnitureAndDecor preset`, () => {
             ],
             "name": "productspec",
             "type": {
-              "__typename": "LocalizableTextAttributeDefinitionType",
-              "name": "ltext",
+              "ltext": {
+                "dummy": null,
+              },
             },
           },
           {
@@ -450,8 +451,9 @@ describe(`with furnitureAndDecor preset`, () => {
             ],
             "name": "color",
             "type": {
-              "__typename": "LocalizableTextAttributeDefinitionType",
-              "name": "ltext",
+              "ltext": {
+                "dummy": null,
+              },
             },
           },
           {
@@ -479,8 +481,9 @@ describe(`with furnitureAndDecor preset`, () => {
             ],
             "name": "finish",
             "type": {
-              "__typename": "LocalizableTextAttributeDefinitionType",
-              "name": "ltext",
+              "ltext": {
+                "dummy": null,
+              },
             },
           },
           {
@@ -508,8 +511,9 @@ describe(`with furnitureAndDecor preset`, () => {
             ],
             "name": "colorlabel",
             "type": {
-              "__typename": "LocalizableTextAttributeDefinitionType",
-              "name": "ltext",
+              "ltext": {
+                "dummy": null,
+              },
             },
           },
           {
@@ -537,8 +541,9 @@ describe(`with furnitureAndDecor preset`, () => {
             ],
             "name": "finishlabel",
             "type": {
-              "__typename": "LocalizableTextAttributeDefinitionType",
-              "name": "ltext",
+              "ltext": {
+                "dummy": null,
+              },
             },
           },
           {
@@ -602,8 +607,9 @@ describe(`with furnitureAndDecor preset`, () => {
             ],
             "name": "size",
             "type": {
-              "__typename": "LocalizableTextAttributeDefinitionType",
-              "name": "ltext",
+              "ltext": {
+                "dummy": null,
+              },
             },
           },
           {
@@ -637,8 +643,9 @@ describe(`with furnitureAndDecor preset`, () => {
             ],
             "name": "product-description",
             "type": {
-              "__typename": "LocalizableTextAttributeDefinitionType",
-              "name": "ltext",
+              "ltext": {
+                "dummy": null,
+              },
             },
           },
           {

--- a/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/furniture-and-decor.ts
+++ b/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/furniture-and-decor.ts
@@ -7,7 +7,7 @@ import {
   AttributeDefinitionDraft,
   AttributeBooleanTypeDraft,
   AttributeLocalizedEnumTypeDraft,
-  AttributeLocalizableTextType,
+  AttributeLocalizableTextTypeDraft,
   AttributeLocalizedEnumValueDraft,
 } from '../../../../index';
 import type { TProductTypeDraftBuilder } from '../../../types';
@@ -25,7 +25,7 @@ const furnitureAndDecor = (): TProductTypeDraftBuilder =>
       AttributeDefinitionDraft.presets
         .empty()
         .name('productspec')
-        .type(AttributeLocalizableTextType.random())
+        .type(AttributeLocalizableTextTypeDraft.random())
         .label(
           LocalizedString.presets
             .empty()
@@ -51,7 +51,7 @@ const furnitureAndDecor = (): TProductTypeDraftBuilder =>
       AttributeDefinitionDraft.presets
         .empty()
         .name('color')
-        .type(AttributeLocalizableTextType.random())
+        .type(AttributeLocalizableTextTypeDraft.random())
         .label(
           LocalizedString.presets
             .empty()
@@ -67,7 +67,7 @@ const furnitureAndDecor = (): TProductTypeDraftBuilder =>
       AttributeDefinitionDraft.presets
         .empty()
         .name('finish')
-        .type(AttributeLocalizableTextType.random())
+        .type(AttributeLocalizableTextTypeDraft.random())
         .label(
           LocalizedString.presets
             .empty()
@@ -83,7 +83,7 @@ const furnitureAndDecor = (): TProductTypeDraftBuilder =>
       AttributeDefinitionDraft.presets
         .empty()
         .name('colorlabel')
-        .type(AttributeLocalizableTextType.random())
+        .type(AttributeLocalizableTextTypeDraft.random())
         .label(
           LocalizedString.presets
             .empty()
@@ -99,7 +99,7 @@ const furnitureAndDecor = (): TProductTypeDraftBuilder =>
       AttributeDefinitionDraft.presets
         .empty()
         .name('finishlabel')
-        .type(AttributeLocalizableTextType.random())
+        .type(AttributeLocalizableTextTypeDraft.random())
         .label(
           LocalizedString.presets
             .empty()
@@ -132,7 +132,7 @@ const furnitureAndDecor = (): TProductTypeDraftBuilder =>
       AttributeDefinitionDraft.presets
         .empty()
         .name('size')
-        .type(AttributeLocalizableTextType.random())
+        .type(AttributeLocalizableTextTypeDraft.random())
         .label(
           LocalizedString.presets.empty()['en-GB']('Size')['en-US']('Size')
         )
@@ -150,7 +150,7 @@ const furnitureAndDecor = (): TProductTypeDraftBuilder =>
       AttributeDefinitionDraft.presets
         .empty()
         .name('product-description')
-        .type(AttributeLocalizableTextType.random())
+        .type(AttributeLocalizableTextTypeDraft.random())
         .label(
           LocalizedString.presets
             .empty()

--- a/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/product-sets.spec.ts
+++ b/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/product-sets.spec.ts
@@ -73,8 +73,9 @@ describe(`with productSets preset`, () => {
             "type": {
               "set": {
                 "elementType": {
-                  "__typename": "LocalizableTextAttributeDefinitionType",
-                  "name": "ltext",
+                  "ltext": {
+                    "dummy": null,
+                  },
                 },
               },
             },

--- a/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/product-sets.ts
+++ b/models/product-type/src/product-type/product-type-draft/presets/sample-data-goodstore/product-sets.ts
@@ -4,7 +4,7 @@ import {
   inputHints,
 } from '../../../../attribute-definition/constants';
 import {
-  AttributeLocalizableTextType,
+  AttributeLocalizableTextTypeDraft,
   AttributeSetTypeDraft,
   AttributeDefinitionDraft,
 } from '../../../../index';
@@ -23,7 +23,7 @@ const productSets = (): TProductTypeDraftBuilder =>
         .name('type')
         .type(
           AttributeSetTypeDraft.random().elementType(
-            AttributeLocalizableTextType.random()
+            AttributeLocalizableTextTypeDraft.random()
           )
         )
         .label(


### PR DESCRIPTION
## Summary

All attribute types had a draft model, except this one. Created it for symmetry and transformed it accordingly to meet the graphql schema's needs.