### PR TITLE
refactor(ci): for aggregate release mode

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,11 +7,7 @@
     }
   ],
   "commit": false,
-  "fixed": [
-    [
-      "@commercetools-test-data/*"
-    ]
-  ],
+  "fixed": [["@commercetools-test-data/*"]],
   "access": "restricted",
   "baseBranch": "main"
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,6 @@ jobs:
           app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
           private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
 
-      - name: Storing release version for changeset
-        id: release_version
-        run: echo "VALUE=$(./scripts/print_release_version.sh)" >> $GITHUB_OUTPUT
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -32,6 +25,13 @@ jobs:
           # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
           # https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/8
           token: ${{ steps.generate_github_token.outputs.token }}
+
+      - name: Storing release version for changeset
+        id: release_version
+        run: echo "VALUE=$(./scripts/print_release_version.sh)" >> $GITHUB_OUTPUT
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,14 @@ jobs:
         with:
           app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
           private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
-          
+
+      - name: Storing release version for changeset
+        id: release_version
+        run: echo "VALUE=$(./scripts/print_release_version.sh)" >> $GITHUB_OUTPUT
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -55,11 +62,16 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        # We use dotansimha as it supports the aggregate release mode.
+        # uses: changesets/action@v1.3.0
+        uses: dotansimha/changesets-action@v1.5.2
         with:
           publish: pnpm changeset publish
           version: pnpm changeset:version-and-format
           commit: 'ci(changesets): version packages'
+          createGithubReleases: aggregate
+          githubReleaseName: v${{ steps.release_version.outputs.value }}
+          githubTagName: v${{ steps.release_version.outputs.value }}
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
 

--- a/scripts/print_release_version.sh
+++ b/scripts/print_release_version.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Running "changeset version" to know the new release version
+pnpm changeset version &>/dev/null
+
+release_version=$(node -e "console.log(require('./core/package.json').version)")
+
+git reset --hard &>/dev/null
+
+echo "$release_version"


### PR DESCRIPTION
This migrates `test-data` release to the aggregate release mode like App Kit and also flipflip. Recently with many releases and many packages the changelog becomes quite hard to read.

This would cause the releases to be aggregate like [this](https://github.com/commercetools/merchant-center-application-kit/releases/tag/v22.8.2).