### PR TITLE
chore(business-unit): graphql transformers for Company and Division models

### DIFF
--- a/.changeset/popular-falcons-share.md
+++ b/.changeset/popular-falcons-share.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/business-unit': minor
+---
+
+Replaced graphql scaffolding with real implementation for Company and Division

--- a/models/business-unit/src/company/builder.spec.ts
+++ b/models/business-unit/src/company/builder.spec.ts
@@ -2,12 +2,12 @@
 /* eslint-disable jest/valid-title */
 
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import type { TBusinessUnit, TBusinessUnitGraphql } from '../types';
+import type { TCompany, TCompanyGraphql } from '../types';
 import * as BusinessUnit from './index';
 
 describe('builder', () => {
   it(
-    ...createBuilderSpec<TBusinessUnit, TBusinessUnit>(
+    ...createBuilderSpec<TCompany, TCompany>(
       'default',
       BusinessUnit.random(),
       expect.objectContaining({
@@ -43,7 +43,7 @@ describe('builder', () => {
   );
 
   it(
-    ...createBuilderSpec<TBusinessUnit, TBusinessUnit>(
+    ...createBuilderSpec<TCompany, TCompany>(
       'rest',
       BusinessUnit.random(),
       expect.objectContaining({
@@ -79,7 +79,7 @@ describe('builder', () => {
   );
 
   it(
-    ...createBuilderSpec<TBusinessUnit, TBusinessUnitGraphql>(
+    ...createBuilderSpec<TCompany, TCompanyGraphql>(
       'graphql',
       BusinessUnit.random(),
       expect.objectContaining({

--- a/models/business-unit/src/company/builder.spec.ts
+++ b/models/business-unit/src/company/builder.spec.ts
@@ -2,7 +2,7 @@
 /* eslint-disable jest/valid-title */
 
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import type { TBusinessUnit } from '../types';
+import type { TBusinessUnit, TBusinessUnitGraphql } from '../types';
 import * as BusinessUnit from './index';
 
 describe('builder', () => {
@@ -77,5 +77,55 @@ describe('builder', () => {
       })
     )
   );
-  // test for the graphql shape not added at this time
+
+  it(
+    ...createBuilderSpec<TBusinessUnit, TBusinessUnitGraphql>(
+      'graphql',
+      BusinessUnit.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        key: expect.any(String),
+        status: expect.any(String),
+        storesRef: expect.objectContaining({
+          typeId: 'store',
+        }),
+        stores: [],
+        storeMode: expect.any(String),
+        unitType: 'Company',
+        name: expect.any(String),
+        contactEmail: expect.any(String),
+        addresses: expect.any(Array),
+        shippingAddressIds: [],
+        defaultShippingAddressId: null,
+        billingAddressIds: [],
+        defaultBillingAddressId: null,
+        associateMode: expect.any(String),
+        associates: expect.any(Array),
+        inheritedAssociates: expect.any(Array),
+        parentUnitRef: null,
+        parentUnit: null,
+        topLevelUnitRef: expect.objectContaining({
+          typeId: 'business-unit',
+        }),
+        topLevelUnit: expect.objectContaining({
+          __typename: 'BusinessUnit',
+        }),
+        custom: null,
+        createdAt: expect.any(String),
+        createdBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+          userRef: expect.objectContaining({ typeId: 'user' }),
+        }),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+          userRef: expect.objectContaining({ typeId: 'user' }),
+        }),
+        ancestors: expect.any(Array),
+        inheritedStores: null,
+        __typename: 'BusinessUnit',
+      })
+    )
+  );
 });

--- a/models/business-unit/src/company/builder.ts
+++ b/models/business-unit/src/company/builder.ts
@@ -1,10 +1,10 @@
 import { Builder } from '@commercetools-test-data/core';
-import type { TCreateBusinessUnitBuilder, TBusinessUnit } from '../types';
+import type { TCreateCompanyBuilder, TCompany } from '../types';
 import generator from './generator';
 import transformers from './transformers';
 
-const Model: TCreateBusinessUnitBuilder = () =>
-  Builder<TBusinessUnit>({
+const Model: TCreateCompanyBuilder = () =>
+  Builder<TCompany>({
     generator,
     transformers,
   });

--- a/models/business-unit/src/company/company-draft/builder.spec.ts
+++ b/models/business-unit/src/company/company-draft/builder.spec.ts
@@ -2,14 +2,14 @@
 /* eslint-disable jest/valid-title */
 
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import type { TBusinessUnitDraft } from '../../types';
-import * as BusinessUnitDraft from './index';
+import type { TCompanyDraft } from '../../types';
+import * as CompanyDraft from './index';
 
 describe('builder', () => {
   it(
-    ...createBuilderSpec<TBusinessUnitDraft, TBusinessUnitDraft>(
+    ...createBuilderSpec<TCompanyDraft, TCompanyDraft>(
       'default',
-      BusinessUnitDraft.random(),
+      CompanyDraft.random(),
       expect.objectContaining({
         key: expect.any(String),
         status: expect.any(String),
@@ -31,9 +31,9 @@ describe('builder', () => {
   );
 
   it(
-    ...createBuilderSpec<TBusinessUnitDraft, TBusinessUnitDraft>(
+    ...createBuilderSpec<TCompanyDraft, TCompanyDraft>(
       'rest',
-      BusinessUnitDraft.random(),
+      CompanyDraft.random(),
       expect.objectContaining({
         key: expect.any(String),
         status: expect.any(String),

--- a/models/business-unit/src/company/company-draft/builder.ts
+++ b/models/business-unit/src/company/company-draft/builder.ts
@@ -1,13 +1,10 @@
 import { Builder } from '@commercetools-test-data/core';
-import type {
-  TCreateBusinessUnitDraftBuilder,
-  TBusinessUnitDraft,
-} from '../../types';
+import type { TCreateCompanyDraftBuilder, TCompanyDraft } from '../../types';
 import generator from './generator';
 import transformers from './transformers';
 
-const Model: TCreateBusinessUnitDraftBuilder = () =>
-  Builder<TBusinessUnitDraft>({
+const Model: TCreateCompanyDraftBuilder = () =>
+  Builder<TCompanyDraft>({
     generator,
     transformers,
   });

--- a/models/business-unit/src/company/company-draft/generator.ts
+++ b/models/business-unit/src/company/company-draft/generator.ts
@@ -1,11 +1,11 @@
 import { AddressDraft } from '@commercetools-test-data/commons';
 import { fake, Generator, oneOf } from '@commercetools-test-data/core';
 import { status, storeMode, unitType, associateMode } from '../../constants';
-import type { TBusinessUnitDraft } from '../../types';
+import type { TCompanyDraft } from '../../types';
 
 // https://docs.commercetools.com/api/projects/business-units#companydraft
 
-const generator = Generator<TBusinessUnitDraft>({
+const generator = Generator<TCompanyDraft>({
   fields: {
     key: fake((f) => f.lorem.slug(2)),
     status: oneOf(...Object.values(status)),

--- a/models/business-unit/src/company/company-draft/transformers.ts
+++ b/models/business-unit/src/company/company-draft/transformers.ts
@@ -1,21 +1,17 @@
 import { Transformer } from '@commercetools-test-data/core';
-import type {
-  TBusinessUnitDraft,
-  TBusinessUnitDraftGraphql,
-} from '../../types';
+import type { TCompanyDraft, TCompanyDraftGraphql } from '../../types';
 
 const transformers = {
-  default: Transformer<TBusinessUnitDraft, TBusinessUnitDraft>('default', {
+  default: Transformer<TCompanyDraft, TCompanyDraft>('default', {
     buildFields: ['addresses'],
   }),
-  rest: Transformer<TBusinessUnitDraft, TBusinessUnitDraft>('rest', {
+  rest: Transformer<TCompanyDraft, TCompanyDraft>('rest', {
     buildFields: ['addresses'],
   }),
   //only scaffolding provided at this time
-  graphql: Transformer<TBusinessUnitDraft, TBusinessUnitDraftGraphql>(
-    'graphql',
-    { buildFields: [] }
-  ),
+  graphql: Transformer<TCompanyDraft, TCompanyDraftGraphql>('graphql', {
+    buildFields: [],
+  }),
 };
 
 export default transformers;

--- a/models/business-unit/src/company/generator.ts
+++ b/models/business-unit/src/company/generator.ts
@@ -11,13 +11,13 @@ import {
 } from '@commercetools-test-data/core';
 import { createRelatedDates } from '@commercetools-test-data/utils';
 import { status, storeMode, unitType, associateMode } from '../constants';
-import type { TBusinessUnit } from '../types';
+import type { TCompany } from '../types';
 
 const [getOlderDate, getNewerDate] = createRelatedDates();
 
 // https://docs.commercetools.com/api/projects/business-units#company
 
-const generator = Generator<TBusinessUnit>({
+const generator = Generator<TCompany>({
   fields: {
     id: fake((f) => f.string.uuid()),
     version: sequence(),

--- a/models/business-unit/src/company/generator.ts
+++ b/models/business-unit/src/company/generator.ts
@@ -36,6 +36,7 @@ const generator = Generator<TBusinessUnit>({
     associateMode: associateMode.Explicit,
     associates: [],
     inheritedAssociates: [],
+    parentUnit: null,
     topLevelUnit: KeyReference.random().typeId('business-unit'),
     custom: null,
     createdAt: fake(getOlderDate),

--- a/models/business-unit/src/company/transformers.ts
+++ b/models/business-unit/src/company/transformers.ts
@@ -3,16 +3,20 @@ import type { TBusinessUnit, TBusinessUnitGraphql } from '../types';
 
 const transformers = {
   default: Transformer<TBusinessUnit, TBusinessUnit>('default', {
-    buildFields: ['addresses', 'createdBy', 'lastModifiedBy'],
+    buildFields: ['addresses', 'createdBy', 'lastModifiedBy', 'topLevelUnit'],
   }),
   rest: Transformer<TBusinessUnit, TBusinessUnit>('rest', {
-    buildFields: ['addresses', 'createdBy', 'lastModifiedBy'],
+    buildFields: ['addresses', 'createdBy', 'lastModifiedBy', 'topLevelUnit'],
   }),
-
-  //only scaffolding provided at this time
   graphql: Transformer<TBusinessUnit, TBusinessUnitGraphql>('graphql', {
-    buildFields: [],
-    addFields: () => ({
+    buildFields: ['addresses', 'createdBy', 'lastModifiedBy'],
+    replaceFields: ({ fields }) => ({
+      ...fields,
+      topLevelUnit: {
+        ...fields,
+      },
+      ancestors: [],
+      inheritedStores: null,
       __typename: 'BusinessUnit',
     }),
   }),

--- a/models/business-unit/src/company/transformers.ts
+++ b/models/business-unit/src/company/transformers.ts
@@ -1,22 +1,19 @@
 import { KeyReference } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
-import type { TBusinessUnit, TBusinessUnitGraphql } from '../types';
+import type { TCompany, TCompanyGraphql } from '../types';
 
 const transformers = {
-  default: Transformer<TBusinessUnit, TBusinessUnit>('default', {
+  default: Transformer<TCompany, TCompany>('default', {
     buildFields: ['addresses', 'createdBy', 'lastModifiedBy', 'topLevelUnit'],
   }),
-  rest: Transformer<TBusinessUnit, TBusinessUnit>('rest', {
+  rest: Transformer<TCompany, TCompany>('rest', {
     buildFields: ['addresses', 'createdBy', 'lastModifiedBy', 'topLevelUnit'],
   }),
-  graphql: Transformer<
-    TBusinessUnit | TBusinessUnitGraphql,
-    TBusinessUnitGraphql
-  >('graphql', {
+  graphql: Transformer<TCompany | TCompanyGraphql, TCompanyGraphql>('graphql', {
     buildFields: ['addresses', 'createdBy', 'lastModifiedBy'],
     replaceFields: ({ fields }) => {
       return {
-        ...(fields as TBusinessUnit),
+        ...(fields as TCompany),
         storesRef: KeyReference.random().typeId('store').buildGraphql(),
         parentUnitRef: null,
         topLevelUnitRef: KeyReference.random()
@@ -27,7 +24,7 @@ const transformers = {
           fields.topLevelUnit && 'id' in fields.topLevelUnit
             ? fields.topLevelUnit
             : {
-                ...(fields as TBusinessUnit),
+                ...(fields as TCompany),
                 __typename: 'BusinessUnit',
               },
         ancestors:

--- a/models/business-unit/src/company/transformers.ts
+++ b/models/business-unit/src/company/transformers.ts
@@ -1,3 +1,4 @@
+import { KeyReference } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type { TBusinessUnit, TBusinessUnitGraphql } from '../types';
 
@@ -8,17 +9,36 @@ const transformers = {
   rest: Transformer<TBusinessUnit, TBusinessUnit>('rest', {
     buildFields: ['addresses', 'createdBy', 'lastModifiedBy', 'topLevelUnit'],
   }),
-  graphql: Transformer<TBusinessUnit, TBusinessUnitGraphql>('graphql', {
+  graphql: Transformer<
+    TBusinessUnit | TBusinessUnitGraphql,
+    TBusinessUnitGraphql
+  >('graphql', {
     buildFields: ['addresses', 'createdBy', 'lastModifiedBy'],
-    replaceFields: ({ fields }) => ({
-      ...fields,
-      topLevelUnit: {
-        ...fields,
-      },
-      ancestors: [],
-      inheritedStores: null,
-      __typename: 'BusinessUnit',
-    }),
+    replaceFields: ({ fields }) => {
+      return {
+        ...(fields as TBusinessUnit),
+        storesRef: KeyReference.random().typeId('store').buildGraphql(),
+        parentUnitRef: null,
+        topLevelUnitRef: KeyReference.random()
+          .typeId('business-unit')
+          .key(fields.key)
+          .buildGraphql(),
+        topLevelUnit:
+          fields.topLevelUnit && 'id' in fields.topLevelUnit
+            ? fields.topLevelUnit
+            : {
+                ...(fields as TBusinessUnit),
+                __typename: 'BusinessUnit',
+              },
+        ancestors:
+          'ancestors' in fields && fields.ancestors ? fields.ancestors : [],
+        inheritedStores:
+          'inheritedStores' in fields && fields.inheritedStores
+            ? fields.inheritedStores
+            : null,
+        __typename: 'BusinessUnit',
+      };
+    },
   }),
 };
 

--- a/models/business-unit/src/division/builder.spec.ts
+++ b/models/business-unit/src/division/builder.spec.ts
@@ -2,7 +2,7 @@
 /* eslint-disable jest/valid-title */
 
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import type { TBusinessUnit } from '../types';
+import type { TBusinessUnit, TBusinessUnitGraphql } from '../types';
 import * as BusinessUnit from './index';
 
 describe('builder', () => {
@@ -79,5 +79,53 @@ describe('builder', () => {
       })
     )
   );
-  // test for the graphql shape not added at this time
+
+  it(
+    ...createBuilderSpec<TBusinessUnit, TBusinessUnitGraphql>(
+      'graphql',
+      BusinessUnit.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        key: expect.any(String),
+        status: expect.any(String),
+        storesRef: expect.objectContaining({
+          typeId: 'store',
+        }),
+        stores: [],
+        storeMode: expect.any(String),
+        unitType: 'Division',
+        name: expect.any(String),
+        contactEmail: expect.any(String),
+        addresses: expect.any(Array),
+        shippingAddressIds: [],
+        defaultShippingAddressId: null,
+        billingAddressIds: [],
+        defaultBillingAddressId: null,
+        associateMode: expect.any(String),
+        associates: expect.any(Array),
+        inheritedAssociates: expect.any(Array),
+        parentUnit: expect.objectContaining({
+          __typename: 'BusinessUnit',
+        }),
+        topLevelUnit: expect.objectContaining({
+          __typename: 'BusinessUnit',
+        }),
+        custom: null,
+        createdAt: expect.any(String),
+        createdBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+          userRef: expect.objectContaining({ typeId: 'user' }),
+        }),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+          userRef: expect.objectContaining({ typeId: 'user' }),
+        }),
+        ancestors: expect.any(Array),
+        inheritedStores: null,
+        __typename: 'BusinessUnit',
+      })
+    )
+  );
 });

--- a/models/business-unit/src/division/builder.spec.ts
+++ b/models/business-unit/src/division/builder.spec.ts
@@ -2,12 +2,12 @@
 /* eslint-disable jest/valid-title */
 
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import type { TBusinessUnit, TBusinessUnitGraphql } from '../types';
+import type { TDivision, TDivisionGraphql } from '../types';
 import * as BusinessUnit from './index';
 
 describe('builder', () => {
   it(
-    ...createBuilderSpec<TBusinessUnit, TBusinessUnit>(
+    ...createBuilderSpec<TDivision, TDivision>(
       'default',
       BusinessUnit.random(),
       expect.objectContaining({
@@ -44,7 +44,7 @@ describe('builder', () => {
   );
 
   it(
-    ...createBuilderSpec<TBusinessUnit, TBusinessUnit>(
+    ...createBuilderSpec<TDivision, TDivision>(
       'rest',
       BusinessUnit.random(),
       expect.objectContaining({
@@ -81,7 +81,7 @@ describe('builder', () => {
   );
 
   it(
-    ...createBuilderSpec<TBusinessUnit, TBusinessUnitGraphql>(
+    ...createBuilderSpec<TDivision, TDivisionGraphql>(
       'graphql',
       BusinessUnit.random(),
       expect.objectContaining({

--- a/models/business-unit/src/division/builder.ts
+++ b/models/business-unit/src/division/builder.ts
@@ -1,10 +1,10 @@
 import { Builder } from '@commercetools-test-data/core';
-import type { TCreateBusinessUnitBuilder, TBusinessUnit } from '../types';
+import type { TCreateDivisionBuilder, TDivision } from '../types';
 import generator from './generator';
 import transformers from './transformers';
 
-const Model: TCreateBusinessUnitBuilder = () =>
-  Builder<TBusinessUnit>({
+const Model: TCreateDivisionBuilder = () =>
+  Builder<TDivision>({
     generator,
     transformers,
   });

--- a/models/business-unit/src/division/division-draft/builder.spec.ts
+++ b/models/business-unit/src/division/division-draft/builder.spec.ts
@@ -2,14 +2,14 @@
 /* eslint-disable jest/valid-title */
 
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import type { TBusinessUnitDraft } from '../../types';
-import * as BusinessUnitDraft from './index';
+import type { TDivisionDraft } from '../../types';
+import * as DivisionDraft from './index';
 
 describe('builder', () => {
   it(
-    ...createBuilderSpec<TBusinessUnitDraft, TBusinessUnitDraft>(
+    ...createBuilderSpec<TDivisionDraft, TDivisionDraft>(
       'default',
-      BusinessUnitDraft.random(),
+      DivisionDraft.random(),
       expect.objectContaining({
         key: expect.any(String),
         status: expect.any(String),
@@ -32,9 +32,9 @@ describe('builder', () => {
   );
 
   it(
-    ...createBuilderSpec<TBusinessUnitDraft, TBusinessUnitDraft>(
+    ...createBuilderSpec<TDivisionDraft, TDivisionDraft>(
       'rest',
-      BusinessUnitDraft.random(),
+      DivisionDraft.random(),
       expect.objectContaining({
         key: expect.any(String),
         status: expect.any(String),

--- a/models/business-unit/src/division/division-draft/builder.ts
+++ b/models/business-unit/src/division/division-draft/builder.ts
@@ -1,13 +1,10 @@
 import { Builder } from '@commercetools-test-data/core';
-import type {
-  TCreateBusinessUnitDraftBuilder,
-  TBusinessUnitDraft,
-} from '../../types';
+import type { TCreateDivisionDraftBuilder, TDivisionDraft } from '../../types';
 import generator from './generator';
 import transformers from './transformers';
 
-const Model: TCreateBusinessUnitDraftBuilder = () =>
-  Builder<TBusinessUnitDraft>({
+const Model: TCreateDivisionDraftBuilder = () =>
+  Builder<TDivisionDraft>({
     generator,
     transformers,
   });

--- a/models/business-unit/src/division/division-draft/generator.ts
+++ b/models/business-unit/src/division/division-draft/generator.ts
@@ -1,11 +1,11 @@
 import { AddressDraft, KeyReference } from '@commercetools-test-data/commons';
 import { fake, Generator, oneOf } from '@commercetools-test-data/core';
 import { status, storeMode, unitType, associateMode } from '../../constants';
-import type { TBusinessUnitDraft } from '../../types';
+import type { TDivisionDraft } from '../../types';
 
 // https://docs.commercetools.com/api/projects/business-units#divisiondraft
 
-const generator = Generator<TBusinessUnitDraft>({
+const generator = Generator<TDivisionDraft>({
   fields: {
     key: fake((f) => f.lorem.slug(2)),
     status: oneOf(...Object.values(status)),

--- a/models/business-unit/src/division/division-draft/transformers.ts
+++ b/models/business-unit/src/division/division-draft/transformers.ts
@@ -1,21 +1,17 @@
 import { Transformer } from '@commercetools-test-data/core';
-import type {
-  TBusinessUnitDraft,
-  TBusinessUnitDraftGraphql,
-} from '../../types';
+import type { TDivisionDraft, TDivisionDraftGraphql } from '../../types';
 
 const transformers = {
-  default: Transformer<TBusinessUnitDraft, TBusinessUnitDraft>('default', {
+  default: Transformer<TDivisionDraft, TDivisionDraft>('default', {
     buildFields: ['addresses'],
   }),
-  rest: Transformer<TBusinessUnitDraft, TBusinessUnitDraft>('rest', {
+  rest: Transformer<TDivisionDraft, TDivisionDraft>('rest', {
     buildFields: ['addresses'],
   }),
   //only scaffolding provided at this time
-  graphql: Transformer<TBusinessUnitDraft, TBusinessUnitDraftGraphql>(
-    'graphql',
-    { buildFields: [] }
-  ),
+  graphql: Transformer<TDivisionDraft, TDivisionDraftGraphql>('graphql', {
+    buildFields: [],
+  }),
 };
 
 export default transformers;

--- a/models/business-unit/src/division/generator.ts
+++ b/models/business-unit/src/division/generator.ts
@@ -11,13 +11,13 @@ import {
 } from '@commercetools-test-data/core';
 import { createRelatedDates } from '@commercetools-test-data/utils';
 import { status, storeMode, unitType, associateMode } from '../constants';
-import type { TBusinessUnit } from '../types';
+import type { TDivision } from '../types';
 
 const [getOlderDate, getNewerDate] = createRelatedDates();
 
 // https://docs.commercetools.com/api/projects/business-units#division
 
-const generator = Generator<TBusinessUnit>({
+const generator = Generator<TDivision>({
   fields: {
     id: fake((f) => f.string.uuid()),
     version: sequence(),

--- a/models/business-unit/src/division/transformers.ts
+++ b/models/business-unit/src/division/transformers.ts
@@ -1,10 +1,10 @@
 import { KeyReference } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import * as Company from '../company';
-import type { TBusinessUnit, TBusinessUnitGraphql } from '../types';
+import type { TDivision, TDivisionGraphql } from '../types';
 
 const transformers = {
-  default: Transformer<TBusinessUnit, TBusinessUnit>('default', {
+  default: Transformer<TDivision, TDivisionGraphql>('default', {
     buildFields: [
       'addresses',
       'createdBy',
@@ -13,7 +13,7 @@ const transformers = {
       'topLevelUnit',
     ],
   }),
-  rest: Transformer<TBusinessUnit, TBusinessUnit>('rest', {
+  rest: Transformer<TDivision, TDivisionGraphql>('rest', {
     buildFields: [
       'addresses',
       'createdBy',
@@ -22,37 +22,37 @@ const transformers = {
       'topLevelUnit',
     ],
   }),
-  graphql: Transformer<
-    TBusinessUnit | TBusinessUnitGraphql,
-    TBusinessUnitGraphql
-  >('graphql', {
-    buildFields: ['addresses', 'createdBy', 'lastModifiedBy'],
-    replaceFields: ({ fields }) => ({
-      ...(fields as TBusinessUnit),
-      storesRef: KeyReference.random().typeId('store').buildGraphql(),
-      parentUnitRef: KeyReference.random()
-        .typeId('business-unit')
-        .buildGraphql(),
-      parentUnit:
-        fields.parentUnit && 'id' in fields.parentUnit
-          ? fields.parentUnit
-          : Company.random().buildGraphql(),
-      topLevelUnitRef: KeyReference.random()
-        .typeId('business-unit')
-        .buildGraphql(),
-      topLevelUnit:
-        fields.topLevelUnit && 'id' in fields.topLevelUnit
-          ? fields.topLevelUnit
-          : Company.random().buildGraphql(),
-      ancestors:
-        'ancestors' in fields && fields.ancestors ? fields.ancestors : [],
-      inheritedStores:
-        'inheritedStores' in fields && fields.inheritedStores
-          ? fields.inheritedStores
-          : null,
-      __typename: 'BusinessUnit',
-    }),
-  }),
+  graphql: Transformer<TDivision | TDivisionGraphql, TDivisionGraphql>(
+    'graphql',
+    {
+      buildFields: ['addresses', 'createdBy', 'lastModifiedBy'],
+      replaceFields: ({ fields }) => ({
+        ...(fields as TDivision),
+        storesRef: KeyReference.random().typeId('store').buildGraphql(),
+        parentUnitRef: KeyReference.random()
+          .typeId('business-unit')
+          .buildGraphql(),
+        parentUnit:
+          fields.parentUnit && 'id' in fields.parentUnit
+            ? fields.parentUnit
+            : Company.random().buildGraphql(),
+        topLevelUnitRef: KeyReference.random()
+          .typeId('business-unit')
+          .buildGraphql(),
+        topLevelUnit:
+          fields.topLevelUnit && 'id' in fields.topLevelUnit
+            ? fields.topLevelUnit
+            : Company.random().buildGraphql(),
+        ancestors:
+          'ancestors' in fields && fields.ancestors ? fields.ancestors : [],
+        inheritedStores:
+          'inheritedStores' in fields && fields.inheritedStores
+            ? fields.inheritedStores
+            : null,
+        __typename: 'BusinessUnit',
+      }),
+    }
+  ),
 };
 
 export default transformers;

--- a/models/business-unit/src/division/transformers.ts
+++ b/models/business-unit/src/division/transformers.ts
@@ -1,17 +1,40 @@
 import { Transformer } from '@commercetools-test-data/core';
+import * as Company from '../company';
 import type { TBusinessUnit, TBusinessUnitGraphql } from '../types';
 
 const transformers = {
   default: Transformer<TBusinessUnit, TBusinessUnit>('default', {
-    buildFields: ['addresses', 'createdBy', 'lastModifiedBy', 'parentUnit'],
+    buildFields: [
+      'addresses',
+      'createdBy',
+      'lastModifiedBy',
+      'parentUnit',
+      'topLevelUnit',
+    ],
   }),
   rest: Transformer<TBusinessUnit, TBusinessUnit>('rest', {
-    buildFields: ['addresses', 'createdBy', 'lastModifiedBy', 'parentUnit'],
+    buildFields: [
+      'addresses',
+      'createdBy',
+      'lastModifiedBy',
+      'parentUnit',
+      'topLevelUnit',
+    ],
   }),
-  //only scaffolding provided at this time
   graphql: Transformer<TBusinessUnit, TBusinessUnitGraphql>('graphql', {
-    buildFields: [],
-    addFields: () => ({
+    buildFields: [
+      'addresses',
+      'createdBy',
+      'lastModifiedBy',
+      'parentUnit',
+      'topLevelUnit',
+    ],
+    replaceFields: ({ fields }) => ({
+      ...fields,
+      parentUnit: Company.random(),
+      topLevelUnit: Company.random(),
+      ancestors: [],
+      inheritedStores: null,
       __typename: 'BusinessUnit',
     }),
   }),

--- a/models/business-unit/src/division/transformers.ts
+++ b/models/business-unit/src/division/transformers.ts
@@ -1,3 +1,4 @@
+import { KeyReference } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import * as Company from '../company';
 import type { TBusinessUnit, TBusinessUnitGraphql } from '../types';
@@ -21,20 +22,34 @@ const transformers = {
       'topLevelUnit',
     ],
   }),
-  graphql: Transformer<TBusinessUnit, TBusinessUnitGraphql>('graphql', {
-    buildFields: [
-      'addresses',
-      'createdBy',
-      'lastModifiedBy',
-      'parentUnit',
-      'topLevelUnit',
-    ],
+  graphql: Transformer<
+    TBusinessUnit | TBusinessUnitGraphql,
+    TBusinessUnitGraphql
+  >('graphql', {
+    buildFields: ['addresses', 'createdBy', 'lastModifiedBy'],
     replaceFields: ({ fields }) => ({
-      ...fields,
-      parentUnit: Company.random(),
-      topLevelUnit: Company.random(),
-      ancestors: [],
-      inheritedStores: null,
+      ...(fields as TBusinessUnit),
+      storesRef: KeyReference.random().typeId('store').buildGraphql(),
+      parentUnitRef: KeyReference.random()
+        .typeId('business-unit')
+        .buildGraphql(),
+      parentUnit:
+        fields.parentUnit && 'id' in fields.parentUnit
+          ? fields.parentUnit
+          : Company.random().buildGraphql(),
+      topLevelUnitRef: KeyReference.random()
+        .typeId('business-unit')
+        .buildGraphql(),
+      topLevelUnit:
+        fields.topLevelUnit && 'id' in fields.topLevelUnit
+          ? fields.topLevelUnit
+          : Company.random().buildGraphql(),
+      ancestors:
+        'ancestors' in fields && fields.ancestors ? fields.ancestors : [],
+      inheritedStores:
+        'inheritedStores' in fields && fields.inheritedStores
+          ? fields.inheritedStores
+          : null,
       __typename: 'BusinessUnit',
     }),
   }),

--- a/models/business-unit/src/types.ts
+++ b/models/business-unit/src/types.ts
@@ -1,9 +1,10 @@
 import type {
-  BusinessUnit,
   BusinessUnitDraft,
   BusinessUnitKeyReference,
   KeyReference,
   Store,
+  Company,
+  Division,
 } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
 
@@ -17,19 +18,32 @@ export type TBusinessUnitDraftGraphql = TBusinessUnitDraft & {
 };
 
 //BusinessUnit
-export type TBusinessUnit = BusinessUnit;
-export type TBusinessUnitBuilder = TBuilder<TBusinessUnit>;
-export type TCreateBusinessUnitBuilder = () => TBusinessUnitBuilder;
-export type TBusinessUnitGraphql = Omit<
-  TBusinessUnit,
+export type TCompany = Company;
+export type TDivision = Division;
+export type TCompanyBuilder = TBuilder<TCompany>;
+export type TDivisionBuilder = TBuilder<TDivision>;
+export type TCreateCompanyBuilder = () => TCompanyBuilder;
+export type TCreateDivisionBuilder = () => TDivisionBuilder;
+export type TCompanyGraphql = Omit<TCompany, 'topLevelUnit' | 'parentUnit'> & {
+  ancestors: [];
+  inheritedStores: null;
+  __typename: 'BusinessUnit';
+  storesRef: KeyReference;
+  parentUnitRef: null;
+  parentUnit?: BusinessUnitKeyReference;
+  topLevelUnitRef: BusinessUnitKeyReference;
+  topLevelUnit: TCompany | TCompanyGraphql;
+};
+export type TDivisionGraphql = Omit<
+  TDivision,
   'topLevelUnit' | 'parentUnit'
 > & {
-  ancestors: Array<TBusinessUnitGraphql>;
+  ancestors: Array<TCompanyGraphql | TDivisionGraphql>;
   inheritedStores: Array<Store> | null;
   __typename: 'BusinessUnit';
   storesRef: KeyReference;
-  parentUnitRef: BusinessUnitKeyReference | null;
-  parentUnit?: BusinessUnitKeyReference | undefined;
+  parentUnitRef: BusinessUnitKeyReference;
+  parentUnit?: TDivisionGraphql | TCompanyGraphql;
   topLevelUnitRef: BusinessUnitKeyReference;
-  topLevelUnit: BusinessUnitKeyReference | TBusinessUnit;
+  topLevelUnit: TCompanyGraphql;
 };

--- a/models/business-unit/src/types.ts
+++ b/models/business-unit/src/types.ts
@@ -1,6 +1,8 @@
 import type {
   BusinessUnit,
   BusinessUnitDraft,
+  BusinessUnitKeyReference,
+  KeyReference,
   Store,
 } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
@@ -18,9 +20,16 @@ export type TBusinessUnitDraftGraphql = TBusinessUnitDraft & {
 export type TBusinessUnit = BusinessUnit;
 export type TBusinessUnitBuilder = TBuilder<TBusinessUnit>;
 export type TCreateBusinessUnitBuilder = () => TBusinessUnitBuilder;
-//BusinessUnitGraphql is only scaffolding at this time
-export type TBusinessUnitGraphql = TBusinessUnit & {
+export type TBusinessUnitGraphql = Omit<
+  TBusinessUnit,
+  'topLevelUnit' | 'parentUnit'
+> & {
   ancestors: Array<TBusinessUnitGraphql>;
   inheritedStores: Array<Store> | null;
   __typename: 'BusinessUnit';
+  storesRef: KeyReference;
+  parentUnitRef: BusinessUnitKeyReference | null;
+  parentUnit?: BusinessUnitKeyReference | undefined;
+  topLevelUnitRef: BusinessUnitKeyReference;
+  topLevelUnit: BusinessUnitKeyReference | TBusinessUnit;
 };

--- a/models/business-unit/src/types.ts
+++ b/models/business-unit/src/types.ts
@@ -1,6 +1,7 @@
 import type {
   BusinessUnit,
   BusinessUnitDraft,
+  Store,
 } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
 
@@ -19,5 +20,7 @@ export type TBusinessUnitBuilder = TBuilder<TBusinessUnit>;
 export type TCreateBusinessUnitBuilder = () => TBusinessUnitBuilder;
 //BusinessUnitGraphql is only scaffolding at this time
 export type TBusinessUnitGraphql = TBusinessUnit & {
+  ancestors: Array<TBusinessUnitGraphql>;
+  inheritedStores: Array<Store> | null;
   __typename: 'BusinessUnit';
 };

--- a/models/business-unit/src/types.ts
+++ b/models/business-unit/src/types.ts
@@ -1,19 +1,26 @@
 import type {
-  BusinessUnitDraft,
   BusinessUnitKeyReference,
   KeyReference,
   Store,
   Company,
   Division,
+  CompanyDraft,
+  DivisionDraft,
 } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 //BusinessUnitDraft
-export type TBusinessUnitDraft = BusinessUnitDraft;
-export type TBusinessUnitDraftBuilder = TBuilder<TBusinessUnitDraft>;
-export type TCreateBusinessUnitDraftBuilder = () => TBusinessUnitDraftBuilder;
+export type TCompanyDraft = CompanyDraft;
+export type TDivisionDraft = DivisionDraft;
+export type TCompanyDraftBuilder = TBuilder<TCompanyDraft>;
+export type TDivisionDraftBuilder = TBuilder<TDivisionDraft>;
+export type TCreateCompanyDraftBuilder = () => TCompanyDraftBuilder;
+export type TCreateDivisionDraftBuilder = () => TDivisionDraftBuilder;
 //BusinessUnitDraftGraphql is only scaffolding at this time
-export type TBusinessUnitDraftGraphql = TBusinessUnitDraft & {
+export type TCompanyDraftGraphql = TCompanyDraft & {
+  __typename: 'BusinessUnitDraft';
+};
+export type TDivisionDraftGraphql = TDivisionDraft & {
   __typename: 'BusinessUnitDraft';
 };
 


### PR DESCRIPTION
This PR aims to replace the current scaffolding in the Company and Division models with the real implementation.

- Adds parentUnit field as null value in Company to prevent associated errors because of missing field
- Adds parentUnit and topLevelUnit to buildFields where applicable
- Adds ancestors and inheritedStores fields to graphQL transformer sprevent associated errors because of missing fields
- Replaces topLevelUnit field with itself for Company in graphQL transformer to match referenceExpansion
- Replaces parentUnit and topLevelUnit with Companies in Division graphQL transformer to match referenceExpansion