### PR TITLE
Remove status from custom view draft

### DIFF
--- a/.changeset/eleven-turkeys-cry.md
+++ b/.changeset/eleven-turkeys-cry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/custom-view': patch
+---
+
+Remove status from custom view draft

--- a/models/custom-view/src/custom-view/custom-view-draft/builder.spec.ts
+++ b/models/custom-view/src/custom-view/custom-view-draft/builder.spec.ts
@@ -24,7 +24,6 @@ describe('builder', () => {
             oAuthScopes: expect.arrayContaining([expect.any(String)]),
           }),
         ]),
-        status: 'DRAFT',
         type: 'CustomPanel',
         typeSettings: expect.objectContaining({
           size: expect.stringMatching(/^(SMALL|LARGE)$/),
@@ -52,7 +51,6 @@ describe('builder', () => {
             oAuthScopes: expect.arrayContaining([expect.any(String)]),
           }),
         ]),
-        status: 'DRAFT',
         type: 'CustomPanel',
         typeSettings: expect.objectContaining({
           size: expect.stringMatching(/^(SMALL|LARGE)$/),

--- a/models/custom-view/src/custom-view/custom-view-draft/generator.ts
+++ b/models/custom-view/src/custom-view/custom-view-draft/generator.ts
@@ -21,7 +21,6 @@ const generator = Generator<TCustomViewDraft>({
       CustomViewPermission.presets.ViewOnlyPermissions(),
       CustomViewPermission.presets.ManageOnlyPermissions(),
     ]),
-    status: 'DRAFT',
     type: fake((f) => f.helpers.arrayElement(['CustomPanel'])),
     typeSettings: fake((f) => CustomViewTypeSettings.random()),
   },

--- a/models/custom-view/src/custom-view/types.ts
+++ b/models/custom-view/src/custom-view/types.ts
@@ -64,7 +64,7 @@ export type TCustomViewGraphql = TCustomView & {
 
 export type TCustomViewDraft = Omit<
   TCustomView,
-  'id' | 'createdAt' | 'updatedAt' | 'ownerId'
+  'id' | 'createdAt' | 'updatedAt' | 'ownerId' | 'status'
 >;
 export type TCustomViewDraftGraphql = TCustomViewDraft & {
   __typename: 'CustomViewDraftDataInput';


### PR DESCRIPTION
### Summary

We don't need to have status in the customViewDraft. 

See the [CustomViewDraftDataInput](https://github.com/commercetools/merchant-center-services/blob/0edc1501facd3a24501dfacae65aed7197671168/packages/settings/lib/schemas/custom-view.graphql#L135) in the schema
