### PR TITLE
chore(test-data): fix product presets with correct datatypes

### DIFF
--- a/.changeset/nasty-trees-talk.md
+++ b/.changeset/nasty-trees-talk.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product': minor
+---
+
+update goodstore presets with correct datatypes

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/bedding-bundle-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/bedding-bundle-01.spec.ts
@@ -11,7 +11,16 @@ describe(`with beddingBundle01 preset`, () => {
         "attributes": [
           {
             "name": "product-ref",
-            "value": "",
+            "value": [
+              {
+                "key": "ben-pillow-cover",
+                "typeId": "product",
+              },
+              {
+                "key": "modern-three-seater-sofa",
+                "typeId": "product",
+              },
+            ],
           },
         ],
         "images": [],
@@ -31,7 +40,7 @@ describe(`with beddingBundle01 preset`, () => {
         "attributes": [
           {
             "name": "product-ref",
-            "value": """",
+            "value": "[{"typeId":"product","key":"ben-pillow-cover"},{"typeId":"product","key":"modern-three-seater-sofa"}]",
           },
         ],
         "images": [],

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/bedding-bundle-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/bedding-bundle-01.ts
@@ -1,6 +1,9 @@
+import { ProductVariantDraft } from '../../..';
+import { TProductDraft } from '../../../../';
 import { AttributeDraft } from '../../../../attribute';
+import benPillowCover from '../../../../product/product-draft/presets/sample-data-goodstore/ben-pillow-cover';
+import modernThreeSeaterSofa from '../../../../product/product-draft/presets/sample-data-goodstore/modern-three-seater-sofa';
 import type { TProductVariantDraftBuilder } from '../../../types';
-import * as ProductVariantDraft from '../../index';
 
 const beddingBundle01 = (): TProductVariantDraftBuilder =>
   ProductVariantDraft.presets
@@ -9,6 +12,19 @@ const beddingBundle01 = (): TProductVariantDraftBuilder =>
     .key('bed-bundle-1')
     .prices([])
     .images([])
-    .attributes([AttributeDraft.random().name('product-ref').value('')]);
+    .attributes([
+      AttributeDraft.random()
+        .name('product-ref')
+        .value([
+          {
+            typeId: 'product',
+            key: benPillowCover().build<TProductDraft>().key,
+          },
+          {
+            typeId: 'product',
+            key: modernThreeSeaterSofa().build<TProductDraft>().key,
+          },
+        ]),
+    ]);
 
 export default beddingBundle01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/classic-champagne-glasses-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/classic-champagne-glasses-01.spec.ts
@@ -25,7 +25,7 @@ describe(`with classicChampagneGlasses01 preset`, () => {
           },
           {
             "name": "new-arrival",
-            "value": "true",
+            "value": true,
           },
         ],
         "images": [
@@ -120,7 +120,7 @@ describe(`with classicChampagneGlasses01 preset`, () => {
           },
           {
             "name": "new-arrival",
-            "value": ""true"",
+            "value": "true",
           },
         ],
         "images": [

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/classic-champagne-glasses-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/classic-champagne-glasses-01.ts
@@ -48,7 +48,7 @@ const classicChampagneGlasses01 = (): TProductVariantDraftBuilder =>
         'en-GB': '- Set of 5 glasses\n- Premium glass\n- Fragile',
         'de-DE': '- Set aus 5 Gläsern\n- Hochwertiges Glas\n- Zerbrechlich',
       }),
-      AttributeDraft.random().name('new-arrival').value('true'),
+      AttributeDraft.random().name('new-arrival').value(true),
     ]);
 
 export default classicChampagneGlasses01;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.spec.ts
@@ -44,7 +44,7 @@ describe(`with cottonSilkBedsheet01 preset`, () => {
           },
           {
             "name": "new-arrival",
-            "value": "false",
+            "value": false,
           },
           {
             "name": "size",
@@ -148,7 +148,7 @@ describe(`with cottonSilkBedsheet01 preset`, () => {
           },
           {
             "name": "new-arrival",
-            "value": ""false"",
+            "value": "false",
           },
           {
             "name": "size",

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-goodstore/cotton-silk-bedsheet-01.ts
@@ -45,7 +45,7 @@ const cottonSilkBedsheet01 = (): TProductVariantDraftBuilder =>
       AttributeDraft.random()
         .name('color')
         .value({ 'en-GB': '#FFF', 'de-DE': '#FFF', 'en-US': '#FFF' }),
-      AttributeDraft.random().name('new-arrival').value('false'),
+      AttributeDraft.random().name('new-arrival').value(false),
       AttributeDraft.random().name('size').value({ 'en-GB': 'Queen' }),
       AttributeDraft.random()
         .name('color-filter')

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/bedding-bundle.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/bedding-bundle.spec.ts
@@ -24,7 +24,16 @@ describe(`with beddingBundle preset`, () => {
           "attributes": [
             {
               "name": "product-ref",
-              "value": "",
+              "value": [
+                {
+                  "key": "ben-pillow-cover",
+                  "typeId": "product",
+                },
+                {
+                  "key": "modern-three-seater-sofa",
+                  "typeId": "product",
+                },
+              ],
             },
           ],
           "images": [],
@@ -93,7 +102,7 @@ describe(`with beddingBundle preset`, () => {
           "attributes": [
             {
               "name": "product-ref",
-              "value": """",
+              "value": "[{"typeId":"product","key":"ben-pillow-cover"},{"typeId":"product","key":"modern-three-seater-sofa"}]",
             },
           ],
           "images": [],

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-champagne-glasses.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-champagne-glasses.spec.ts
@@ -50,7 +50,7 @@ describe(`with classicChampagneGlasses preset`, () => {
             },
             {
               "name": "new-arrival",
-              "value": "true",
+              "value": true,
             },
           ],
           "images": [
@@ -215,7 +215,7 @@ describe(`with classicChampagneGlasses preset`, () => {
             },
             {
               "name": "new-arrival",
-              "value": ""true"",
+              "value": "true",
             },
           ],
           "images": [

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cotton-silk-bedsheet.spec.ts
@@ -61,7 +61,7 @@ describe(`with cottonSilkBedsheet preset`, () => {
             },
             {
               "name": "new-arrival",
-              "value": "false",
+              "value": false,
             },
             {
               "name": "size",


### PR DESCRIPTION
## Summary

This PR fixes three product presets for goodstore data that were not importing correctly.