### PR TITLE
chore(test-data): deactivate goodstore discount presets

### DIFF
--- a/.changeset/tiny-dragons-care.md
+++ b/.changeset/tiny-dragons-care.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-test-data/product-discount': patch
+'@commercetools-test-data/cart-discount': patch
+'@commercetools-test-data/discount-code': patch
+---
+
+deactivate goodstore discounts

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/free-shipping.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/free-shipping.spec.ts
@@ -19,7 +19,7 @@ describe('with the preset `freeShipping`', () => {
           "en-US": "Free shipping when your order is at least 100 GBP",
           "fr": undefined,
         },
-        "isActive": true,
+        "isActive": false,
         "key": "FreeShip100",
         "name": {
           "de": undefined,
@@ -64,7 +64,7 @@ describe('with the preset `freeShipping`', () => {
             "value": "Free shipping when your order is at least 100 GBP",
           },
         ],
-        "isActive": true,
+        "isActive": false,
         "key": "FreeShip100",
         "name": [
           {

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/free-shipping.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/free-shipping.ts
@@ -26,7 +26,7 @@ const freeShipping = (): TCartDiscountDraftBuilder =>
         ['en-GB']('Free shipping when your order is at least 100 GBP')
     )
     .stackingMode(stackingMode.Stacking)
-    .isActive(true)
+    .isActive(false)
     .requiresDiscountCode(false)
     .sortOrder('0.22')
     .key('FreeShip100');

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/furniture-bogo.spec.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/furniture-bogo.spec.ts
@@ -19,7 +19,7 @@ describe('with the preset `furnitureBogo`', () => {
           "en-US": "Two for one on all furniture items (discount on the cheapest item)",
           "fr": undefined,
         },
-        "isActive": true,
+        "isActive": false,
         "key": "FurnitureBOGO",
         "name": {
           "de": undefined,
@@ -69,7 +69,7 @@ describe('with the preset `furnitureBogo`', () => {
             "value": "Two for one on all furniture items (discount on the cheapest item)",
           },
         ],
-        "isActive": true,
+        "isActive": false,
         "key": "FurnitureBOGO",
         "name": [
           {

--- a/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/furniture-bogo.ts
+++ b/models/cart-discount/src/cart-discount/cart-discount-draft/presets/sample-data-goodstore/furniture-bogo.ts
@@ -46,7 +46,7 @@ const furnitureBogo = (): TCartDiscountDraftBuilder =>
         )
     )
     .stackingMode(stackingMode.Stacking)
-    .isActive(true)
+    .isActive(false)
     .requiresDiscountCode(true)
     .sortOrder('0.15')
     .key('FurnitureBOGO');

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-goodstore/furniture-bogo.spec.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-goodstore/furniture-bogo.spec.ts
@@ -24,7 +24,7 @@ describe('with the preset `furnitureBogo`', () => {
           "fr": undefined,
         },
         "groups": [],
-        "isActive": true,
+        "isActive": false,
         "maxApplications": 1,
         "maxApplicationsPerCustomer": 1,
         "name": {
@@ -59,7 +59,7 @@ describe('with the preset `furnitureBogo`', () => {
         "custom": undefined,
         "description": [],
         "groups": [],
-        "isActive": true,
+        "isActive": false,
         "maxApplications": 1,
         "maxApplicationsPerCustomer": 1,
         "name": [

--- a/models/discount-code/src/discount-code-draft/presets/sample-data-goodstore/furniture-bogo.ts
+++ b/models/discount-code/src/discount-code-draft/presets/sample-data-goodstore/furniture-bogo.ts
@@ -11,7 +11,7 @@ const furnitureBogo = (cartDiscountId: string): TDiscountCodeDraftBuilder =>
     .cartDiscounts([
       Reference.random().id(cartDiscountId).typeId('cart-discount'),
     ])
-    .isActive(true)
+    .isActive(false)
     .maxApplications(1)
     .maxApplicationsPerCustomer(1)
     .groups([]);

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-bakeware.spec.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-bakeware.spec.ts
@@ -18,7 +18,7 @@ describe('with the preset `discountBakeware`', () => {
           "en-US": "5 EUR Off All Bakeware Items",
           "fr": undefined,
         },
-        "isActive": true,
+        "isActive": false,
         "key": "Bakeware5EUROff",
         "name": {
           "de": undefined,
@@ -62,7 +62,7 @@ describe('with the preset `discountBakeware`', () => {
             "value": "5 EUR Off All Bakeware Items",
           },
         ],
-        "isActive": true,
+        "isActive": false,
         "key": "Bakeware5EUROff",
         "name": [
           {

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-bakeware.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-bakeware.ts
@@ -32,7 +32,7 @@ const discountBakeware = (): TProductDiscountDraftBuilder =>
         ['en-US']('5 EUR Off All Bakeware Items')
         ['en-GB']('5 EUR Off All Bakeware Items')
     )
-    .isActive(true)
+    .isActive(false)
     .sortOrder('0.5')
     .key('Bakeware5EUROff');
 

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-furniture-and-decor.spec.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-furniture-and-decor.spec.ts
@@ -18,7 +18,7 @@ describe('with the preset `discountFurnitureAndDecor`', () => {
           "en-US": "10 USD Off All Furniture & Decor",
           "fr": undefined,
         },
-        "isActive": true,
+        "isActive": false,
         "key": "FurnitureDecor10USDOff",
         "name": {
           "de": undefined,
@@ -62,7 +62,7 @@ describe('with the preset `discountFurnitureAndDecor`', () => {
             "value": "10 USD Off All Furniture & Decor",
           },
         ],
-        "isActive": true,
+        "isActive": false,
         "key": "FurnitureDecor10USDOff",
         "name": [
           {

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-furniture-and-decor.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-furniture-and-decor.ts
@@ -32,7 +32,7 @@ const discountFurnitureAndDecor = (): TProductDiscountDraftBuilder =>
         ['en-US']('10 USD Off All Furniture & Decor')
         ['en-GB']('10 USD Off All Furniture & Decor')
     )
-    .isActive(true)
+    .isActive(false)
     .sortOrder('0.2')
     .key('FurnitureDecor10USDOff');
 

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-new-arrivals.spec.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-new-arrivals.spec.ts
@@ -18,7 +18,7 @@ describe('with the preset `discountNewArrivals`', () => {
           "en-US": "15% Off All New Arrivals",
           "fr": undefined,
         },
-        "isActive": true,
+        "isActive": false,
         "key": "NewArrivals15pctOff",
         "name": {
           "de": undefined,
@@ -57,7 +57,7 @@ describe('with the preset `discountNewArrivals`', () => {
             "value": "15% Off All New Arrivals",
           },
         ],
-        "isActive": true,
+        "isActive": false,
         "key": "NewArrivals15pctOff",
         "name": [
           {

--- a/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-new-arrivals.ts
+++ b/models/product-discount/src/product-discount/product-discount-draft/presets/sample-data-goodstore/discount-new-arrivals.ts
@@ -20,7 +20,7 @@ const discountNewArrivals = (): TProductDiscountDraftBuilder =>
         ['en-US']('15% Off All New Arrivals')
         ['en-GB']('15% Off All New Arrivals')
     )
-    .isActive(true)
+    .isActive(false)
     .sortOrder('0.67')
     .key('NewArrivals15pctOff');
 


### PR DESCRIPTION
## Summary

Flip flopping into deactivated discounts to ensure we can create our data error-free.