### PR TITLE
fix(presets): add keys to payment presets

### DIFF
--- a/.changeset/slimy-mangos-give.md
+++ b/.changeset/slimy-mangos-give.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/payment': patch
+---
+
+Add Keys to Payment presets for Fashion/GoodStore sample data.

--- a/models/payment/package.json
+++ b/models/payment/package.json
@@ -22,6 +22,7 @@
     "@commercetools-test-data/commons": "6.3.3",
     "@commercetools-test-data/customer": "6.3.3",
     "@commercetools-test-data/core": "6.3.3",
+    "@commercetools-test-data/order": "6.3.3",
     "@commercetools-test-data/utils": "6.3.3",
     "@commercetools/platform-sdk": "^6.0.0",
     "@faker-js/faker": "^8.0.0"

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.spec.ts
@@ -3,7 +3,9 @@ import paymentAUS1 from './payment-aus1';
 
 it(`should set all fields to specified values`, () => {
   const paymentDraftAUS2 = paymentAUS1().build<TPaymentDraft>();
-  expect(paymentDraftAUS2.key).toMatchInlineSnapshot(`undefined`);
+  expect(paymentDraftAUS2.key).toMatchInlineSnapshot(
+    `"sample-australia-02-cart"`
+  );
   expect(paymentDraftAUS2.anonymousId).toMatchInlineSnapshot(`undefined`);
   expect(paymentDraftAUS2.interfaceId).toMatchInlineSnapshot(`undefined`);
   expect(paymentDraftAUS2.customer).toMatchInlineSnapshot(`

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus1.ts
@@ -7,6 +7,10 @@ import {
   CustomerDraft,
   type TCustomerDraft,
 } from '@commercetools-test-data/customer';
+import {
+  OrderFromCartDraft,
+  TOrderFromCartDraft,
+} from '@commercetools-test-data/order';
 import * as PaymentDraft from '../..';
 import { PaymentMethodInfoDraft } from '../../../../payment-method-info';
 import { PaymentStatusDraft } from '../../../../payment-status';
@@ -17,9 +21,14 @@ const customerAUS = CustomerDraft.presets.sampleDataFashion
   .sampleAustralia()
   .build<TCustomerDraft>();
 
+const orderAUS2 = OrderFromCartDraft.presets.sampleDataFashion
+  .sampleAustraliaCart02(1)
+  .build<TOrderFromCartDraft>();
+
 const paymentAUS1 = (): TPaymentDraftBuilder =>
   PaymentDraft.presets
     .empty()
+    .key(orderAUS2.cart!.key!)
     .customer(KeyReference.presets.customer().key(customerAUS.key!))
     .amountPlanned(Money.random().centAmount(4075).currencyCode('AUD'))
     .paymentMethodInfo(

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.spec.ts
@@ -3,7 +3,9 @@ import paymentAUS2 from './payment-aus2';
 
 it(`should set all fields to specified values`, () => {
   const paymentDraftAUS2 = paymentAUS2().build<TPaymentDraft>();
-  expect(paymentDraftAUS2.key).toMatchInlineSnapshot(`undefined`);
+  expect(paymentDraftAUS2.key).toMatchInlineSnapshot(
+    `"sample-australia-02-cart_1"`
+  );
   expect(paymentDraftAUS2.anonymousId).toMatchInlineSnapshot(`undefined`);
   expect(paymentDraftAUS2.interfaceId).toMatchInlineSnapshot(`undefined`);
   expect(paymentDraftAUS2.customer).toMatchInlineSnapshot(`

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-aus2.ts
@@ -7,6 +7,10 @@ import {
   CustomerDraft,
   type TCustomerDraft,
 } from '@commercetools-test-data/customer';
+import {
+  OrderFromCartDraft,
+  TOrderFromCartDraft,
+} from '@commercetools-test-data/order';
 import * as PaymentDraft from '../..';
 import { PaymentMethodInfoDraft } from '../../../../payment-method-info';
 import { PaymentStatusDraft } from '../../../../payment-status';
@@ -17,9 +21,14 @@ const customerAUS = CustomerDraft.presets.sampleDataFashion
   .sampleAustralia()
   .build<TCustomerDraft>();
 
+const orderAUS2 = OrderFromCartDraft.presets.sampleDataFashion
+  .sampleAustraliaCart02(1)
+  .build<TOrderFromCartDraft>();
+
 const paymentAUS2 = (): TPaymentDraftBuilder =>
   PaymentDraft.presets
     .empty()
+    .key(orderAUS2.cart!.key! + '_1')
     .customer(KeyReference.presets.customer().key(customerAUS.key!))
     .amountPlanned(Money.random().centAmount(4000).currencyCode('AUD'))
     .paymentMethodInfo(

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.spec.ts
@@ -3,7 +3,7 @@ import paymentUSA from './payment-usa';
 
 it(`should set all fields to specified values`, () => {
   const paymentUSADraft = paymentUSA().build<TPaymentDraft>();
-  expect(paymentUSADraft.key).toMatchInlineSnapshot(`undefined`);
+  expect(paymentUSADraft.key).toMatchInlineSnapshot(`"sample-usa-01-cart"`);
   expect(paymentUSADraft.anonymousId).toMatchInlineSnapshot(`undefined`);
   expect(paymentUSADraft.interfaceId).toMatchInlineSnapshot(`undefined`);
   expect(paymentUSADraft.customer).toMatchInlineSnapshot(`

--- a/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-fashion/payment-usa.ts
@@ -7,6 +7,10 @@ import {
   CustomerDraft,
   type TCustomerDraft,
 } from '@commercetools-test-data/customer';
+import {
+  OrderFromCartDraft,
+  TOrderFromCartDraft,
+} from '@commercetools-test-data/order';
 import * as PaymentDraft from '../..';
 import { PaymentMethodInfoDraft } from '../../../../payment-method-info';
 import { PaymentStatusDraft } from '../../../../payment-status';
@@ -17,9 +21,14 @@ const customerUSA = CustomerDraft.presets.sampleDataFashion
   .sampleUsa()
   .build<TCustomerDraft>();
 
+const orderUS = OrderFromCartDraft.presets.sampleDataFashion
+  .sampleUsaCart01(1)
+  .build<TOrderFromCartDraft>();
+
 const paymentUSA = (): TPaymentDraftBuilder =>
   PaymentDraft.presets
     .empty()
+    .key(orderUS.cart!.key!)
     .customer(KeyReference.presets.customer().key(customerUSA.key!))
     .amountPlanned(Money.random().centAmount(32348).currencyCode('USD'))
     .paymentMethodInfo(

--- a/models/payment/src/payment/payment-draft/presets/sample-data-goodstore/jennifer-jones-payment.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-goodstore/jennifer-jones-payment.spec.ts
@@ -19,7 +19,7 @@ describe(`with jenniferJonesPayment preset`, () => {
         },
         "interfaceId": undefined,
         "interfaceInteractions": undefined,
-        "key": undefined,
+        "key": "jennifer-jones-01",
         "paymentMethodInfo": {
           "method": "Debit Card",
           "name": {
@@ -81,7 +81,7 @@ describe(`with jenniferJonesPayment preset`, () => {
         },
         "interfaceId": undefined,
         "interfaceInteractions": undefined,
-        "key": undefined,
+        "key": "jennifer-jones-01",
         "paymentMethodInfo": {
           "method": "Debit Card",
           "name": {

--- a/models/payment/src/payment/payment-draft/presets/sample-data-goodstore/jennifer-jones-payment.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-goodstore/jennifer-jones-payment.ts
@@ -7,6 +7,10 @@ import {
   CustomerDraft,
   type TCustomerDraft,
 } from '@commercetools-test-data/customer';
+import {
+  OrderFromCartDraft,
+  TOrderFromCartDraft,
+} from '@commercetools-test-data/order';
 import * as PaymentDraft from '../..';
 import { PaymentMethodInfoDraft } from '../../../../payment-method-info';
 import { PaymentStatusDraft } from '../../../../payment-status';
@@ -17,9 +21,14 @@ const customerJenniferJones = CustomerDraft.presets.sampleDataGoodStore
   .jenniferJones()
   .build<TCustomerDraft>();
 
+const orderJenniferJones = OrderFromCartDraft.presets.sampleDataGoodStore
+  .jenniferJonesCart01(1)
+  .build<TOrderFromCartDraft>();
+
 const jenniferJonesPayment = (): TPaymentDraftBuilder =>
   PaymentDraft.presets
     .empty()
+    .key(orderJenniferJones.cart!.key!)
     .customer(KeyReference.presets.customer().key(customerJenniferJones.key!))
     .amountPlanned(Money.random().centAmount(485759).currencyCode('GBP'))
     .paymentMethodInfo(

--- a/models/payment/src/payment/payment-draft/presets/sample-data-goodstore/sebastian-mueller-payment.spec.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-goodstore/sebastian-mueller-payment.spec.ts
@@ -19,7 +19,7 @@ describe(`with sebastianMuellerPayment preset`, () => {
         },
         "interfaceId": undefined,
         "interfaceInteractions": undefined,
-        "key": undefined,
+        "key": "sebastian-mueller-01",
         "paymentMethodInfo": {
           "method": "Credit Card",
           "name": {
@@ -81,7 +81,7 @@ describe(`with sebastianMuellerPayment preset`, () => {
         },
         "interfaceId": undefined,
         "interfaceInteractions": undefined,
-        "key": undefined,
+        "key": "sebastian-mueller-01",
         "paymentMethodInfo": {
           "method": "Credit Card",
           "name": {

--- a/models/payment/src/payment/payment-draft/presets/sample-data-goodstore/sebastian-mueller-payment.ts
+++ b/models/payment/src/payment/payment-draft/presets/sample-data-goodstore/sebastian-mueller-payment.ts
@@ -7,6 +7,10 @@ import {
   CustomerDraft,
   type TCustomerDraft,
 } from '@commercetools-test-data/customer';
+import {
+  OrderFromCartDraft,
+  TOrderFromCartDraft,
+} from '@commercetools-test-data/order';
 import * as PaymentDraft from '../..';
 import { PaymentMethodInfoDraft } from '../../../../payment-method-info';
 import { PaymentStatusDraft } from '../../../../payment-status';
@@ -17,9 +21,14 @@ const customerSebastianMueller = CustomerDraft.presets.sampleDataGoodStore
   .sebastianMuller()
   .build<TCustomerDraft>();
 
+const orderSebastianMueller = OrderFromCartDraft.presets.sampleDataGoodStore
+  .sebastianMuellerCart01(1)
+  .build<TOrderFromCartDraft>();
+
 const sebastianMuellerPayment = (): TPaymentDraftBuilder =>
   PaymentDraft.presets
     .empty()
+    .key(orderSebastianMueller.cart!.key!)
     .customer(
       KeyReference.presets.customer().key(customerSebastianMueller.key!)
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       '@commercetools-test-data/customer':
         specifier: 6.3.3
         version: link:../customer
+      '@commercetools-test-data/order':
+        specifier: 6.3.2
+        version: link:../order
       '@commercetools-test-data/utils':
         specifier: 6.3.3
         version: link:../../utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,9 +440,6 @@ importers:
       '@commercetools-test-data/customer':
         specifier: 6.3.3
         version: link:../customer
-      '@commercetools-test-data/order':
-        specifier: 6.3.2
-        version: link:../order
       '@commercetools-test-data/utils':
         specifier: 6.3.3
         version: link:../../utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       '@commercetools-test-data/customer':
         specifier: 6.3.3
         version: link:../customer
+      '@commercetools-test-data/order':
+        specifier: 6.3.3
+        version: link:../order
       '@commercetools-test-data/utils':
         specifier: 6.3.3
         version: link:../../utils


### PR DESCRIPTION
This PR adds keys to `PaymentDraft` presets for both Fashion and GoodStore sample data - this will simplify the process of assigning payments to orders in the import resolver. 