### PR TITLE
chore(business-unit): add typename fields to graphql transformers

### DIFF
--- a/.changeset/five-shirts-shout.md
+++ b/.changeset/five-shirts-shout.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/business-unit': minor
+---
+
+Added typename fields to graphql transformers

--- a/models/business-unit/src/company/transformers.ts
+++ b/models/business-unit/src/company/transformers.ts
@@ -12,6 +12,9 @@ const transformers = {
   //only scaffolding provided at this time
   graphql: Transformer<TBusinessUnit, TBusinessUnitGraphql>('graphql', {
     buildFields: [],
+    addFields: () => ({
+      __typename: 'BusinessUnit',
+    }),
   }),
 };
 

--- a/models/business-unit/src/division/transformers.ts
+++ b/models/business-unit/src/division/transformers.ts
@@ -11,6 +11,9 @@ const transformers = {
   //only scaffolding provided at this time
   graphql: Transformer<TBusinessUnit, TBusinessUnitGraphql>('graphql', {
     buildFields: [],
+    addFields: () => ({
+      __typename: 'BusinessUnit',
+    }),
   }),
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -11838,3 +11834,7 @@ packages:
   /zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
This adds the typename fields to the transformers of Division and Company. Thus enabling us to use it in our graphql based tests.