### PR TITLE
feat(graphql drafts): attempt at removing __typename from transformed fields for graphql drafts

### DIFF
--- a/.changeset/beige-donuts-press.md
+++ b/.changeset/beige-donuts-press.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/core': minor
+---
+
+feat(graphql drafts): remove \_\_typename added by builders of transformed fields from graphql drafts using isGrpahqlDraft param

--- a/core/src/helpers.ts
+++ b/core/src/helpers.ts
@@ -28,6 +28,33 @@ const upperFirst = (value: string): string =>
 const lowerFirst = (value: string): string =>
   value.charAt(0).toLowerCase() + value.slice(1);
 
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+function deleteKeyFromObject(inputObject: any, keyToDelete: string) {
+  for (let [currentObjectKey, currentObjectValue] of Object.entries(
+    inputObject
+  )) {
+    if (currentObjectKey === keyToDelete) {
+      delete inputObject[keyToDelete];
+    } else if (Array.isArray(currentObjectValue)) {
+      deleteKeyFromObjectInArray(currentObjectValue, keyToDelete);
+    } else if (isObject(currentObjectValue)) {
+      deleteKeyFromObject(currentObjectValue, keyToDelete);
+    }
+  }
+}
+
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+function deleteKeyFromObjectInArray(inputArray: any[], keyToDelete: string) {
+  for (let currentIndex = 0; currentIndex < inputArray.length; currentIndex++) {
+    let currentElement = inputArray[currentIndex];
+    if (Array.isArray(currentElement)) {
+      deleteKeyFromObjectInArray(currentElement, keyToDelete);
+    } else if (isObject(currentElement)) {
+      deleteKeyFromObject(currentElement, keyToDelete);
+    }
+  }
+}
+
 const omitOne = <T, K extends keyof T>(entity: T, prop: K): Omit<T, K> => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { [prop]: deleted, ...newState } = entity;
@@ -175,6 +202,7 @@ export {
   isBuilderFunction,
   upperFirst,
   lowerFirst,
+  deleteKeyFromObject,
   omitMany,
   pickMany,
   convertBuiltNameToTransformName,

--- a/core/src/transformer.ts
+++ b/core/src/transformer.ts
@@ -82,8 +82,9 @@ function Transformer<Model, TransformedModel>(
 
     if (transformOptions?.isGraphqlDraft) {
       fieldsToBuild?.forEach((builtField) => {
-        const builtFieldHasTypename = transformedFields[builtField]?['__typename'] as unknown as String;
-        if(builtFieldHasTypename){
+        // @ts-ignore: TS does not know about the `Model` being an object.
+        if (transformedFields[builtField]?.['__typename']) {
+          // @ts-ignore: TS does not know about the `Model` being an object.
           delete transformedFields[builtField]['__typename'];
         }
       });

--- a/core/src/transformer.ts
+++ b/core/src/transformer.ts
@@ -1,4 +1,4 @@
-import { buildField, buildFields } from './helpers';
+import { buildField, buildFields, deleteKeyFromObject } from './helpers';
 import type {
   TTransformer,
   TTransformerOptions,
@@ -36,6 +36,11 @@ function Transformer<Model, TransformedModel>(
           };
         }
       });
+
+      if (transformOptions?.isGraphqlDraft) {
+        /**recursively delete '__typename' field from all built fields in graphql draft */
+        deleteKeyFromObject(transformedFields, '__typename');
+      }
     }
 
     // The default transformer only allows building nested fields to not
@@ -77,16 +82,6 @@ function Transformer<Model, TransformedModel>(
     if (fieldsToRemove) {
       fieldsToRemove.forEach((fieldToRemove) => {
         delete transformedFields[fieldToRemove];
-      });
-    }
-
-    if (transformOptions?.isGraphqlDraft) {
-      fieldsToBuild?.forEach((builtField) => {
-        // @ts-ignore: TS does not know about the `Model` being an object.
-        if (transformedFields[builtField]?.['__typename']) {
-          // @ts-ignore: TS does not know about the `Model` being an object.
-          delete transformedFields[builtField]['__typename'];
-        }
       });
     }
 

--- a/core/src/transformer.ts
+++ b/core/src/transformer.ts
@@ -80,6 +80,15 @@ function Transformer<Model, TransformedModel>(
       });
     }
 
+    if (transformOptions?.isGraphqlDraft) {
+      fieldsToBuild?.forEach((builtField) => {
+        const builtFieldHasTypename = transformedFields[builtField]?['__typename'] as unknown as String;
+        if(builtFieldHasTypename){
+          delete transformedFields[builtField]['__typename'];
+        }
+      });
+    }
+
     return transformedFields as unknown as TransformedModel;
   }
 

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -54,7 +54,7 @@ export type TTransformerOptions<Model, TransformedModel> = {
    * this flag removes all "__typename" fields from transformed models
    * so that the draft can be used with the API
    */
-  isGraphqlDraft: Boolean;
+  isGraphqlDraft?: Boolean;
 };
 
 export interface TTransformer<Model> {

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -50,6 +50,11 @@ export type TTransformerOptions<Model, TransformedModel> = {
   removeFields?: (keyof Model)[];
   replaceFields?: (args: { fields: Model }) => TransformedModel;
   buildFields?: (keyof Model)[];
+  /** When transforming fields for GraphQL draft models,
+   * this flag removes all "__typename" fields from transformed models
+   * so that the draft can be used with the API
+   */
+  isGraphqlDraft: Boolean;
 };
 
 export interface TTransformer<Model> {

--- a/models/product/package.json
+++ b/models/product/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/attribute-definition": "5.11.2",
     "@commercetools-test-data/category": "6.6.0",
     "@commercetools-test-data/commons": "6.6.0",
-    "@commercetools-test-data/core": "6.6.0",
+    "@commercetools-test-data/core": "link:../../../../core",
     "@commercetools-test-data/product-type": "6.6.0",
     "@commercetools-test-data/product-variant": "5.11.2",
     "@commercetools-test-data/tax-category": "6.6.0",

--- a/models/product/src/product/product-draft/builder.spec.ts
+++ b/models/product/src/product/product-draft/builder.spec.ts
@@ -180,17 +180,20 @@ describe('builder', () => {
       expect.objectContaining({
         name: expect.arrayContaining([
           expect.objectContaining({
-            __typename: 'LocalizedString',
+            locale: expect.any(String),
+            value: expect.any(String),
           }),
         ]),
         slug: expect.arrayContaining([
           expect.objectContaining({
-            __typename: 'LocalizedString',
+            locale: expect.any(String),
+            value: expect.any(String),
           }),
         ]),
         description: expect.arrayContaining([
           expect.objectContaining({
-            __typename: 'LocalizedString',
+            locale: expect.any(String),
+            value: expect.any(String),
           }),
         ]),
         categories: expect.arrayContaining([

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.spec.ts
@@ -103,7 +103,6 @@ describe(`with anniversaryShirt preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "tops-kids",
             "typeId": "category",
           },
@@ -129,14 +128,12 @@ describe(`with anniversaryShirt preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Anniversary Shirt",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "shirts",
           "typeId": "product-type",
         },
@@ -144,14 +141,12 @@ describe(`with anniversaryShirt preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-anniversary-shirt",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.spec.ts
@@ -220,7 +220,6 @@ describe(`with denimJacket preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "tops-men",
             "typeId": "category",
           },
@@ -328,14 +327,12 @@ describe(`with denimJacket preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Denim Jacket",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "jackets",
           "typeId": "product-type",
         },
@@ -343,14 +340,12 @@ describe(`with denimJacket preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-denim-jacket",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.spec.ts
@@ -128,7 +128,6 @@ describe(`with flairJeans preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bottoms-women",
             "typeId": "category",
           },
@@ -166,14 +165,12 @@ describe(`with flairJeans preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Flair Jeans",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "pants",
           "typeId": "product-type",
         },
@@ -181,14 +178,12 @@ describe(`with flairJeans preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-flair-jeans",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.spec.ts
@@ -211,7 +211,6 @@ describe(`with halloweenTop preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "tops-men",
             "typeId": "category",
           },
@@ -302,14 +301,12 @@ describe(`with halloweenTop preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Halloween Top",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "shirts",
           "typeId": "product-type",
         },
@@ -317,14 +314,12 @@ describe(`with halloweenTop preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-halloween-top",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.spec.ts
@@ -244,7 +244,6 @@ describe(`with maternityTop preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "tops-women",
             "typeId": "category",
           },
@@ -318,14 +317,12 @@ describe(`with maternityTop preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Maternity Top",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "shirts",
           "typeId": "product-type",
         },
@@ -333,14 +330,12 @@ describe(`with maternityTop preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-maternity-top",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.spec.ts
@@ -170,7 +170,6 @@ describe(`with necklace preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "other-women",
             "typeId": "category",
           },
@@ -261,14 +260,12 @@ describe(`with necklace preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Necklace",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "accessories",
           "typeId": "product-type",
         },
@@ -276,14 +273,12 @@ describe(`with necklace preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-necklace",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.spec.ts
@@ -166,7 +166,6 @@ describe(`with promDress preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "other-women",
             "typeId": "category",
           },
@@ -236,14 +235,12 @@ describe(`with promDress preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Prom Dress",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "dresses",
           "typeId": "product-type",
         },
@@ -251,14 +248,12 @@ describe(`with promDress preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-prom-dress",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.spec.ts
@@ -197,7 +197,6 @@ describe(`with sampleSandals preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "other-kids",
             "typeId": "category",
           },
@@ -301,14 +300,12 @@ describe(`with sampleSandals preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Sandals",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "accessories",
           "typeId": "product-type",
         },
@@ -316,14 +313,12 @@ describe(`with sampleSandals preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-sandals",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.spec.ts
@@ -181,7 +181,6 @@ describe(`with skinnyJeans preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bottoms-women",
             "typeId": "category",
           },
@@ -255,14 +254,12 @@ describe(`with skinnyJeans preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Skinny Jeans",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "pants",
           "typeId": "product-type",
         },
@@ -270,14 +267,12 @@ describe(`with skinnyJeans preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-skinny-jeans",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.spec.ts
@@ -166,7 +166,6 @@ describe(`with sportCoat preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "tops-men",
             "typeId": "category",
           },
@@ -236,14 +235,12 @@ describe(`with sportCoat preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Sport Coat",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "jackets",
           "typeId": "product-type",
         },
@@ -251,14 +248,12 @@ describe(`with sportCoat preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-sport-coat",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.spec.ts
@@ -182,7 +182,6 @@ describe(`with summerDress preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "other-women",
             "typeId": "category",
           },
@@ -269,14 +268,12 @@ describe(`with summerDress preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Summer Dress",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "dresses",
           "typeId": "product-type",
         },
@@ -284,14 +281,12 @@ describe(`with summerDress preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-summer-dress",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.spec.ts
@@ -286,7 +286,6 @@ describe(`with toddlerTrousers preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bottoms_kids",
             "typeId": "category",
           },
@@ -368,14 +367,12 @@ describe(`with toddlerTrousers preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Toddler Trousers",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "pants",
           "typeId": "product-type",
         },
@@ -383,14 +380,12 @@ describe(`with toddlerTrousers preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-toddler-trousers",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.spec.ts
@@ -166,7 +166,6 @@ describe(`with toteBag preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "other-women",
             "typeId": "category",
           },
@@ -236,14 +235,12 @@ describe(`with toteBag preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sample Tote Bag",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "accessories",
           "typeId": "product-type",
         },
@@ -251,14 +248,12 @@ describe(`with toteBag preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sample-tote-bag",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/abigail-lounge-chair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/abigail-lounge-chair.spec.ts
@@ -199,22 +199,18 @@ describe(`with abigailLoungeChair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
@@ -222,17 +218,14 @@ describe(`with abigailLoungeChair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A lounge chair with pink velvet upholstery and brass spindle legs is a luxurious and stylish piece of furniture that can add a touch of glamour to any living room, bedroom or office. The chair features a comfortable and spacious seat with soft and plush velvet upholstery in soft pink color.  The backrest and armrests of the chair are slightly curved, providing a comfortable and supportive place to sit and relax. The brass spindle legs are tapered, adding to the overall elegance and sophistication of the design.  The combination of pink velvet and brass is both opulent and chic, making the lounge chair a perfect addition to a range of decor styles, from modern and minimalist to vintage-inspired and glam.  Overall, a lounge chair with pink velvet upholstery and brass spindle legs is a luxurious and comfortable piece of furniture that can add a touch of glamour and sophistication to any space. Its soft and plush upholstery, combined with its elegant and timeless design, make it a perfect place to relax and unwind in style.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A lounge chair with pink velvet upholstery and brass spindle legs is a luxurious and stylish piece of furniture that can add a touch of glamour to any living room, bedroom or office. The chair features a comfortable and spacious seat with soft and plush velvet upholstery in soft pink color.  The backrest and armrests of the chair are slightly curved, providing a comfortable and supportive place to sit and relax. The brass spindle legs are tapered, adding to the overall elegance and sophistication of the design.  The combination of pink velvet and brass is both opulent and chic, making the lounge chair a perfect addition to a range of decor styles, from modern and minimalist to vintage-inspired and glam.  Overall, a lounge chair with pink velvet upholstery and brass spindle legs is a luxurious and comfortable piece of furniture that can add a touch of glamour and sophistication to any space. Its soft and plush upholstery, combined with its elegant and timeless design, make it a perfect place to relax and unwind in style.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Loungesessel mit rosafarbener Samtpolsterung und Spindelbeinen aus Messing ist ein luxuriöses und stilvolles Möbelstück, das jedem Wohnzimmer, Schlafzimmer oder Büro einen Hauch von Glamour verleihen kann. Der Stuhl verfügt über einen bequemen und geräumigen Sitz mit weicher und plüschiger Samtpolsterung in zartrosa Farbe.  Die Rückenlehne und die Armlehnen des Stuhls sind leicht gebogen und bieten einen bequemen und stützenden Platz zum Sitzen und Entspannen. Die Spindelbeine aus Messing sind konisch zulaufend und tragen zur allgemeinen Eleganz und Raffinesse des Designs bei.  Die Kombination aus rosafarbenem Samt und Messing ist sowohl opulent als auch schick und macht diesen Loungesessel zu einer perfekten Ergänzung für eine Reihe von Einrichtungsstilen, von modern und minimalistisch bis hin zu Vintage-inspiriert und glamourös. Seine weiche Polsterung, kombiniert mit seinem eleganten und zeitlosen Design, machen ihn zu einem perfekten Ort, um sich stilvoll zu entspannen.",
           },
@@ -337,24 +330,20 @@ describe(`with abigailLoungeChair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Abigail Lounge Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Abigail Lounge Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Abigail Lounge-Sessel",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -362,24 +351,20 @@ describe(`with abigailLoungeChair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "abigail-lounge-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "abigail-lounge-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "abigail-lounge-stuhl",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/amalia-rug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/amalia-rug.spec.ts
@@ -171,17 +171,14 @@ describe(`with amaliaRug preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "rugs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -189,17 +186,14 @@ describe(`with amaliaRug preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A round plush accent rug is designed to be soft and comfortable underfoot, with a thick and dense pile that provides a plush feel. The fibers are densely packed together, giving the rug a lush and luxurious feel. The rug is a great decorative accent in a bedroom, living room, or other area where a small touch of softness and comfort is desired.  Because of their small size, round plush accent rugs are easy to move and reposition, making them a versatile addition to any home. They are also easy to clean and maintain, making them a practical choice for high-traffic areas.  Overall, a round plush accent rug is a cozy and inviting addition to any room. Its soft texture and luxurious feel make it a popular choice for those who want to add a touch of comfort and style to their living space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A round plush accent rug is designed to be soft and comfortable underfoot, with a thick and dense pile that provides a plush feel. The fibers are densely packed together, giving the rug a lush and luxurious feel. The rug is a great decorative accent in a bedroom, living room, or other area where a small touch of softness and comfort is desired.  Because of their small size, round plush accent rugs are easy to move and reposition, making them a versatile addition to any home. They are also easy to clean and maintain, making them a practical choice for high-traffic areas.  Overall, a round plush accent rug is a cozy and inviting addition to any room. Its soft texture and luxurious feel make it a popular choice for those who want to add a touch of comfort and style to their living space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser runde Plüsch-Akzent-Teppich weich und bequem. Der dichte Flor vermittelt ein weiches Gefühl. Die Fasern sind dicht gepackt und verleihen dem Teppich ein üppiges und luxuriöses Gefühl. Der Teppich ist ein großartiger dekorativer Akzent in einem Schlafzimmer, Wohnzimmer oder anderen Bereichen, in denen ein kleiner Hauch von Weichheit und Komfort erwünscht ist.  Aufgrund ihrer geringen Größe lassen sich runde Plüschteppiche leicht bewegen und neu positionieren, was sie zu einer vielseitigen Ergänzung für jedes Zuhause macht. Sie sind außerdem leicht zu reinigen und zu pflegen, was sie zu einer praktischen Wahl für stark frequentierte Bereiche macht.  Insgesamt ist ein runder Teppich mit Plüschakzenten eine gemütliche und einladende Ergänzung für jeden Raum. Seine weiche Textur und luxuriöse Haptik machen es zu einer beliebten Wahl für diejenigen, die ihrem Wohnraum einen Hauch von Komfort und Stil verleihen möchten.",
           },
@@ -296,24 +290,20 @@ describe(`with amaliaRug preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Amalia Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Amalia Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Teppich "Amalia"",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -321,24 +311,20 @@ describe(`with amaliaRug preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "amalia-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "amalia-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "amalia-teppich",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/aria-rug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/aria-rug.spec.ts
@@ -198,17 +198,14 @@ describe(`with ariaRug preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "rugs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -216,17 +213,14 @@ describe(`with ariaRug preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Der Aria-Teppich ist ein Flächenteppich mit einem geometrischen Muster, das ein sich wiederholendes Design aus Formen und Linien aufweist, das sowohl modern als auch vielseitig ist. Es kann einem Raum visuelles Interesse und Textur verleihen und dabei helfen, einen Raum zu definieren und zu verankern.  Insgesamt ist ein Teppich mit geometrischem Muster eine vielseitige und stilvolle Wahl für jeden Raum. Sein mutiges und markantes Design kann einem Raum Charakter und Interesse verleihen, während seine weiche und komfortable Textur eine gemütliche und einladende Atmosphäre schaffen kann.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Aria Rug is an area rug with a geometric pattern that features a repeating design made up of shapes and lines, which is both modern and eclectic. It can add visual interest and texture to a room, and can help define and anchor a space.  Overall, an area rug with a geometric pattern is a versatile and stylish choice for any room. Its bold and striking design can add character and interest to a space, while its soft and comfortable texture can create a cozy and inviting atmosphere.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Aria Rug is an area rug with a geometric pattern that features a repeating design made up of shapes and lines, which is both modern and eclectic. It can add visual interest and texture to a room, and can help define and anchor a space.  Overall, an area rug with a geometric pattern is a versatile and stylish choice for any room. Its bold and striking design can add character and interest to a space, while its soft and comfortable texture can create a cozy and inviting atmosphere.",
           },
@@ -347,24 +341,20 @@ describe(`with ariaRug preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Aria Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Aria Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Teppich "Aria"",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -372,24 +362,20 @@ describe(`with ariaRug preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "aria-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "aria-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "aria-teppich",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/art-deco-chair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/art-deco-chair.spec.ts
@@ -172,17 +172,14 @@ describe(`with artDecoChair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -190,17 +187,14 @@ describe(`with artDecoChair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "An art deco chair with metal legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with durable cotton upholstery providing a soft and luxurious feel. The metal legs have a smooth finish that accentuates the chair's modern style. The chair features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair is a striking piece of furniture that adds both style and comfort to any room.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "An art deco chair with metal legs has a sleek, streamlined design that exudes sophistication and elegance. The chair has a comfortable padded seat and backrest, with durable cotton upholstery providing a soft and luxurious feel. The metal legs have a smooth finish that accentuates the chair's modern style. The chair features distinctive art deco elements such as angular shapes, bold lines, and geometric patterns. Overall, this chair is a striking piece of furniture that adds both style and comfort to any room.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser Art-Deco-Stuhl mit Metallbeinen hat ein schlankes, stromlinienförmiges Design, das Raffinesse und Eleganz ausstrahlt. Der Stuhl hat einen bequem gepolsterten Sitz und eine Rückenlehne mit strapazierfähiger Baumwollpolsterung, die ein weiches und luxuriöses Gefühl vermittelt. Die Metallbeine haben eine glatte Oberfläche, die den modernen Stil des Stuhls betont. Der Stuhl bedient sich markante Art-Deco-Elemente wie eckige Formen, kräftige Linien und geometrische Muster. Der Stuhl ist ein markantes Möbelstück, das jedem Raum Stil und Komfort verleiht.",
           },
@@ -297,24 +291,20 @@ describe(`with artDecoChair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Art Deco Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Art Deco Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Sessel im Art-Deco-Stil",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -322,24 +312,20 @@ describe(`with artDecoChair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "art-deco-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "art-deco-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "art-deco-stuhl",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/art-deco-coffee-table.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/art-deco-coffee-table.spec.ts
@@ -203,17 +203,14 @@ describe(`with artDecoCoffeeTable preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "tables",
             "typeId": "category",
           },
@@ -221,17 +218,14 @@ describe(`with artDecoCoffeeTable preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "An Art Deco coffee table with gold legs and a black marble top is a luxurious and stylish piece of furniture that can add a touch of glamour to any living room. The table features a geometric design, with sleek and angular lines that are characteristic of the Art Deco style.  The legs of the table are made from metal and have a shiny gold finish that adds a touch of opulence to the design. The tabletop is made from black marble, which has a natural veined pattern that gives each piece a unique and luxurious appearance. The marble top is smooth and polished, creating a sleek and sophisticated surface for displaying books, drinks, or decorative accessories.  The combination of gold and black creates a striking contrast that is both bold and elegant. The Art Deco style of the table is both timeless and glamorous, making it a perfect complement to a range of decor styles, from contemporary to vintage-inspired.  Overall, an Art Deco coffee table with gold legs and a black marble top is a luxurious and stylish addition to any living room. Its unique and striking design, combined with its high-quality materials and craftsmanship, make it a standout piece of furniture that can elevate the look and feel of any space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "An Art Deco coffee table with gold legs and a black marble top is a luxurious and stylish piece of furniture that can add a touch of glamour to any living room. The table features a geometric design, with sleek and angular lines that are characteristic of the Art Deco style.  The legs of the table are made from metal and have a shiny gold finish that adds a touch of opulence to the design. The tabletop is made from black marble, which has a natural veined pattern that gives each piece a unique and luxurious appearance. The marble top is smooth and polished, creating a sleek and sophisticated surface for displaying books, drinks, or decorative accessories.  The combination of gold and black creates a striking contrast that is both bold and elegant. The Art Deco style of the table is both timeless and glamorous, making it a perfect complement to a range of decor styles, from contemporary to vintage-inspired.  Overall, an Art Deco coffee table with gold legs and a black marble top is a luxurious and stylish addition to any living room. Its unique and striking design, combined with its high-quality materials and craftsmanship, make it a standout piece of furniture that can elevate the look and feel of any space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser Art-Deco-Couchtisch mit goldenen Beinen und einer schwarzen Marmorplatte ist ein luxuriöses und stilvolles Möbelstück, das jedem Wohnzimmer einen Hauch von Glamour verleihen kann. Der Tisch verfügt über ein geometrisches Design mit schlanken und eckigen Linien, die charakteristisch für den Art-Deco-Stil sind. Die Beine des Tisches sind aus Metall gefertigt und haben eine glänzende Goldoberfläche, die dem Design einen Hauch von Opulenz verleiht. Die Tischplatte besteht aus schwarzem Marmor, der ein natürliches geädertes Muster aufweist, das jedem Stück ein einzigartiges und luxuriöses Aussehen verleiht. Die Marmorplatte ist glatt und poliert und schafft eine glatte und raffinierte Oberfläche für die Präsentation von Büchern, Getränken oder dekorativen Accessoires.  Die Kombination aus Gold und Schwarz schafft einen auffälligen Kontrast, der sowohl mutig als auch elegant ist. Der Art-Deco-Stil des Tisches ist sowohl zeitlos als auch glamourös, was ihn zu einer perfekten Ergänzung für eine Reihe von Einrichtungsstilen macht, von zeitgenössisch bis hin zu Vintage-inspiriert. Ein Art-Deco-Couchtisch mit goldenen Beinen und einer schwarzen Marmorplatte ist eine luxuriöse und stilvolle Ergänzung für jedes Wohnzimmer. Sein einzigartiges und markantes Design, kombiniert mit seinen hochwertigen Materialien und seiner Handwerkskunst, machen es zu einem herausragenden Möbelstück, das das Erscheinungsbild jedes Raums aufwerten kann.",
           },
@@ -344,24 +338,20 @@ describe(`with artDecoCoffeeTable preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Art Deco Coffee Table",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Art Deco Coffee Table",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Couchtisch im Art-Deco-Stil",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -369,24 +359,20 @@ describe(`with artDecoCoffeeTable preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "art-deco-coffe-table",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "art-deco-coffe-table",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "art-deco-couchtisch",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ashen-rug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ashen-rug.spec.ts
@@ -182,17 +182,14 @@ describe(`with ashenRug preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "rugs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -200,17 +197,14 @@ describe(`with ashenRug preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A modern shag carpet is a type of rug or carpet with a long, plush pile that is known for its softness and comfort. Unlike traditional shag carpets, which were popular in the 1970s and had a somewhat shaggy and unkempt appearance, modern shag carpets are more refined and have a sleek, contemporary look.  In addition to their softness and comfort, modern shag carpets are also known for their ability to absorb sound and create a cozy, inviting atmosphere. They are often used in living rooms, bedrooms, and other spaces where comfort and style are important.  Overall, a modern shag carpet is a luxurious and stylish addition to any home. Its soft, plush texture and sleek, contemporary look make it a popular choice for those looking to add comfort and style to their living space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A modern shag carpet is a type of rug or carpet with a long, plush pile that is known for its softness and comfort. Unlike traditional shag carpets, which were popular in the 1970s and had a somewhat shaggy and unkempt appearance, modern shag carpets are more refined and have a sleek, contemporary look.  In addition to their softness and comfort, modern shag carpets are also known for their ability to absorb sound and create a cozy, inviting atmosphere. They are often used in living rooms, bedrooms, and other spaces where comfort and style are important.  Overall, a modern shag carpet is a luxurious and stylish addition to any home. Its soft, plush texture and sleek, contemporary look make it a popular choice for those looking to add comfort and style to their living space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein moderner Shag-Teppich ist eine Art Vorleger oder Teppich mit langem Plüschflor, der für seine Weichheit und seinen Komfort bekannt ist. Im Gegensatz zu traditionellen Shag-Teppichen, die in den 1970er Jahren beliebt waren und ein etwas zotteliges und ungepflegtes Aussehen hatten, sind moderne Shag-Teppiche raffinierter und haben ein elegantes, zeitgemäßes Aussehen.  Neben ihrer Weichheit und ihrem Komfort sind moderne Hochflorteppiche auch für ihre Fähigkeit bekannt, Schall zu absorbieren und eine gemütliche, einladende Atmosphäre zu schaffen. Sie werden oft in Wohnzimmern, Schlafzimmern und anderen Räumen verwendet, in denen Komfort und Stil wichtig sind.  Ein moderner Hochflorteppich ist eine luxuriöse und stilvolle Ergänzung für jedes Zuhause. Seine weiche, plüschige Textur und sein schlankes, modernes Aussehen machen ihn zu einer beliebten Wahl für diejenigen, die ihrem Wohnraum Komfort und Stil verleihen möchten.",
           },
@@ -315,24 +309,20 @@ describe(`with ashenRug preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Ashen Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Ashen Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Teppich "Ashen"",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -340,24 +330,20 @@ describe(`with ashenRug preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "ashen-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "ashen-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "ashen-teppich",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ben-pillow-cover.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ben-pillow-cover.spec.ts
@@ -174,12 +174,10 @@ describe(`with benPillowCover preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedding",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -187,17 +185,14 @@ describe(`with benPillowCover preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Ben Pillow Cover is a brown linen decorative pillowcase used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size rectangle decorative pillow. It features a neutral brown color that can complement a wide variety of decor styles and color schemes.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are typically finished with a neat hem, which adds a polished look to the overall design.  The pillowcase is often used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a brown linen decorative pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Ben Pillow Cover is a brown linen decorative pillowcase used to add visual interest and texture to a room. It is made from a natural linen fabric, which is known for its durability, breathability, and classic look.  The pillowcase is designed to fit over a standard size rectangle decorative pillow. It features a neutral brown color that can complement a wide variety of decor styles and color schemes.  The linen fabric has a soft and slightly textured surface that adds a cozy and inviting feel to the pillow. The edges of the pillowcase are typically finished with a neat hem, which adds a polished look to the overall design.  The pillowcase is often used to add a touch of warmth and natural elegance to a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different shapes and colors to create a layered and cohesive look.  Overall, a brown linen decorative pillowcase is a versatile and timeless accent piece that can enhance the comfort and style of any room in the home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Der Kissenbezug "Ben" ist ein dekorativer Kissenbezug aus braunem Leinen. Er ist ein visueller Akzent in jedem Raum. Er besteht aus einem natürlichen Leinenstoff, der für seine Haltbarkeit, Atmungsaktivität und seinen klassischen Look bekannt ist.  Der Kissenbezug ist so konzipiert, dass er über ein rechteckiges dekoratives Kissen in Standardgröße passt. Es verfügt über eine neutrale braune Farbe, die eine Vielzahl von Einrichtungsstilen und Farbschemata ergänzen kann.  Der Leinenstoff hat eine weiche und leicht strukturierte Oberfläche, die dem Kissen ein gemütliches und einladendes Gefühl verleiht. Die Kanten des Kissenbezugs sind in der Regel mit einem sauberen Saum versehen, der dem Gesamtdesign einen eleganten Look verleiht.  Der Kissenbezug wird oft verwendet, um einem Raum einen Hauch von Wärme und natürlicher Eleganz zu verleihen, egal ob er auf einem Bett, einem Sofa oder einem Akzentstuhl platziert wird. Es kann allein verwendet oder mit anderen dekorativen Kissen in verschiedenen Formen und Farben kombiniert werden, um einen mehrschichtigen und zusammenhängenden Look zu schaffen.  Insgesamt ist ein dekorativer Kissenbezug aus braunem Leinen ein vielseitiges und zeitloses Akzentstück, das den Komfort und Stil jedes Raums im Haus verbessern kann.",
           },
@@ -294,24 +289,20 @@ describe(`with benPillowCover preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Ben Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Ben Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Kissenbezug "Ben"",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -319,24 +310,20 @@ describe(`with benPillowCover preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "ben-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "ben-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "ben-kissenbezug",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/braided-rug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/braided-rug.spec.ts
@@ -179,17 +179,14 @@ describe(`with braidedRug preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "rugs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -197,17 +194,14 @@ describe(`with braidedRug preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A braided round jute rug for the living room is a stylish and natural home decor accessory that can add warmth and texture to any space. The rug is made from durable and sustainable jute fibers, which are braided together to create a round shape.  The braided construction of the rug creates a textured surface that is both soft and durable underfoot. The natural fibers of the jute give the rug a warm and earthy appearance, making it a perfect complement to a range of decor styles, from modern and minimalist to rustic and bohemian.  The round shape of the rug is ideal for creating a cozy and intimate seating area in a larger living room or for adding visual interest to a smaller space.   Overall, a braided round jute rug is a stylish and natural way to add warmth and texture to a living room. Its durable and sustainable construction, combined with its warm and earthy appearance, make it a versatile and timeless home decor accessory that can be enjoyed for years to come.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A braided round jute rug for the living room is a stylish and natural home decor accessory that can add warmth and texture to any space. The rug is made from durable and sustainable jute fibers, which are braided together to create a round shape.  The braided construction of the rug creates a textured surface that is both soft and durable underfoot. The natural fibers of the jute give the rug a warm and earthy appearance, making it a perfect complement to a range of decor styles, from modern and minimalist to rustic and bohemian.  The round shape of the rug is ideal for creating a cozy and intimate seating area in a larger living room or for adding visual interest to a smaller space.   Overall, a braided round jute rug is a stylish and natural way to add warmth and texture to a living room. Its durable and sustainable construction, combined with its warm and earthy appearance, make it a versatile and timeless home decor accessory that can be enjoyed for years to come.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser geflochtene, runde Juteteppich für das Wohnzimmer ist ein stilvolles und natürliches Wohnaccessoire, welches jedem Raum Wärme und Struktur verleiht. Der Teppich besteht aus strapazierfähigen und nachhaltigen Jutefasern, die zu einer runden Form zusammengeflochten sind.  Das Flechtmuster des Teppichs erzeugt eine strukturierte Oberfläche, die sowohl weich als auch strapazierfähig ist. Die Naturfasern der Jute verleihen dem Teppich ein warmes und erdiges Aussehen und machen ihn zu einer perfekten Ergänzung für eine Reihe von Einrichtungsstilen, von modern und minimalistisch bis hin zu rustikal und unkonventionell.  Die runde Form des Teppichs ist ideal, um einen gemütlichen und intimen Sitzbereich in einem größeren Wohnzimmer zu schaffen oder um einem kleineren Raum visuelle Finesse zu verleihen. Ein geflochtener runder Juteteppich eine stilvolle und natürliche Möglichkeit, einem Wohnzimmer Wärme und Textur zu verleihen. Seine langlebige und nachhaltige Konstruktion, kombiniert mit seinem warmen und erdigen Aussehen, machen es zu einem vielseitigen und zeitlosen Wohnaccessoire, an dem Sie jahrelang Freude haben werden.",
           },
@@ -316,24 +310,20 @@ describe(`with braidedRug preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Braided Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Braided Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Geflochtener Teppich",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -341,24 +331,20 @@ describe(`with braidedRug preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "braided-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "braided-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "geflochtener-teppich",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/bruno-chair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/bruno-chair.spec.ts
@@ -187,17 +187,14 @@ describe(`with brunoChair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -205,17 +202,14 @@ describe(`with brunoChair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A modern linen and wood chair features a simple yet stylish design. The chair has a sleek wooden frame, which is stained in a natural wood finish. The seat and backrest are made of a soft linen fabric that is padded for comfort. The linen fabric is a neutral beige.  The backrest of the chair is slightly angled, providing additional comfort and support for the user. The legs of the chair are slightly tapered and have protective foot pads to prevent damage to flooring.  Overall, this modern linen and wood chair is a versatile and elegant addition to any living room, dining room, or office space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A modern linen and wood chair features a simple yet stylish design. The chair has a sleek wooden frame, which is stained in a natural wood finish. The seat and backrest are made of a soft linen fabric that is padded for comfort. The linen fabric is a neutral beige.  The backrest of the chair is slightly angled, providing additional comfort and support for the user. The legs of the chair are slightly tapered and have protective foot pads to prevent damage to flooring.  Overall, this modern linen and wood chair is a versatile and elegant addition to any living room, dining room, or office space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein moderner Stuhl aus Leinen und Holz zeichnet sich durch ein einfaches, aber stilvolles Design aus. Der Stuhl hat einen schlanken Holzrahmen, der in einem natürlichen Holzfinish gebeizt ist. Der Sitz und die Rückenlehne bestehen aus einem weichen Leinenstoff, der für Komfort gepolstert ist. Der Leinenstoff ist ein neutrales Beige.  Die Rückenlehne des Stuhls ist leicht angewinkelt, was dem Benutzer zusätzlichen Komfort und Unterstützung bietet. Die Beine des Stuhls sind leicht konisch und haben schützende Fußpolster, um Schäden am Bodenbelag zu vermeiden.  Insgesamt ist dieser moderne Leinen- und Holzstuhl eine vielseitige und elegante Ergänzung für jedes Wohnzimmer, Esszimmer oder Büro.",
           },
@@ -320,24 +314,20 @@ describe(`with brunoChair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Bruno Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Bruno Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Sessel "Bruno"",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -345,24 +335,20 @@ describe(`with brunoChair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "bruno-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "bruno-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "bruno-stuhl",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/canela-three-seater-sofa.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/canela-three-seater-sofa.spec.ts
@@ -200,17 +200,14 @@ describe(`with canelaThreeSeaterSofa preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "sofas",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -218,17 +215,14 @@ describe(`with canelaThreeSeaterSofa preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A leather three-seater sofa is a piece of furniture designed to provide comfortable seating for three people. The sofa is made of high-quality leather, which is known for its durability, strength, and natural beauty. The leather material is treated with protective coatings to make it more resistant to wear and tear, stains, and spills.  The sofa features a sturdy frame made of wood, with a series of springs and cushions providing support and comfort for the seated individuals. The cushions are filled with down feathers.  The leather sofa has clean lines and minimal decorative elements for a more modern or contemporary look.  Overall, a leather three-seater sofa is a versatile and stylish piece of furniture that can provide comfortable seating and add a touch of elegance to any living space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A leather three-seater sofa is a piece of furniture designed to provide comfortable seating for three people. The sofa is made of high-quality leather, which is known for its durability, strength, and natural beauty. The leather material is treated with protective coatings to make it more resistant to wear and tear, stains, and spills.  The sofa features a sturdy frame made of wood, with a series of springs and cushions providing support and comfort for the seated individuals. The cushions are filled with down feathers.  The leather sofa has clean lines and minimal decorative elements for a more modern or contemporary look.  Overall, a leather three-seater sofa is a versatile and stylish piece of furniture that can provide comfortable seating and add a touch of elegance to any living space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Leder-Dreisitzer-Sofa ist ein Möbelstück, das entworfen wurde, um bequemen Platz für drei Personen zu bieten. Das Sofa ist aus hochwertigem Leder gefertigt, das für seine Langlebigkeit, Stärke und natürliche Schönheit bekannt ist. Das Ledermaterial ist mit einer Schutzbeschichtung behandelt, um es widerstandsfähiger gegen Abnutzung, Flecken und Spritzer zu machen.  Das Sofa verfügt über einen stabilen Rahmen aus Holz mit einer Reihe von Federn und Kissen, die den sitzenden Personen Halt und Komfort bieten. Die Kissen sind mit Daunenfedern gefüllt.  Das Ledersofa hat klare Linien und minimale dekorative Elemente für einen moderneren oder zeitgemäßeren Look.  Ein Leder-Dreisitzer-Sofa ein vielseitiges und stilvolles Möbelstück, das bequeme Sitzgelegenheiten bietet und jedem Wohnraum einen Hauch von Eleganz verleiht.",
           },
@@ -341,24 +335,20 @@ describe(`with canelaThreeSeaterSofa preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Canela Three-Seater Sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Canela Three-Seater Sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Canela 3-Sitzer-Sofa",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -366,24 +356,20 @@ describe(`with canelaThreeSeaterSofa preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "canela-three-seater-sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "canela-three-seater-sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "canela-3-sitzer-sofa",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/charcoal-chair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/charcoal-chair.spec.ts
@@ -196,17 +196,14 @@ describe(`with charcoalChair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -214,17 +211,14 @@ describe(`with charcoalChair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This chair with leather upholstery features a sturdy frame and legs. The seat and backrest are covered in high-quality leather, which may be smooth or textured depending on the design. The leather is stretched taut over a layer of padding to provide comfort and support for the person sitting in the chair.  The chair has a high backrest making it ideal for the dining room or a study room.  Overall, a chair with leather upholstery is typically sleek and modern in design, providing a comfortable and stylish seating option for any room.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This chair with leather upholstery features a sturdy frame and legs. The seat and backrest are covered in high-quality leather, which may be smooth or textured depending on the design. The leather is stretched taut over a layer of padding to provide comfort and support for the person sitting in the chair.  The chair has a high backrest making it ideal for the dining room or a study room.  Overall, a chair with leather upholstery is typically sleek and modern in design, providing a comfortable and stylish seating option for any room.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser Stuhl mit Lederbezug verfügt über einen stabilen Rahmen und Beine. Sitzfläche und Rückenlehne sind mit hochwertigem Leder bezogen, das je nach Ausführung glatt oder strukturiert sein kann. Das Leder wird straff über eine Polsterschicht gespannt, um der auf dem Stuhl sitzenden Person Komfort und Halt zu bieten.  Der Stuhl hat eine hohe Rückenlehne, was ihn ideal für das Esszimmer oder ein Arbeitszimmer macht.  Ein Stuhl mit Lederpolsterung ist elegant und modern im Design und bietet eine komfortable und stilvolle Sitzgelegenheit für jeden Raum.",
           },
@@ -337,24 +331,20 @@ describe(`with charcoalChair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Charcoal Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Charcoal Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Stuhl "Hokzkohle"",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -362,24 +352,20 @@ describe(`with charcoalChair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "charcoal-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "charcoal-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "holzkohle-stuhl",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/charlie-armchair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/charlie-armchair.spec.ts
@@ -188,17 +188,14 @@ describe(`with charlieArmchair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -206,17 +203,14 @@ describe(`with charlieArmchair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A corduroy chair with wooden legs has a cozy and rustic feel. The chair has a sturdy wooden frame and four straight, tapered legs that support the seat and backrest. The corduroy upholstery is soft and plush fabric with a distinctive ribbed texture that adds visual interest and depth to the chair. The color of the corduroy is a warm and earthy tone. The wooden legs are finished in a natural wood stain. The chair has a simple and understated design that complements a variety of interior decor styles.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A corduroy chair with wooden legs has a cozy and rustic feel. The chair has a sturdy wooden frame and four straight, tapered legs that support the seat and backrest. The corduroy upholstery is soft and plush fabric with a distinctive ribbed texture that adds visual interest and depth to the chair. The color of the corduroy is a warm and earthy tone. The wooden legs are finished in a natural wood stain. The chair has a simple and understated design that complements a variety of interior decor styles.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser Sessel mit Kordbezug und Holzbeinen hat eine gemütliche und rustikale Ausstrahlung. Der Stuhl hat einen stabilen Holzrahmen und vier gerade, sich verjüngende Beine, die den Sitz und die Rückenlehne tragen. Die Kordpolsterung ist ein weicher und plüschiger Stoff mit einer unverwechselbaren gerippten Textur, die dem Stuhl visuelle Rafinesse und Tiefe verleiht. Der Kordstoff ist in einem warmem und erdigen Ton gehalten. Die Holzbeine sind natürlich gebeizt. Der Stuhl hat ein einfaches und dezentes Design, das zu einer Vielzahl von Einrichtungsstilen passt.",
           },
@@ -321,24 +315,20 @@ describe(`with charlieArmchair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Charlie Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Charlie Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Sessel "Charlie"",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -346,24 +336,20 @@ describe(`with charlieArmchair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "charlie-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "charlie-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "charlie-sessel",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/chianti-wine-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/chianti-wine-glass.spec.ts
@@ -145,17 +145,14 @@ describe(`with chiantiWineGlass preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -163,17 +160,14 @@ describe(`with chiantiWineGlass preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Chianti Wine Glass is specifically designed to enhance the experience of drinking red wine. It has a round or slightly tapered bowl that is larger than that of a white wine glass, allowing the wine to breathe and develop its full aroma and flavor.  The bowl of a red wine glass is wider at the base and tapers slightly towards the top, helping to concentrate the aromas of the wine and directing them towards the nose. The stem of the glass is typically long and slender, allowing the drinker to hold the glass without warming the wine with their body heat.  Overall, a red wine glass is a stylish and functional piece of glassware that is specifically designed to enhance the flavor and aroma of red wine. Its elegant design and attention to detail make it a popular choice for wine enthusiasts and casual drinkers alike.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Chianti Wine Glass is specifically designed to enhance the experience of drinking red wine. It has a round or slightly tapered bowl that is larger than that of a white wine glass, allowing the wine to breathe and develop its full aroma and flavor.  The bowl of a red wine glass is wider at the base and tapers slightly towards the top, helping to concentrate the aromas of the wine and directing them towards the nose. The stem of the glass is typically long and slender, allowing the drinker to hold the glass without warming the wine with their body heat.  Overall, a red wine glass is a stylish and functional piece of glassware that is specifically designed to enhance the flavor and aroma of red wine. Its elegant design and attention to detail make it a popular choice for wine enthusiasts and casual drinkers alike.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das Chianti Weinglas wurde speziell entwickelt, um das Erlebnis beim Trinken von Rotwein zu verbessern. Es hat einen runden oder leicht konisch zulaufenden Körper, der größer ist als der eines Weißweinglases, wodurch der Wein atmen und sein volles Aroma und seinen vollen Geschmack entfalten kann.  Das Rotweinglas ist unten breiter und verjüngt sich leicht nach oben, wodurch die Aromen des Weins konzentriert und zur Nase geleitet werden. Der Stiel des Glases ist lang und schlank. Dadurch kann das Glas gehalten werden, ohne den Wein zu erwärmen. Dieses Rotweinglas ist ein stilvolles und funktionales Glas, das speziell entwickelt wurde, um den Geschmack und das Aroma von Rotwein zu verbessern. Sein elegantes Design und die Liebe zum Detail machen es zu einer beliebten Wahl für Weinliebhaber und Gelegenheitstrinker gleichermaßen.",
           },
@@ -258,24 +252,20 @@ describe(`with chiantiWineGlass preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Chianti Wine Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Chianti Wine Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Chianti Weinglas",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -283,24 +273,20 @@ describe(`with chiantiWineGlass preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "chianti-wine-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "chianti-wine-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "chianti-weinglas",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-beer-mug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-beer-mug.spec.ts
@@ -145,17 +145,14 @@ describe(`with classicBeerMug preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -163,17 +160,14 @@ describe(`with classicBeerMug preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This Classic Beer Mug has a thick and sturdy handle that makes it easy to hold and prevents the drinker's hand from warming the beer. The mug is made of glass. This design allows the beer to settle and develop its full flavor and aroma. The thick walls of the mug help to insulate the beer and keep it cold for longer.  The mug typically holds between 12 and 20 ounces of beer. The mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This Classic Beer Mug has a thick and sturdy handle that makes it easy to hold and prevents the drinker's hand from warming the beer. The mug is made of glass. This design allows the beer to settle and develop its full flavor and aroma. The thick walls of the mug help to insulate the beer and keep it cold for longer.  The mug typically holds between 12 and 20 ounces of beer. The mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser klassische Bierkrug hat einen robusten Griff, der das Halten erleichtert und verhindert, dass die Hand des Trinkers das Bier erwärmt. Als Material wird hochwertiges Glas eingesetzt. Durch dieses Design kann das Bier seinen vollen Geschmack und sein volles Aroma entfalten. Die robusten Wände des Krugs bilden eine Art Isolationsschicht und halten somit länger das Bier länger kalt.  Der Becher fasst normalerweise zwischen 12 und 20 Unzen Bier. Der Becher ist leicht zu reinigen und zu pflegen. Es kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.",
           },
@@ -258,24 +252,20 @@ describe(`with classicBeerMug preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Classic Beer Mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Classic Beer Mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Klassisches Bierglas",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -283,24 +273,20 @@ describe(`with classicBeerMug preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "classic-beer-mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "classic-beer-mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "klassischer-bierkrug",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-champagne-glasses.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-champagne-glasses.spec.ts
@@ -180,17 +180,14 @@ describe(`with classicChampagneGlasses preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -198,17 +195,14 @@ describe(`with classicChampagneGlasses preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Classic champagne flutes are tall and slender stemware glasses that are designed specifically for serving champagne or other sparkling wines. They have a narrow and elongated bowl that tapers towards the top, which helps to preserve the carbonation and aroma of the wine.  The stem of the flute is long and thin, which allows the drinker to hold the glass without warming the contents inside. This is important because champagne and other sparkling wines are typically served chilled and can lose their effervescence if they become too warm.  The base of the flute is broad and sturdy, which provides stability and balance to the glass. The classic design of the champagne flute is elegant and timeless, making it a popular choice for formal occasions and celebrations.  The glasses are made from high-quality crystal or glass, which gives them a clear and sparkling appearance. Some champagne flutes may also feature decorative etching or patterns on the bowl or stem, adding an extra touch of elegance to the design.  Overall, classic champagne flutes are a stylish and elegant way to serve champagne and other sparkling wines. Their unique design and high-quality materials make them a popular choice for special occasions, such as weddings, anniversaries, or New Year's Eve celebrations.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Classic champagne flutes are tall and slender stemware glasses that are designed specifically for serving champagne or other sparkling wines. They have a narrow and elongated bowl that tapers towards the top, which helps to preserve the carbonation and aroma of the wine.  The stem of the flute is long and thin, which allows the drinker to hold the glass without warming the contents inside. This is important because champagne and other sparkling wines are typically served chilled and can lose their effervescence if they become too warm.  The base of the flute is broad and sturdy, which provides stability and balance to the glass. The classic design of the champagne flute is elegant and timeless, making it a popular choice for formal occasions and celebrations.  The glasses are made from high-quality crystal or glass, which gives them a clear and sparkling appearance. Some champagne flutes may also feature decorative etching or patterns on the bowl or stem, adding an extra touch of elegance to the design.  Overall, classic champagne flutes are a stylish and elegant way to serve champagne and other sparkling wines. Their unique design and high-quality materials make them a popular choice for special occasions, such as weddings, anniversaries, or New Year's Eve celebrations.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Klassische Champagnerflöten sind hohe und schlanke Stielgläser, die speziell zum Servieren von Champagner oder anderen Schaumweinen entwickelt wurden. Sie haben einen schmalen und länglichen Kelch, der sich nach oben hin verjüngt, wodurch die Kohlensäure und das Aroma des Weins erhalten bleiben.  Der Stiel ist lang und dünn und verhindert das Erwärmen des Champagners durch Körperwärme. Dies ist wichtig, da Champagner und andere Schaumweine normalerweise gekühlt serviert werden und ihre Spritzigkeit verlieren können, wenn sie zu warm werden.  Die Basis des Glases ist breit und robust, was dem Glas Stabilität und Gleichgewicht verleiht. Das klassische Design der Champagnerflöte ist elegant und zeitlos, was sie zu einer beliebten Wahl für formelle Anlässe und Feiern macht.  Die Gläser sind aus hochwertigem Kristall oder Glas gefertigt, was ihnen ein klares und funkelndes Aussehen verleiht. Einige Champagnerflöten können auch dekorative Ätzungen oder Muster auf dem Kelch oder Stiel aufweisen, was dem Design einen zusätzlichen Hauch von Eleganz verleiht.  Insgesamt sind klassische Champagnerflöten eine stilvolle und elegante Art, Champagner und andere Schaumweine zu servieren. Ihr einzigartiges Design und hochwertige Materialien machen sie zu einer beliebten Wahl für besondere Anlässe wie Hochzeiten, Jubiläen oder Silvesterfeiern.",
           },
@@ -321,24 +315,20 @@ describe(`with classicChampagneGlasses preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Classic Champagne Glasses",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Classic Champagne Glasses",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Klassische Champagnergläser",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -346,24 +336,20 @@ describe(`with classicChampagneGlasses preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "classic-champagne-glasses",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "classic-champagne-glasses",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "klassische-champagnerglser",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-coffee-cup.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-coffee-cup.spec.ts
@@ -183,17 +183,14 @@ describe(`with classicCoffeeCup preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -201,17 +198,14 @@ describe(`with classicCoffeeCup preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Classic Coffee Cup is a classic drinking vessel that can be used to serve coffee in formal settings. The cup is made of ceramic or porcelain and has a cylindrical shape with a handle on one side. It may be plain in design and has a capacity of around 6 to 8 ounces.  The saucer is a small plate that is round and is designed to hold the coffee cup when it is not in use. It is made of the same material as the cup. The saucer has a rim or edge that is slightly raised to help prevent spills.  When serving coffee in a cup with a saucer, it is common to also provide a small spoon for stirring the coffee and adding sugar or cream. Overall, a coffee cup with a saucer is a classic and elegant way to enjoy a cup of coffee, and is often associated with sophistication and refinement.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Classic Coffee Cup is a classic drinking vessel that can be used to serve coffee in formal settings. The cup is made of ceramic or porcelain and has a cylindrical shape with a handle on one side. It may be plain in design and has a capacity of around 6 to 8 ounces.  The saucer is a small plate that is round and is designed to hold the coffee cup when it is not in use. It is made of the same material as the cup. The saucer has a rim or edge that is slightly raised to help prevent spills.  When serving coffee in a cup with a saucer, it is common to also provide a small spoon for stirring the coffee and adding sugar or cream. Overall, a coffee cup with a saucer is a classic and elegant way to enjoy a cup of coffee, and is often associated with sophistication and refinement.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Die Classic Coffee Cup ist ein klassisches Trinkgefäß, das zum Servieren von Kaffee in formellen Umgebungen verwendet werden kann. Die Tasse besteht aus Keramik oder Porzellan und hat eine zylindrische Form mit einem Henkel an einer Seite. Es kann schlicht im Design sein und hat eine Kapazität von etwa 6 bis 8 Unzen.  Die Untertasse ist ein kleiner Teller, der rund ist und dazu dient, die Kaffeetasse zu halten, wenn sie nicht verwendet wird. Es besteht aus dem gleichen Material wie die Tasse. Die Untertasse hat einen Rand oder Rand, der leicht erhöht ist, um ein Verschütten zu verhindern.  Beim Servieren von Kaffee in einer Tasse mit Untertasse ist es üblich, auch einen kleinen Löffel zum Umrühren des Kaffees und zum Hinzufügen von Zucker oder Sahne bereitzustellen. Insgesamt ist eine Kaffeetasse mit Untertasse eine klassische und elegante Art, eine Tasse Kaffee zu genießen, und wird oft mit Raffinesse und Raffinesse in Verbindung gebracht.",
           },
@@ -316,24 +310,20 @@ describe(`with classicCoffeeCup preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Classic Coffee Cup",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Classic Coffee Cup",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Klassische Kaffeetasse",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -341,24 +331,20 @@ describe(`with classicCoffeeCup preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "classic-coffee-cup",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "classic-coffee-cup",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "klassische-kaffeetasse",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-serving-tray.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/classic-serving-tray.spec.ts
@@ -185,22 +185,18 @@ describe(`with classicServingTray preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "serving-platters",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serveware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -208,17 +204,14 @@ describe(`with classicServingTray preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This Classic Serving Tray is a versatile and functional item that can be used in a variety of settings. The tray is rectangular, with raised edges and handles on either side, making it easy to carry and transport.  This Classic Serving Tray features a simple and timeless design, with clean lines and a minimalist aesthetic. It can be used for a variety of purposes, such as carrying drinks and appetizers, serving breakfast in bed, or displaying decorative items.  To clean, it is recommended to wash it by hand with a mild detergent, using a soft cloth or sponge. Harsh cleaning agents or abrasives should be avoided, as they can damage the surface of the tray.  Overall, a classic serving tray is a practical and stylish item that adds a touch of sophistication to any setting. Its timeless design and versatility make it a popular choice for serving and displaying food, drinks, and other items.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This Classic Serving Tray is a versatile and functional item that can be used in a variety of settings. The tray is rectangular, with raised edges and handles on either side, making it easy to carry and transport.  This Classic Serving Tray features a simple and timeless design, with clean lines and a minimalist aesthetic. It can be used for a variety of purposes, such as carrying drinks and appetizers, serving breakfast in bed, or displaying decorative items.  To clean, it is recommended to wash it by hand with a mild detergent, using a soft cloth or sponge. Harsh cleaning agents or abrasives should be avoided, as they can damage the surface of the tray.  Overall, a classic serving tray is a practical and stylish item that adds a touch of sophistication to any setting. Its timeless design and versatility make it a popular choice for serving and displaying food, drinks, and other items.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieses klassische Serviertablett ist ein vielseitiger und funktionaler Artikel. Das Tablett ist rechteckig, mit erhöhten Kanten und Griffen auf beiden Seiten, wodurch es leicht zu tragen und zu transportieren ist.  Dieses klassische Serviertablett zeichnet sich durch ein einfaches und zeitloses Design mit klaren Linien und einer minimalistischen Ästhetik aus. Es kann für eine Vielzahl von Zwecken verwendet werden, z. B. zum Transport von Getränken und Häppchen, zum Servieren des Frühstücks am Bett oder zum Präsentieren von Dekorationsgegenständen.  Zur Reinigung wird empfohlen, es mit einem milden Reinigungsmittel und einem weichen Tuch oder Schwamm von Hand zu waschen. Scharfe Reinigungsmittel oder Scheuermittel sollten vermieden werden, da sie die Oberfläche des Tabletts beschädigen können. Zusammengefasst handelt es sich um ein klassisches Serviertablett mit praktischen und stilvollen Elementen, welches jeder Umgebung einen Hauch von Raffinesse verleiht. Sein zeitloses Design und seine Vielseitigkeit machen es zu einer beliebten Wahl zum Servieren und Präsentieren von Speisen, Getränken und anderen Gegenständen.",
           },
@@ -323,24 +316,20 @@ describe(`with classicServingTray preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Classic Serving Tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Classic Serving Tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Klassisches Serviertablett",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -348,24 +337,20 @@ describe(`with classicServingTray preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "classic-serving-tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "classic-serving-tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "klassisches-serviertablett",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/clink-champagne-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/clink-champagne-glass.spec.ts
@@ -146,17 +146,14 @@ describe(`with clinkChampagneGlass preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -164,17 +161,14 @@ describe(`with clinkChampagneGlass preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A tapered champagne glass, also known as a champagne flute, is a type of stemware that is specifically designed to enhance the experience of drinking champagne or sparkling wine. The glass has a tall, narrow bowl that tapers towards the top, allowing the drinker to see the bubbles rising to the surface of the drink.  The tall, slender stem of the glass helps to keep the drinker's hand away from the bowl, preventing the champagne from being warmed by body heat. The base of the glass is typically wide and flat, providing stability and balance.  The design of the tapered champagne glass is intended to enhance the aroma and flavor of the drink. The narrow bowl concentrates the bubbles and the aroma of the champagne, directing it towards the drinker's nose. This allows the drinker to fully appreciate the aroma and flavor of the champagne.  The tapered champagne glass is typically used for serving champagne or other sparkling wines, but may also be used for other carbonated drinks or cocktails. It is easy to clean and maintain, and can be washed by hand or in a dishwasher.  Overall, the tapered champagne glass is a stylish and elegant piece of stemware that is specifically designed to enhance the experience of drinking champagne or sparkling wine. Its unique design and attention to detail make it a popular choice for special occasions and celebrations.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A tapered champagne glass, also known as a champagne flute, is a type of stemware that is specifically designed to enhance the experience of drinking champagne or sparkling wine. The glass has a tall, narrow bowl that tapers towards the top, allowing the drinker to see the bubbles rising to the surface of the drink.  The tall, slender stem of the glass helps to keep the drinker's hand away from the bowl, preventing the champagne from being warmed by body heat. The base of the glass is typically wide and flat, providing stability and balance.  The design of the tapered champagne glass is intended to enhance the aroma and flavor of the drink. The narrow bowl concentrates the bubbles and the aroma of the champagne, directing it towards the drinker's nose. This allows the drinker to fully appreciate the aroma and flavor of the champagne.  The tapered champagne glass is typically used for serving champagne or other sparkling wines, but may also be used for other carbonated drinks or cocktails. It is easy to clean and maintain, and can be washed by hand or in a dishwasher.  Overall, the tapered champagne glass is a stylish and elegant piece of stemware that is specifically designed to enhance the experience of drinking champagne or sparkling wine. Its unique design and attention to detail make it a popular choice for special occasions and celebrations.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein konisches Champagnerglas, auch als Champagnerflöte bekannt, ist ein Glas, das speziell entwickelt wurde, um das Erlebnis beim Trinken von Champagner oder Sekt zu verbessern. Das Glas hat einen hohen, schmalen Kelch, der sich nach oben hin verjüngt - schauen Sie zu wie sich die Bläschen in Ihrem Glas tanzen. Der hohe, schlanke Stiel des Glases verhindert das Aufwärmen des Getränks durch Körperwärme. Die Basis des Glases ist breit und flach und sorgt für Stabilität und Balance.  Das Design des konisch zulaufenden Sektglases soll das Aroma und den Geschmack des Getränks verstärken. Der schmale Kelch konzentriert die Bläschen und das Aroma des Champagner. Dadurch können Sie den Geschmack des Champagners voll und ganz genießen.  Das konische Sektglas wird typischerweise zum Servieren von Sekt oder anderen Schaumweinen verwendet, kann aber auch für andere kohlensäurehaltige Getränke oder Cocktails verwendet werden. Es ist leicht zu reinigen und zu pflegen und kann von Hand oder in der Spülmaschine gewaschen werden.  Insgesamt ist das konische Champagnerglas ein stilvolles und elegantes Stielglas, das speziell entwickelt wurde, um das Erlebnis beim Trinken von Champagner oder Sekt zu verbessern. Sein einzigartiges Design und die Liebe zum Detail machen es zu einer beliebten Wahl für besondere Anlässe und Feiern.",
           },
@@ -259,24 +253,20 @@ describe(`with clinkChampagneGlass preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Clink Champagne Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Clink Champagne Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Sektgläser zum Anstoßen",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -284,24 +274,20 @@ describe(`with clinkChampagneGlass preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "clink-champagne-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "clink-champagne-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "sektglas-anstoen",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cloud-queen-bed.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cloud-queen-bed.spec.ts
@@ -180,17 +180,14 @@ describe(`with cloudQueenBed preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "beds",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
@@ -198,17 +195,14 @@ describe(`with cloudQueenBed preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A queen-sized bed with fabric upholstery and a pillow-like headboard is a comfortable and elegant piece of bedroom furniture. The bed frame is rectangular and large enough to accommodate a standard queen-sized mattress. The fabric upholstery covers the entire frame, creating a smooth and comfortable surface to lean against. The headboard is the centerpiece of the bed, with a soft and plush surface that resembles a pillow. It is rectangular in shape and attached to the top of the bed frame, providing a comfortable backrest for reading or watching TV in bed. The headboard may be upholstered in the same fabric as the bed frame or in a complementary color or pattern. Overall, this bed combines comfort and style, making it a perfect addition to any bedroom.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A queen-sized bed with fabric upholstery and a pillow-like headboard is a comfortable and elegant piece of bedroom furniture. The bed frame is rectangular and large enough to accommodate a standard queen-sized mattress. The fabric upholstery covers the entire frame, creating a smooth and comfortable surface to lean against. The headboard is the centerpiece of the bed, with a soft and plush surface that resembles a pillow. It is rectangular in shape and attached to the top of the bed frame, providing a comfortable backrest for reading or watching TV in bed. The headboard may be upholstered in the same fabric as the bed frame or in a complementary color or pattern. Overall, this bed combines comfort and style, making it a perfect addition to any bedroom.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Queensize-Bett mit Stoffbezug - auch auf dem Kopfteil  - ist ein komfortables und elegantes Schlafzimmermöbel. Der Bettrahmen ist rechteckig und groß genug, um eine Standardmatratze in Queen-Size-Größe aufzunehmen. Die Stoffpolsterung bedeckt den gesamten Rahmen und schafft eine glatte und bequeme Oberfläche zum Anlehnen. Das Kopfteil ist das Herzstück des Bettes, mit einer weichen und plüschigen Oberfläche, die einem Kissen ähnelt. Es hat eine rechteckige Form und ist oben am Bettrahmen befestigt und bietet eine bequeme Rückenlehne zum Lesen oder Fernsehen im Bett. Das Kopfteil kann mit dem gleichen Stoff wie der Bettrahmen oder in einer komplementären Farbe oder einem Muster bezogen werden. Insgesamt vereint dieses Bett Komfort und Stil und ist somit eine perfekte Ergänzung für jedes Schlafzimmer.",
           },
@@ -313,24 +307,20 @@ describe(`with cloudQueenBed preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Cloud Queen Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Cloud Queen Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Queen-Bett "Cloud"",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -338,24 +328,20 @@ describe(`with cloudQueenBed preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "cloud-queen-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "cloud-queen-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "cloud-queen-bett",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/cobblestone-rug.spec.ts
@@ -155,17 +155,14 @@ describe(`with cobblestoneRug preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "rugs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -173,17 +170,14 @@ describe(`with cobblestoneRug preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser Strukturteppich kann in einer Vielzahl von Räumen verwendet werden, von Wohnzimmern über Schlafzimmer bis hin zu Heimbüros. Er ist besonders beliebt in modernen und zeitgenössischen Einrichtungsstilen. Hier kann er ein mutiger und grafischer Hingucker sein.  Insgesamt ist ein Teppich mit geometrischen Akzenten eine stilvolle und vielseitige Designwahl, die jedem Raum im Haus visuelles Interesse und Textur verleihen kann.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Cobblestone Rug can be used in a variety of spaces, from living rooms to bedrooms to home offices. It is especially popular in modern and contemporary decor styles, where they can add a bold and graphic element to the space.  Overall, a geometric accent rug is a stylish and versatile design choice that can add visual interest and texture to any room in the home.",
           },
@@ -272,24 +266,20 @@ describe(`with cobblestoneRug preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Cobblestone Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Cobblestone Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Strukturteppich "Kopfsteinpflaster"",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -297,24 +287,20 @@ describe(`with cobblestoneRug preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "cobblestone-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "kopfsteinpflaster",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "cobblestone-rug",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/geometric-pillow-case.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/geometric-pillow-case.spec.ts
@@ -435,17 +435,14 @@ describe(`with geometricPillowCase preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bedding",
             "typeId": "category",
           },
@@ -453,17 +450,14 @@ describe(`with geometricPillowCase preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A geometric pillowcase for throw pillows is a stylish and modern home decor accessory that can add a pop of visual interest to any room. The pillowcase is typically made from a soft and durable material, such as cotton, linen, or polyester, and features a bold geometric pattern that creates a sense of depth and dimension.  The geometric pattern on the pillowcase is typically created using a variety of shapes, such as triangles, squares, or hexagons, arranged in a repeating pattern. The pillowcase features a zipper closure, making it easy to remove and wash as needed.  The geometric pillowcase is a versatile and stylish accessory that can be used to accent a variety of decor styles, from modern and minimalist to bohemian and eclectic. It is perfect for complementing other patterned decor elements in a more eclectic space.  Overall, a geometric pillowcase for throw pillows is a stylish and versatile accessory that can help to create a cohesive and visually interesting decor scheme in any room. Its bold and modern design, combined with its soft and durable materials, make it a must-have accessory for any home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A geometric pillowcase for throw pillows is a stylish and modern home decor accessory that can add a pop of visual interest to any room. The pillowcase is typically made from a soft and durable material, such as cotton, linen, or polyester, and features a bold geometric pattern that creates a sense of depth and dimension.  The geometric pattern on the pillowcase is typically created using a variety of shapes, such as triangles, squares, or hexagons, arranged in a repeating pattern. The pillowcase features a zipper closure, making it easy to remove and wash as needed.  The geometric pillowcase is a versatile and stylish accessory that can be used to accent a variety of decor styles, from modern and minimalist to bohemian and eclectic. It is perfect for complementing other patterned decor elements in a more eclectic space.  Overall, a geometric pillowcase for throw pillows is a stylish and versatile accessory that can help to create a cohesive and visually interesting decor scheme in any room. Its bold and modern design, combined with its soft and durable materials, make it a must-have accessory for any home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein geometrischer Kissenbezug für Zierkissen ist ein stilvolles und modernes Wohnaccessoire, das jedem Raum einen Hauch von visuellem Interesse verleihen kann. Der Kissenbezug besteht normalerweise aus einem weichen und strapazierfähigen Material wie Baumwolle, Leinen oder Polyester und weist ein kräftiges geometrisches Muster auf, das ein Gefühl von Tiefe und Dimension erzeugt.  Das geometrische Muster auf dem Kissenbezug wird normalerweise mit einer Vielzahl von Formen wie Dreiecken, Quadraten oder Sechsecken erstellt, die in einem sich wiederholenden Muster angeordnet sind. Der Kissenbezug verfügt über einen Reißverschluss, so dass er bei Bedarf einfach abgenommen und gewaschen werden kann.  Der geometrische Kissenbezug ist ein vielseitiges und stilvolles Accessoire, das verwendet werden kann, um eine Vielzahl von Einrichtungsstilen zu betonen, von modern und minimalistisch bis hin zu unkonventionell und vielseitig. Er ist perfekt, um andere gemusterte Dekorelemente in einem vielseitigen Raum zu ergänzen.  Insgesamt ist ein geometrischer Kissenbezug für Zierkissen ein stilvolles und vielseitiges Accessoire, das dazu beitragen kann, in jedem Raum ein zusammenhängendes und optisch interessantes Dekor zu schaffen. Das mutige und moderne Design, kombiniert mit weichen und langlebigen Materialien, machen ihn zu einem unverzichtbaren Accessoire für jedes Zuhause.",
           },
@@ -568,24 +562,20 @@ describe(`with geometricPillowCase preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Geometric Pillow Case",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Geometric Pillow Case",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Geometrischer Kissenbezug",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -593,24 +583,20 @@ describe(`with geometricPillowCase preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "geometric-pillow-case",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "geometric-pillow-case",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "geometrischer-kissenbezug",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/glam-armchair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/glam-armchair.spec.ts
@@ -191,17 +191,14 @@ describe(`with glamArmchair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -209,17 +206,14 @@ describe(`with glamArmchair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A gold velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The gold color of the velvet fabric is soft and delicate, adding a touch of glamour to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the gold velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The armrests are also curved, providing a comfortable place to rest the arms. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A gold velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The gold color of the velvet fabric is soft and delicate, adding a touch of glamour to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the gold velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The armrests are also curved, providing a comfortable place to rest the arms. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein goldfarbener Samtstuhl mit Messingrahmen ist ein elegantes und luxuriöses Möbelstück. Das weiche, plüschige Samtmaterial des Stuhls sorgt für ein bequemes und gemütliches Sitzerlebnis. Die goldene Farbe des Samtstoffs ist weich und zart und verleiht dem Gesamtbild des Stuhls einen Hauch von Glamour.  Der Messingrahmen des Stuhls ist robust und langlebig und bietet eine solide Grundlage für den Sitzbereich. Die Messingfarbe des Gestells verleiht dem Gesamtbild des Stuhls einen Hauch von Wärme und Raffinesse. Die Kombination aus Goldsamt und Messingrahmen schafft einen auffälligen Kontrast und macht diesen Stuhl zu einem Statement-Piece in jedem Raum.  Der Stuhl verfügt über eine hohe Rückenlehne mit geschwungenem Design, die Rücken und Schultern stützt. Die Armlehnen sind ebenfalls gebogen und bieten eine bequeme Ablagefläche für die Arme. Der Stuhl ist sowohl stilvoll als auch auf Komfort ausgelegt, was ihn zu einer großartigen Ergänzung für jedes Wohnzimmer, Schlafzimmer oder Büro macht.",
           },
@@ -324,24 +318,20 @@ describe(`with glamArmchair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Glam Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Glam Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Glam Sessel",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -349,24 +339,20 @@ describe(`with glamArmchair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "glam-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "glam-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "glam-sessel",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/gold-rimmed-champagne-glasses.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/gold-rimmed-champagne-glasses.spec.ts
@@ -176,17 +176,14 @@ describe(`with goldRimmedChampagneGlasses preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
@@ -194,17 +191,14 @@ describe(`with goldRimmedChampagneGlasses preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A set of gold rimmed champagne crystal glasses is a luxurious and elegant way to serve champagne or sparkling wine. These glasses are made of high-quality crystal, which gives them a clear and sparkling appearance that beautifully reflects the bubbles in the champagne.  The glasses feature a delicate and slender stem, which allows the drinker to hold the glass without warming the contents inside. The gold rimmed detail adds an extra touch of luxury and sophistication to the design, giving the glasses a glamorous and opulent appearance.  Overall, a set of gold rimmed champagne crystal glasses is a stunning and luxurious addition to any home bar or entertaining collection. Their elegant and timeless design, combined with their high-quality materials and intricate detailing, make them a perfect choice for celebrating life's special moments in style.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A set of gold rimmed champagne crystal glasses is a luxurious and elegant way to serve champagne or sparkling wine. These glasses are made of high-quality crystal, which gives them a clear and sparkling appearance that beautifully reflects the bubbles in the champagne.  The glasses feature a delicate and slender stem, which allows the drinker to hold the glass without warming the contents inside. The gold rimmed detail adds an extra touch of luxury and sophistication to the design, giving the glasses a glamorous and opulent appearance.  Overall, a set of gold rimmed champagne crystal glasses is a stunning and luxurious addition to any home bar or entertaining collection. Their elegant and timeless design, combined with their high-quality materials and intricate detailing, make them a perfect choice for celebrating life's special moments in style.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Mit einem Set aus Champagner-Kristallgläsern mit Goldrand lässt sich auf luxuriöse und elegante Art Champagner oder Sekt servieren. Diese Gläser sind aus hochwertigem Kristall gefertigt, was ihnen ein klares und funkelndes Aussehen verleiht, das die Blasen im Champagner wunderschön widerspiegelt.  Die Gläser verfügen über einen zarten und schlanken Stiel, der es dem Trinker ermöglicht, das Glas zu halten, ohne den Inhalt darin zu erwärmen. Die goldene Umrandung ist ein Detail, das dem Design einen zusätzlichen Hauch von Luxus und Raffinesse und den Gläsern damit ein glamouröses und opulentes Aussehen verleiht. Insgesamt ist das Set aus Champagner-Kristallgläsern mit Goldrand eine atemberaubende und luxuriöse Ergänzung für jede Hausbar oder Unterhaltungssammlung. Das elegante und zeitlose Design, kombiniert mit hochwertigen Materialien und aufwendigen Details, macht es zur perfekten Wahl, um die besonderen Momente des Lebens stilvoll zu feiern.",
           },
@@ -313,24 +307,20 @@ describe(`with goldRimmedChampagneGlasses preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Gold Rimmed Champagne Glasses",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Gold Rimmed Champagne Glasses",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Champagnergläser mit Goldrand",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -338,24 +328,20 @@ describe(`with goldRimmedChampagneGlasses preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "gold-rimmed-champagne-glasses",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "gold-rimmed-champagne-glasses",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "champagnerglser-mit-goldrand",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/green-serving-plate.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/green-serving-plate.spec.ts
@@ -168,22 +168,18 @@ describe(`with greenServingPlate preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "plates",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serving-platters",
             "typeId": "category",
           },
@@ -191,17 +187,14 @@ describe(`with greenServingPlate preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Eine stilvolle grüne Servierplatte ist ein Teller, der entworfen wurde, um Speisen mit einem zusätzlichen Hauch von Eleganz und Raffinesse zu servieren. Die Platte ist in einem stilvollen Grünton gefärbt, der von einem sanften Pastellgrün bis zu einem lebhaften Limettengrün variieren kann. Die Farbe wird durch eine glänzende oder matte Oberfläche ergänzt, die der Servierplatte Tiefe und Textur verleiht. Die Form der Platte kann variieren. Einige gebogenen Kanten machen sie visuell zusätzlich interessant. Der Teller hat ein dekoratives Muster und eine Textur.  Eine stilvolle grüne Servierplatte ist ideal zum Servieren einer Vielzahl von Speisen, einschließlich Vorspeisen, Hauptgerichten und Desserts. Insgesamt ist der Teller eine schöne und funktionale Wahl zum Servieren von Speisen. Sein einzigartiges Design und seine Farbe machen ihn zu einem Blickfang auf jedem Tisch, während seine Stabilität und Praktikabilität dafür sorgen, dass er sowohl für das tägliche Essen als auch für besondere Anlässe verwendet werden kann.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A stylish green serving plate is a dish designed to serve food with an added touch of elegance and sophistication.   The plate is colored in a stylish green shade, which can vary from a soft pastel green to a vibrant lime green. The color is complemented by a glossy or matte finish, adding depth and texture to the plate.  The shape of the plate can vary, with some curved edges for added visual interest. The plate has a decorative pattern and texture.  A stylish green serving plate is ideal for serving a variety of foods, including appetizers, entrees, and desserts. Overall, a stylish green serving plate is a beautiful and functional choice for serving food. Its unique design and color make it a statement piece on any table, while its durability and practicality ensure it can be used for everyday dining as well as special occasions.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A stylish green serving plate is a dish designed to serve food with an added touch of elegance and sophistication.   The plate is colored in a stylish green shade, which can vary from a soft pastel green to a vibrant lime green. The color is complemented by a glossy or matte finish, adding depth and texture to the plate.  The shape of the plate can vary, with some curved edges for added visual interest. The plate has a decorative pattern and texture.  A stylish green serving plate is ideal for serving a variety of foods, including appetizers, entrees, and desserts. Overall, a stylish green serving plate is a beautiful and functional choice for serving food. Its unique design and color make it a statement piece on any table, while its durability and practicality ensure it can be used for everyday dining as well as special occasions.",
           },
@@ -298,24 +291,20 @@ describe(`with greenServingPlate preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Green Serving Plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Green Serving Plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Grüne Servierplatte",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -323,24 +312,20 @@ describe(`with greenServingPlate preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "green-serving-plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "green-serving-plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "grne-servierplatte",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/harmony-drinking-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/harmony-drinking-glass.spec.ts
@@ -146,17 +146,14 @@ describe(`with harmonyDrinkingGlass preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -164,17 +161,14 @@ describe(`with harmonyDrinkingGlass preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Harmony Drinking Glass is designed to hold water or other beverages. It has a capacity of around 8 to 12 ounces.  The design of the water glass is intended to make it easy and comfortable to hold and drink from. It has a straight, smooth-sided body with a thick, stable base that provides balance and stability. The rim of the glass is slightly curved or rounded, making it comfortable to drink from.  The Harmony Drinking Glass can be used for a variety of beverages, including water, juice, iced tea, and other non-alcoholic drinks.  The drinking glasses are generally easy to clean and maintain. They can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Harmony Drinking Glass is a simple and functional type of drinking glass that is ideal for everyday use. Its basic design and versatility make it a popular choice for both casual and formal settings.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Harmony Drinking Glass is designed to hold water or other beverages. It has a capacity of around 8 to 12 ounces.  The design of the water glass is intended to make it easy and comfortable to hold and drink from. It has a straight, smooth-sided body with a thick, stable base that provides balance and stability. The rim of the glass is slightly curved or rounded, making it comfortable to drink from.  The Harmony Drinking Glass can be used for a variety of beverages, including water, juice, iced tea, and other non-alcoholic drinks.  The drinking glasses are generally easy to clean and maintain. They can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Harmony Drinking Glass is a simple and functional type of drinking glass that is ideal for everyday use. Its basic design and versatility make it a popular choice for both casual and formal settings.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das Trinkglas Harmonie wurde entwickelt, um Wasser oder andere Getränke zu servieren. Es hat eine Kapazität von etwa 230 bis 350ml. Das Design des Wasserglases soll das Halten und Trinken einfach und bequem machen. Es hat einen geraden Körper mit glatten Seiten und einer dicken, stabilen Basis, die für Gleichgewicht und Stabilität sorgt. Der Rand des Glases ist leicht gewölbt oder abgerundet, was das Trinken angenehm macht. Das Trinkglas Harmonie kann für eine Vielzahl von Getränken verwendet werden, darunter Wasser, Saft, Eistee und andere alkoholfreie Getränke. Die Trinkgläser sind im Allgemeinen leicht zu reinigen und zu pflegen. Sie können von Hand oder in der Spülmaschine gewaschen werden und sollten gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden. Insgesamt ist das Harmonie Trinkglas ein schlichter und funktionaler Trinkglastyp, der sich ideal für den täglichen Gebrauch eignet. Sein einfaches Design und seine Vielseitigkeit machen es zu einer beliebten Wahl für lässige und formelle Anlässe.",
           },
@@ -259,24 +253,20 @@ describe(`with harmonyDrinkingGlass preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Harmony Drinking Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Harmony Drinking Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Harmonie Trinkglas",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -284,24 +274,20 @@ describe(`with harmonyDrinkingGlass preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "harmony-drinking-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "harmony-drinking-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "harmonie-trinkglas",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/harvest-plate.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/harvest-plate.spec.ts
@@ -180,27 +180,22 @@ describe(`with harvestPlate preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "plates",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serving-platters",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serveware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
@@ -208,17 +203,14 @@ describe(`with harvestPlate preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This seashell-shaped serving plate is ideal for serving seafood, such as shrimp, oysters, or sushi rolls, but can also be used for other types of cuisine. It is a popular choice for beach-themed parties, coastal restaurants, or for those who enjoy decorating their home with nautical accents.  Overall, a seashell shaped serving plate is a unique and stylish choice for serving food. Its natural appearance and beach-inspired design make it a fun and whimsical addition to any dining occasion.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This seashell-shaped serving plate is ideal for serving seafood, such as shrimp, oysters, or sushi rolls, but can also be used for other types of cuisine. It is a popular choice for beach-themed parties, coastal restaurants, or for those who enjoy decorating their home with nautical accents.  Overall, a seashell shaped serving plate is a unique and stylish choice for serving food. Its natural appearance and beach-inspired design make it a fun and whimsical addition to any dining occasion.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Diese muschelförmige Servierplatte ist ideal zum Servieren von Meeresfrüchten wie Garnelen, Austern oder Sushi-Rollen, kann aber auch für andere Gerichte verwendet werden. Es ist eine beliebte Wahl für Strandpartys, Küstenrestaurants oder für diejenigen, die ihr Zuhause gerne mit nautischen Akzenten dekorieren. Insgesamt ist ein muschelförmiger Servierteller eine einzigartige und stilvolle Wahl zum Servieren von Speisen. Sein natürliches Aussehen und das vom Strand inspirierte Design machen es zu einer lustigen und skurrilen Ergänzung für jeden Essensanlass.",
           },
@@ -315,24 +307,20 @@ describe(`with harvestPlate preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Harvest Plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Harvest Plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ernteplatte",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -340,24 +328,20 @@ describe(`with harvestPlate preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "harvest-plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "harvest-plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "ernteplatte",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ice-bucket.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ice-bucket.spec.ts
@@ -147,17 +147,14 @@ describe(`with iceBucket preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bar-accessories",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -165,17 +162,14 @@ describe(`with iceBucket preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A metal ice bucket is a container used for holding and serving ice. It is made of stainless steel and designed to keep the ice cold for an extended period of time.   The exterior of the ice bucket is polished and has an extended lip for easy carrying. The interior is smooth and polished to prevent the ice from sticking to the walls of the bucket.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A metal ice bucket is a container used for holding and serving ice. It is made of stainless steel and designed to keep the ice cold for an extended period of time.   The exterior of the ice bucket is polished and has an extended lip for easy carrying. The interior is smooth and polished to prevent the ice from sticking to the walls of the bucket.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Eiskübel aus Metall ist ein Behälter zum Aufbewahren und Servieren von Eis. Er besteht aus Edelstahl und ist so konzipiert, dass er das Eis über einen längeren Zeitraum kalt hält. Das Äußere des Eiskübels ist poliert und hat eine verlängerte Lippe zum einfachen Tragen. Die Innenseite ist glatt und poliert, damit das Eis nicht an den Wänden des Eimers kleben bleibt.",
           },
@@ -260,24 +254,20 @@ describe(`with iceBucket preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Ice Bucket",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Ice Bucket",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Eis Eimer",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -285,24 +275,20 @@ describe(`with iceBucket preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "ice-bucket",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "ice-bucket",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "eis-eimer",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/idun-pillow-cover.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/idun-pillow-cover.spec.ts
@@ -171,12 +171,10 @@ describe(`with idunPillowCover preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedding",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -184,17 +182,14 @@ describe(`with idunPillowCover preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A brown velvet pillowcase is a type of textile covering for a decorative pillow that is typically used to add visual interest, texture, and a touch of luxury to a room. It is made from a soft and plush velvet fabric, which is known for its smooth surface, rich color, and lustrous sheen.  The pillowcase is designed to fit over a standard size decorative pillow, usually around 18 inches square. It features a square shape and a warm brown color that can complement a variety of decor styles and color schemes.  The velvet fabric has a silky and luxurious feel that adds a touch of sophistication and elegance to the pillow. The edges of the pillowcase are typically finished with a neat hem, which adds a polished look to the overall design.  The pillowcase is often used to create a cozy and inviting atmosphere in a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different textures and colors to create a layered and harmonious look.  Overall, a brown velvet pillowcase is a beautiful and indulgent accent piece that can enhance the comfort and style of any room in the home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A brown velvet pillowcase is a type of textile covering for a decorative pillow that is typically used to add visual interest, texture, and a touch of luxury to a room. It is made from a soft and plush velvet fabric, which is known for its smooth surface, rich color, and lustrous sheen.  The pillowcase is designed to fit over a standard size decorative pillow, usually around 18 inches square. It features a square shape and a warm brown color that can complement a variety of decor styles and color schemes.  The velvet fabric has a silky and luxurious feel that adds a touch of sophistication and elegance to the pillow. The edges of the pillowcase are typically finished with a neat hem, which adds a polished look to the overall design.  The pillowcase is often used to create a cozy and inviting atmosphere in a room, whether it is placed on a bed, a sofa, or an accent chair. It can be used on its own or paired with other decorative pillows in different textures and colors to create a layered and harmonious look.  Overall, a brown velvet pillowcase is a beautiful and indulgent accent piece that can enhance the comfort and style of any room in the home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein brauner Samt-Kissenbezug ist eine Art Textilbezug für ein dekoratives Kissen, das normalerweise verwendet wird, um einem Raum visuelles Interesse, Textur und einen Hauch von Luxus zu verleihen. Es besteht aus einem weichen und plüschigen Samtstoff, der für seine glatte Oberfläche, seine satte Farbe und seinen glänzenden Schimmer bekannt ist. Der Kissenbezug ist so konzipiert, dass er über ein dekoratives Kissen in Standardgröße passt, normalerweise etwa 18 Zoll im Quadrat. Er hat eine quadratische Form und eine warme braune Farbe, die eine Vielzahl von Einrichtungsstilen und Farbschemata ergänzen kann. Der Samtstoff fühlt sich seidig und luxuriös an und verleiht dem Kissen einen Hauch von Raffinesse und Eleganz. Die Kanten des Kissenbezugs sind in der Regel mit einem sauberen Saum versehen, der dem Gesamtdesign einen eleganten Look verleiht. Der Kissenbezug wird oft verwendet, um eine gemütliche und einladende Atmosphäre in einem Raum zu schaffen, egal ob er auf einem Bett, einem Sofa oder einem Akzentstuhl platziert wird. Er kann allein oder in Kombination mit anderen dekorativen Kissen in verschiedenen Texturen und Farben verwendet werden, um ein mehrschichtiges und harmonisches Aussehen zu schaffen. Insgesamt ist ein Kissenbezug aus braunem Samt ein wunderschönes und luxuriöses Accessoire, das den Komfort und den Stil eines jeden Raumes im Haus verbessern kann. ",
           },
@@ -291,24 +286,20 @@ describe(`with idunPillowCover preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Idun Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Idun Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Idun Kissenbezug",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -316,24 +307,20 @@ describe(`with idunPillowCover preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "idun-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "idun-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "idun-kissenbezug",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/indoor-jute-planter.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/indoor-jute-planter.spec.ts
@@ -252,17 +252,14 @@ describe(`with indoorJutePlanter preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-accents",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -270,17 +267,14 @@ describe(`with indoorJutePlanter preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "An indoor jute planter for plants is a decorative and eco-friendly way to display greenery in your home. The planter is made from natural jute fibers, which are woven into a sturdy and breathable container for your plants.  The neutral color of the jute fibers complements the natural color of plants, making them stand out beautifully.  The jute fibers of the planter are absorbent, allowing for proper drainage and air circulation for the plant roots. This helps to prevent root rot and other soil-borne diseases, ensuring healthy plant growth.  Overall, an indoor jute planter is a charming and practical way to bring a touch of nature into your home, while also being kind to the planet.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "An indoor jute planter for plants is a decorative and eco-friendly way to display greenery in your home. The planter is made from natural jute fibers, which are woven into a sturdy and breathable container for your plants.  The neutral color of the jute fibers complements the natural color of plants, making them stand out beautifully.  The jute fibers of the planter are absorbent, allowing for proper drainage and air circulation for the plant roots. This helps to prevent root rot and other soil-borne diseases, ensuring healthy plant growth.  Overall, an indoor jute planter is a charming and practical way to bring a touch of nature into your home, while also being kind to the planet.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Indoor-Blumentopf für Pflanzen ist eine dekorative und umweltfreundliche Möglichkeit, Pflanzen in Ihrem Zuhause zu präsentieren. Der Blumentopf besteht aus natürlichen Jutefasern, die zu einem robusten und atmungsaktiven Behälter für Ihre Pflanzen verwoben sind. Die neutrale Farbe der Jutefasern ergänzt die natürliche Farbe der Pflanzen und lässt sie schön zur Geltung kommen. Die Jutefasern des Blumentopfes sind saugfähig und ermöglichen eine ordnungsgemäße Entwässerung und Luftzirkulation für die Pflanzenwurzeln. Dies trägt dazu bei, Wurzelfäule und andere bodenbürtige Krankheiten zu verhindern und ein gesundes Pflanzenwachstum zu gewährleisten. Insgesamt ist ein Blumentopf aus Jute für den Innenbereich eine charmante und praktische Möglichkeit, einen Hauch von Natur in Ihr Zuhause zu bringen und gleichzeitig die Umwelt zu schonen.",
           },
@@ -373,24 +367,20 @@ describe(`with indoorJutePlanter preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Indoor Jute Planter",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Indoor Jute Planter",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Indoor Jute Blumentopf ",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -398,24 +388,20 @@ describe(`with indoorJutePlanter preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "indoor-jute-planter",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "indoor-jute-planter",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "indoor-jute-planter",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ivory-lounge-chair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ivory-lounge-chair.spec.ts
@@ -195,22 +195,18 @@ describe(`with ivoryLoungeChair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
@@ -218,17 +214,14 @@ describe(`with ivoryLoungeChair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This arm chair is a bold and funky piece of furniture that takes its inspiration from the eclectic styles of the 1970s. The chair features a round, circular shape, with a low backrest and generously padded seat that provide comfortable seating for extended periods of time.  The arms of the chair are wide and round, creating a comfortable and supportive space for you to rest your arms while lounging.   Overall, a 70's inspired round arm chair is a playful and fun piece of furniture that can add a touch of retro flair to any room. Its round shape and generous padding, make it a comfortable and inviting spot for lounging and relaxation.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This arm chair is a bold and funky piece of furniture that takes its inspiration from the eclectic styles of the 1970s. The chair features a round, circular shape, with a low backrest and generously padded seat that provide comfortable seating for extended periods of time.  The arms of the chair are wide and round, creating a comfortable and supportive space for you to rest your arms while lounging.   Overall, a 70's inspired round arm chair is a playful and fun piece of furniture that can add a touch of retro flair to any room. Its round shape and generous padding, make it a comfortable and inviting spot for lounging and relaxation.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser Sessel ist ein kühnes und flippiges Möbelstück, das seine Inspiration aus den eklektischen Stilen der 1970er Jahre bezieht. Der Stuhl hat eine runde, kreisförmige Form mit einer niedrigen Rückenlehne und einer großzügig gepolsterten Sitzfläche, die für längere Zeit bequemen Sitz bietet.  Die Armlehnen des Stuhls sind breit und rund und schaffen einen bequemen und stützenden Platz, an dem Sie Ihre Arme beim Faulenzen ausruhen können.  Insgesamt ist ein von den 70er Jahren inspirierter runder Sessel ein verspieltes und lustiges Möbelstück, das jedem Raum einen Hauch von Retro-Flair verleihen kann. Seine runde Form und die großzügige Polsterung machen ihn zu einem komfortablen und einladenden Ort zum Faulenzen und Entspannen.",
           },
@@ -341,24 +334,20 @@ describe(`with ivoryLoungeChair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Ivory Lounge Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Ivory Lounge Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Elfenbein Lounge Stuhl",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -366,24 +355,20 @@ describe(`with ivoryLoungeChair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "ivory-lounge-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "ivory-lounge-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "elfenbein-lounge-stuhl",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/ivory-plate.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/ivory-plate.spec.ts
@@ -183,32 +183,26 @@ describe(`with ivoryPlate preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "plates",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serving-platters",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serveware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
@@ -216,17 +210,14 @@ describe(`with ivoryPlate preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This ivory plate is a high-end dish designed for both functional and aesthetic purposes. It is made of high-quality porcelain and has a smooth surface that is both elegant and durable.  The plate is circular in shape and has a flat surface with a slight curve at the edges. The ivory color is a creamy, off-white shade that is warm and inviting, adding a touch of sophistication to any dining setting.  The design of the plate is what sets it apart, as it has been crafted by a skilled designer with an eye for detail.   The plate is a standalone piece intended for special occasions or display. It is ideal for serving appetizers or desserts, and its size and shape make it easy to handle and pass around the table.  Overall, a round designer plate made of ivory is a luxurious and stylish choice for fine dining or special occasions. Its unique design and high-quality construction make it a statement piece that is sure to impress guests and elevate any dining experience.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This ivory plate is a high-end dish designed for both functional and aesthetic purposes. It is made of high-quality porcelain and has a smooth surface that is both elegant and durable.  The plate is circular in shape and has a flat surface with a slight curve at the edges. The ivory color is a creamy, off-white shade that is warm and inviting, adding a touch of sophistication to any dining setting.  The design of the plate is what sets it apart, as it has been crafted by a skilled designer with an eye for detail.   The plate is a standalone piece intended for special occasions or display. It is ideal for serving appetizers or desserts, and its size and shape make it easy to handle and pass around the table.  Overall, a round designer plate made of ivory is a luxurious and stylish choice for fine dining or special occasions. Its unique design and high-quality construction make it a statement piece that is sure to impress guests and elevate any dining experience.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser Elfenbeinteller ist ein High-End-Geschirr, das sowohl für funktionale als auch für ästhetische Zwecke entworfen wurde. Es besteht aus hochwertigem Porzellan und hat eine glatte Oberfläche, die sowohl elegant als auch langlebig ist.  Der Teller ist kreisförmig und hat eine flache Oberfläche mit einer leichten Rundung an den Rändern. Die Elfenbeinfarbe ist ein cremiger, cremefarbener Farbton, der warm und einladend ist und jedem Esszimmer einen Hauch von Raffinesse verleiht.  Das Design des Tellers zeichnet ihn aus, da er von einem erfahrenen Designer mit viel Liebe zum Detail gefertigt wurde.  Der Teller ist ein eigenständiges Stück, das für besondere Anlässe oder zur Präsentation bestimmt ist. Es ist ideal zum Servieren von Vorspeisen oder Desserts, und seine Größe und Form machen es einfach, es zu handhaben und auf dem Tisch herumzureichen.  Insgesamt ist ein runder Designerteller aus Elfenbein eine luxuriöse und stilvolle Wahl für gehobene Speisen oder besondere Anlässe. Sein einzigartiges Design und seine hochwertige Konstruktion machen es zu einem Statement-Stück, das Gäste beeindrucken und jedes kulinarische Erlebnis aufwerten wird.",
           },
@@ -323,24 +314,20 @@ describe(`with ivoryPlate preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Ivory Plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Ivory Plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Elfenbeinteller",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -348,24 +335,20 @@ describe(`with ivoryPlate preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "ivory-plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "ivory-plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "elfenbeinteller",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/jute-rug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/jute-rug.spec.ts
@@ -187,17 +187,14 @@ describe(`with juteRug preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "rugs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -205,17 +202,14 @@ describe(`with juteRug preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A jute area rug is a type of rug made from natural fibers derived from the jute plant. Jute is a long, soft, and shiny vegetable fiber that is spun into strong threads and then woven into textiles. Jute rugs are known for their durability and natural appearance, making them a popular choice for those who want to bring a touch of the outdoors into their homes.  Because jute is a natural fiber, it is eco-friendly and sustainable. However, it can be prone to staining and water damage, so jute area rugs should be used in low-traffic areas or rooms that do not see a lot of moisture. They are often used in living rooms, bedrooms, and other spaces where a natural, earthy look is desired.  Overall, a jute area rug is a beautiful and eco-friendly addition to any home. Its natural fibers and earthy appearance make it a popular choice for those who want to create a warm and inviting atmosphere in their living space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A jute area rug is a type of rug made from natural fibers derived from the jute plant. Jute is a long, soft, and shiny vegetable fiber that is spun into strong threads and then woven into textiles. Jute rugs are known for their durability and natural appearance, making them a popular choice for those who want to bring a touch of the outdoors into their homes.  Because jute is a natural fiber, it is eco-friendly and sustainable. However, it can be prone to staining and water damage, so jute area rugs should be used in low-traffic areas or rooms that do not see a lot of moisture. They are often used in living rooms, bedrooms, and other spaces where a natural, earthy look is desired.  Overall, a jute area rug is a beautiful and eco-friendly addition to any home. Its natural fibers and earthy appearance make it a popular choice for those who want to create a warm and inviting atmosphere in their living space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Juteteppich ist eine Art Teppich aus Naturfasern, die aus der Jutepflanze gewonnen werden. Jute ist eine lange, weiche und glänzende Pflanzenfaser, die zu starken Fäden gesponnen und dann zu Textilien gewebt wird. Juteteppiche sind bekannt für ihre Langlebigkeit und ihr natürliches Aussehen, was sie zu einer beliebten Wahl für diejenigen macht, die einen Hauch von Natur in ihr Zuhause bringen möchten.  Da Jute eine Naturfaser ist, ist sie umweltfreundlich und nachhaltig. Es kann jedoch anfällig für Flecken und Wasserschäden sein, daher sollten Juteteppiche in wenig frequentierten Bereichen oder Räumen verwendet werden, die nicht viel Feuchtigkeit ausgesetzt sind. Sie werden oft in Wohnzimmern, Schlafzimmern und anderen Räumen verwendet, in denen ein natürlicher, erdiger Look gewünscht wird.  Insgesamt ist ein Juteteppich eine schöne und umweltfreundliche Ergänzung für jedes Zuhause. Seine natürlichen Fasern und sein erdiges Aussehen machen es zu einer beliebten Wahl für diejenigen, die eine warme und einladende Atmosphäre in ihrem Wohnraum schaffen möchten.",
           },
@@ -328,24 +322,20 @@ describe(`with juteRug preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Jute Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Jute Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Jute Teppich",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -353,24 +343,20 @@ describe(`with juteRug preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "jute-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "jute-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "jute-teppich",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/lana-pillow-cover.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/lana-pillow-cover.spec.ts
@@ -174,12 +174,10 @@ describe(`with lanaPillowCover preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedding",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -187,17 +185,14 @@ describe(`with lanaPillowCover preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A microfiber pillow cover is a type of textile covering for a pillow that is made from synthetic fibers such as polyester or nylon. Microfiber is known for its softness, durability, and easy maintenance.  The pillow cover is designed to fit over a standard size pillow, usually around 18 inches square. It features a square shape and can come in a variety of colors and patterns to suit different decor styles and preferences.  The microfiber fabric has a smooth and silky feel that is gentle on the skin and provides a comfortable surface for sleeping. It is also breathable and moisture-wicking, which helps to regulate body temperature and prevent overheating during the night.  The pillow cover is often used for its practical and functional features, such as its easy care and resistance to wrinkles, stains, and fading. It can be easily washed and dried in a machine, making it a convenient and low-maintenance option for busy households.  Overall, a microfiber pillow cover is a versatile and practical accessory that can enhance the comfort and durability of a pillow. It can be used for everyday sleeping, as well as for decorative purposes in a variety of settings, such as bedrooms, guest rooms, and living rooms.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A microfiber pillow cover is a type of textile covering for a pillow that is made from synthetic fibers such as polyester or nylon. Microfiber is known for its softness, durability, and easy maintenance.  The pillow cover is designed to fit over a standard size pillow, usually around 18 inches square. It features a square shape and can come in a variety of colors and patterns to suit different decor styles and preferences.  The microfiber fabric has a smooth and silky feel that is gentle on the skin and provides a comfortable surface for sleeping. It is also breathable and moisture-wicking, which helps to regulate body temperature and prevent overheating during the night.  The pillow cover is often used for its practical and functional features, such as its easy care and resistance to wrinkles, stains, and fading. It can be easily washed and dried in a machine, making it a convenient and low-maintenance option for busy households.  Overall, a microfiber pillow cover is a versatile and practical accessory that can enhance the comfort and durability of a pillow. It can be used for everyday sleeping, as well as for decorative purposes in a variety of settings, such as bedrooms, guest rooms, and living rooms.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Mikrofaser-Kissenbezug ist eine Art Textilbezug für ein Kissen, der aus synthetischen Fasern wie Polyester oder Nylon hergestellt wird. Mikrofaser ist bekannt für ihre Weichheit, Haltbarkeit und einfache Pflege.  Der Kissenbezug ist so konzipiert, dass er über ein Kissen in Standardgröße passt, normalerweise etwa 18 Zoll im Quadrat. Es hat eine quadratische Form und kann in einer Vielzahl von Farben und Mustern erhältlich sein, um verschiedenen Einrichtungsstilen und Vorlieben gerecht zu werden.  Das Mikrofasergewebe fühlt sich glatt und seidig an, ist sanft zur Haut und bietet eine angenehme Schlafoberfläche. Es ist außerdem atmungsaktiv und feuchtigkeitstransportierend, was hilft, die Körpertemperatur zu regulieren und eine Überhitzung während der Nacht zu verhindern.  Der Kissenbezug wird oft wegen seiner praktischen und funktionalen Eigenschaften verwendet, wie z. B. seiner Pflegeleichtigkeit und Beständigkeit gegen Falten, Flecken und Ausbleichen. Es kann einfach in einer Maschine gewaschen und getrocknet werden, was es zu einer praktischen und pflegeleichten Option für vielbeschäftigte Haushalte macht.  Insgesamt ist ein Mikrofaser-Kissenbezug ein vielseitiges und praktisches Accessoire, das den Komfort und die Haltbarkeit eines Kissens verbessern kann. Es kann sowohl zum täglichen Schlafen als auch zu dekorativen Zwecken in einer Vielzahl von Umgebungen wie Schlaf-, Gästezimmern und Wohnzimmern verwendet werden.",
           },
@@ -294,24 +289,20 @@ describe(`with lanaPillowCover preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Lana Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Lana Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Lana Kissenbezug",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -319,24 +310,20 @@ describe(`with lanaPillowCover preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "lana-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "lana-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "lana-kissenbezug",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/large-ceramic-plate.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/large-ceramic-plate.spec.ts
@@ -306,22 +306,18 @@ describe(`with largeCeramicPlate preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "plates",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
@@ -329,17 +325,14 @@ describe(`with largeCeramicPlate preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A large ceramic round plate that comes in light olive and light gray colors is a beautiful and versatile piece of dinnerware that is perfect for serving a variety of meals. The plate is typically handcrafted from high-quality ceramic material, and features a glossy finish that gives it a polished and elegant appearance.  The plate is large in size, typically measuring around 12-14 inches in diameter. This makes it ideal for serving large portions of food, such as a main course or a shared appetizer. The round shape of the plate provides ample space for arranging food, while the raised edge of the plate prevents sauces and juices from spilling over the sides.  The plate comes in two beautiful and neutral colors - light olive and light gray. These colors are perfect for complementing a wide range of dining room decor styles and color schemes, from modern and minimalist to rustic and earthy.  The plate features a simple and elegant design, with a smooth surface and a minimalist look. This makes it ideal for both casual and formal dining occasions, from everyday family meals to special occasions and dinner parties.  Overall, a large ceramic round plate in light olive and light gray colors is a beautiful and practical addition to any dining room. Its simple and elegant design, combined with its versatile size and color options, make it a perfect choice for serving a variety of meals and creating a stylish and inviting dining experience.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A large ceramic round plate that comes in light olive and light gray colors is a beautiful and versatile piece of dinnerware that is perfect for serving a variety of meals. The plate is typically handcrafted from high-quality ceramic material, and features a glossy finish that gives it a polished and elegant appearance.  The plate is large in size, typically measuring around 12-14 inches in diameter. This makes it ideal for serving large portions of food, such as a main course or a shared appetizer. The round shape of the plate provides ample space for arranging food, while the raised edge of the plate prevents sauces and juices from spilling over the sides.  The plate comes in two beautiful and neutral colors - light olive and light gray. These colors are perfect for complementing a wide range of dining room decor styles and color schemes, from modern and minimalist to rustic and earthy.  The plate features a simple and elegant design, with a smooth surface and a minimalist look. This makes it ideal for both casual and formal dining occasions, from everyday family meals to special occasions and dinner parties.  Overall, a large ceramic round plate in light olive and light gray colors is a beautiful and practical addition to any dining room. Its simple and elegant design, combined with its versatile size and color options, make it a perfect choice for serving a variety of meals and creating a stylish and inviting dining experience.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein großer runder Keramikteller in Helloliv und Hellgrau ist ein schönes und vielseitiges Geschirr, das sich perfekt zum Servieren einer Vielzahl von Mahlzeiten eignet. Der Teller wird in der Regel aus hochwertigem Keramikmaterial handgefertigt und verfügt über eine glänzende Oberfläche, die ihm ein poliertes und elegantes Aussehen verleiht.  Die Platte ist groß und hat typischerweise einen Durchmesser von etwa 12 bis 14 Zoll. Dadurch eignet er sich ideal zum Servieren großer Speisenportionen, wie z. B. eines Hauptgerichts oder einer gemeinsamen Vorspeise. Die runde Form des Tellers bietet viel Platz zum Anrichten von Speisen, während der erhöhte Rand des Tellers verhindert, dass Saucen und Säfte über die Seiten schwappen.  Der Teller ist in zwei schönen und neutralen Farben erhältlich - Helloliv und Hellgrau. Diese Farben sind perfekt, um eine breite Palette von Einrichtungsstilen und Farbschemata für Esszimmer zu ergänzen, von modern und minimalistisch bis rustikal und erdig.  Der Teller zeichnet sich durch ein schlichtes und elegantes Design mit glatter Oberfläche und einem minimalistischen Look aus. Dies macht es ideal für zwanglose und formelle Anlässe, von alltäglichen Familienessen bis hin zu besonderen Anlässen und Dinnerpartys.  Insgesamt ist ein großer runder Keramikteller in hellen Oliv- und Hellgrautönen eine schöne und praktische Ergänzung für jedes Esszimmer. Sein schlichtes und elegantes Design, kombiniert mit seinen vielseitigen Größen- und Farboptionen, machen ihn zur perfekten Wahl, um eine Vielzahl von Mahlzeiten zu servieren und ein stilvolles und einladendes Speiseerlebnis zu schaffen.",
           },
@@ -444,24 +437,20 @@ describe(`with largeCeramicPlate preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Large Ceramic Plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Large Ceramic Plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Große Keramikplatte",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -469,24 +458,20 @@ describe(`with largeCeramicPlate preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "large-ceramic-plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "large-ceramic-plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "groe-keramikplatte",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/leah-armchair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/leah-armchair.spec.ts
@@ -188,17 +188,14 @@ describe(`with leahArmchair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -206,17 +203,14 @@ describe(`with leahArmchair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A tufted armchair with brass legs is an elegant and luxurious piece of furniture. The chair typically features a deep seat and a high backrest, which are both padded and upholstered with soft and plush material. The tufted design creates a sophisticated and timeless look, while the brass legs add a touch of glamour and sophistication. The legs give the chair a sleek and modern appearance. The armrests are curved and plush, providing both comfort and support for the arms. Overall, a tufted armchair with brass legs is a stylish and comfortable addition to any living space or lounge area.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A tufted armchair with brass legs is an elegant and luxurious piece of furniture. The chair typically features a deep seat and a high backrest, which are both padded and upholstered with soft and plush material. The tufted design creates a sophisticated and timeless look, while the brass legs add a touch of glamour and sophistication. The legs give the chair a sleek and modern appearance. The armrests are curved and plush, providing both comfort and support for the arms. Overall, a tufted armchair with brass legs is a stylish and comfortable addition to any living space or lounge area.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein getufteter Sessel mit Messingbeinen ist ein elegantes und luxuriöses Möbelstück. Der Stuhl verfügt typischerweise über einen tiefen Sitz und eine hohe Rückenlehne, die beide gepolstert und mit weichem und plüschigem Material bezogen sind. Das getuftete Design sorgt für einen raffinierten und zeitlosen Look, während die Messingbeine einen Hauch von Glamour und Raffinesse verleihen. Die Beine verleihen dem Stuhl ein elegantes und modernes Aussehen. Die Armlehnen sind gebogen und weich und bieten sowohl Komfort als auch Unterstützung für die Arme. Insgesamt ist ein getufteter Sessel mit Messingbeinen eine stilvolle und bequeme Ergänzung für jeden Wohn- oder Loungebereich.",
           },
@@ -321,24 +315,20 @@ describe(`with leahArmchair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Leah Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Leah Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Leah Sessel",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -346,24 +336,20 @@ describe(`with leahArmchair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "leah-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "leah-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "leah-sessel",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/leather-coaster.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/leather-coaster.spec.ts
@@ -172,17 +172,14 @@ describe(`with leatherCoaster preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bar-accessories",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -190,17 +187,14 @@ describe(`with leatherCoaster preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A round leather coaster is designed to be placed underneath a drink to protect the surface beneath from moisture and heat. It measures around 4 inches in diameter and is made of high-quality leather material. The edges of the coaster is finished with brass. The underside of the coaster features a non-slip material to prevent it from sliding on smooth surfaces.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A round leather coaster is designed to be placed underneath a drink to protect the surface beneath from moisture and heat. It measures around 4 inches in diameter and is made of high-quality leather material. The edges of the coaster is finished with brass. The underside of the coaster features a non-slip material to prevent it from sliding on smooth surfaces.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein runder Lederuntersetzer ist so konzipiert, dass er unter einem Getränk platziert werden kann, um die darunter liegende Oberfläche vor Feuchtigkeit und Hitze zu schützen. Es misst etwa 4 Zoll im Durchmesser und besteht aus hochwertigem Ledermaterial. Die Kanten des Untersetzers sind mit Messing veredelt. Die Unterseite des Untersetzers ist mit einem rutschfesten Material versehen, um ein Verrutschen auf glatten Oberflächen zu verhindern.",
           },
@@ -297,24 +291,20 @@ describe(`with leatherCoaster preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Leather Coaster",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Leather Coaster",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Leder Untersetzer",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -322,24 +312,20 @@ describe(`with leatherCoaster preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "leather-coaster",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "leather-coaster",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "untersetzer-aus-leder",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/leather-weave-chair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/leather-weave-chair.spec.ts
@@ -192,17 +192,14 @@ describe(`with leatherWeaveChair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
@@ -210,17 +207,14 @@ describe(`with leatherWeaveChair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A wooden chair with leather weave upholstery is a beautiful and functional piece of furniture that blends natural materials with a touch of luxury. The chair features a sturdy and durable wooden frame, crafted from high-quality hardwood, that provides a solid foundation for the seat and backrest.  The seat and backrest of the chair are made from a tight weave of leather strips, creating a unique and eye-catching texture that adds to the chair's overall appeal.   The chair has a simple and elegant design, with clean lines and a minimalist aesthetic that makes it easy to incorporate into a variety of interior design styles.   The legs of the chair are angled slightly outward for stability. The bottom of the legs may be fitted with protective caps to prevent scratches or damage to your floors.  Overall, a wooden chair with leather weave upholstery is a versatile and stylish piece of furniture that can add warmth, texture, and visual interest to any room. Its combination of natural materials and luxurious details makes it a popular choice for anyone looking to add a touch of sophistication and elegance to their home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A wooden chair with leather weave upholstery is a beautiful and functional piece of furniture that blends natural materials with a touch of luxury. The chair features a sturdy and durable wooden frame, crafted from high-quality hardwood, that provides a solid foundation for the seat and backrest.  The seat and backrest of the chair are made from a tight weave of leather strips, creating a unique and eye-catching texture that adds to the chair's overall appeal.   The chair has a simple and elegant design, with clean lines and a minimalist aesthetic that makes it easy to incorporate into a variety of interior design styles.   The legs of the chair are angled slightly outward for stability. The bottom of the legs may be fitted with protective caps to prevent scratches or damage to your floors.  Overall, a wooden chair with leather weave upholstery is a versatile and stylish piece of furniture that can add warmth, texture, and visual interest to any room. Its combination of natural materials and luxurious details makes it a popular choice for anyone looking to add a touch of sophistication and elegance to their home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Holzstuhl mit Lederbezug ist ein schönes und funktionales Möbelstück, das natürliche Materialien mit einem Hauch von Luxus verbindet. Der Stuhl verfügt über einen robusten und langlebigen Holzrahmen aus hochwertigem Hartholz, der eine solide Grundlage für Sitz und Rückenlehne bietet.  Der Sitz und die Rückenlehne des Stuhls bestehen aus einem engen Gewebe aus Lederstreifen, wodurch eine einzigartige und auffällige Textur entsteht, die den Gesamteindruck des Stuhls verstärkt.  Der Stuhl hat ein einfaches und elegantes Design mit klaren Linien und einer minimalistischen Ästhetik, die sich leicht in eine Vielzahl von Einrichtungsstilen integrieren lässt.  Die Beine des Stuhls sind aus Stabilitätsgründen leicht nach außen geneigt. Die Unterseite der Beine kann mit Schutzkappen versehen werden, um Kratzer oder Schäden an Ihren Böden zu vermeiden.  Insgesamt ist ein Holzstuhl mit Lederbezug ein vielseitiges und stilvolles Möbelstück, das jedem Raum Wärme, Textur und visuelles Interesse verleiht. Seine Kombination aus natürlichen Materialien und luxuriösen Details macht es zu einer beliebten Wahl für alle, die ihrem Zuhause einen Hauch von Raffinesse und Eleganz verleihen möchten.",
           },
@@ -333,24 +327,20 @@ describe(`with leatherWeaveChair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Leather Weave Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Leather Weave Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ledergeflecht Stuhl",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -358,24 +348,20 @@ describe(`with leatherWeaveChair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "leather-weave-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "leather-weave-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "stuhl-aus-ledergeflecht",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/luxe-pillow-cover.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/luxe-pillow-cover.spec.ts
@@ -171,12 +171,10 @@ describe(`with luxePillowCover preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedding",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -184,17 +182,14 @@ describe(`with luxePillowCover preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser luxuriöse Kissenbezug ist aus schwarzem Lammfell gefertigt. Shearling ist bekannt für seine Weichheit, Wärme und isolierenden Eigenschaften.  Der Kissenbezug ist so konzipiert, dass er über ein Kissen in Standardgröße passt, normalerweise etwa 18 Zoll im Quadrat. Es hat eine quadratische Form und eine tiefschwarze Farbe, die eine Vielzahl von Einrichtungsstilen und Farbschemata ergänzen kann.  Der Shearling-Stoff hat eine plüschige und flauschige Textur, die sich unglaublich weich anfühlt. Es bietet eine gemütliche und warme Oberfläche zum Schlafen oder Faulenzen, was es zu einer beliebten Wahl für die kälteren Monate macht.  Der Kissenbezug wird oft wegen seiner dekorativen und luxuriösen Eigenschaften sowie wegen seiner praktischen und funktionalen Vorteile verwendet. Es kann einem Bett, Sofa oder Akzentstuhl einen Hauch von Textur und visuellem Interesse verleihen und gleichzeitig eine bequeme und stützende Oberfläche für Kopf und Nacken bieten.  Das Shearling-Gewebe ist von Natur aus wasser- und schmutzabweisend und lässt sich leicht mit einem feuchten Tuch oder Schwamm reinigen. Es sollte regelmäßig an der Luft getrocknet und aufgelockert werden, um seine Form und Textur zu erhalten.  Insgesamt ist ein schwarzer Lammfell-Kissenbezug ein stilvolles und bequemes Accessoire, das den Komfort und Stil jedes Raums im Haus verbessern kann und gleichzeitig einen praktischen und funktionellen Nutzen bietet.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This Luxe Pillow Cover is made of black shearling. Shearling is known for its softness, warmth, and insulating properties.  The pillow cover is designed to fit over a standard size pillow, usually around 18 inches square. It features a square shape and a deep black color that can complement a variety of decor styles and color schemes.  The shearling fabric has a plush and fluffy texture that is incredibly soft to the touch. It provides a cozy and warm surface for sleeping or lounging, making it a popular choice for colder months.  The pillow cover is often used for its decorative and luxurious features, as well as for its practical and functional benefits. It can add a touch of texture and visual interest to a bed, sofa, or accent chair, while also providing a comfortable and supportive surface for the head and neck.  The shearling fabric is naturally resistant to water and stains, and can be easily cleaned with a damp cloth or sponge. It should be air-dried and fluffed periodically to maintain its shape and texture.  Overall, a black shearling pillow cover is a stylish and comfortable accessory that can enhance the comfort and style of any room in the home, while also providing a practical and functional benefit.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This Luxe Pillow Cover is made of black shearling. Shearling is known for its softness, warmth, and insulating properties.  The pillow cover is designed to fit over a standard size pillow, usually around 18 inches square. It features a square shape and a deep black color that can complement a variety of decor styles and color schemes.  The shearling fabric has a plush and fluffy texture that is incredibly soft to the touch. It provides a cozy and warm surface for sleeping or lounging, making it a popular choice for colder months.  The pillow cover is often used for its decorative and luxurious features, as well as for its practical and functional benefits. It can add a touch of texture and visual interest to a bed, sofa, or accent chair, while also providing a comfortable and supportive surface for the head and neck.  The shearling fabric is naturally resistant to water and stains, and can be easily cleaned with a damp cloth or sponge. It should be air-dried and fluffed periodically to maintain its shape and texture.  Overall, a black shearling pillow cover is a stylish and comfortable accessory that can enhance the comfort and style of any room in the home, while also providing a practical and functional benefit.",
           },
@@ -291,24 +286,20 @@ describe(`with luxePillowCover preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Luxe Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Luxe Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Luxe Kissenbezug",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -316,24 +307,20 @@ describe(`with luxePillowCover preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "luxe-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "luxe-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "luxuriser-kissenbezug",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/marquis-tray.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/marquis-tray.spec.ts
@@ -168,32 +168,26 @@ describe(`with marquisTray preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "plates",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serving-platters",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serveware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "cheese-trays",
             "typeId": "category",
           },
@@ -201,17 +195,14 @@ describe(`with marquisTray preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This wooden serving tray is ideal for serving a variety of foods and drinks, including appetizers, entrees, cocktails, and coffee. It can be used in both casual and formal settings, and are a popular choice for outdoor dining, picnics, and barbecues.  Wooden serving trays are durable and easy to clean, making them a practical choice for everyday use. They can be wiped clean with a damp cloth or washed with soap and water.  Overall, a wooden serving tray is a functional and stylish choice for serving food and drinks. Its natural material and unique texture add warmth and character to any dining setting, while its versatility and practicality make it a staple in many kitchens and dining rooms.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This wooden serving tray is ideal for serving a variety of foods and drinks, including appetizers, entrees, cocktails, and coffee. It can be used in both casual and formal settings, and are a popular choice for outdoor dining, picnics, and barbecues.  Wooden serving trays are durable and easy to clean, making them a practical choice for everyday use. They can be wiped clean with a damp cloth or washed with soap and water.  Overall, a wooden serving tray is a functional and stylish choice for serving food and drinks. Its natural material and unique texture add warmth and character to any dining setting, while its versatility and practicality make it a staple in many kitchens and dining rooms.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieses Serviertablett aus Holz ist ideal zum Servieren einer Vielzahl von Speisen und Getränken, einschließlich Vorspeisen, Hauptgerichten, Cocktails und Kaffee. Es kann sowohl in ungezwungener als auch in formeller Umgebung verwendet werden und ist eine beliebte Wahl für Mahlzeiten im Freien, Picknicks und Grillabende.  Serviertabletts aus Holz sind langlebig und leicht zu reinigen, was sie zu einer praktischen Wahl für den täglichen Gebrauch macht. Sie können mit einem feuchten Tuch abgewischt oder mit Wasser und Seife gewaschen werden.  Insgesamt ist ein Serviertablett aus Holz eine funktionale und stilvolle Wahl zum Servieren von Speisen und Getränken. Sein natürliches Material und seine einzigartige Textur verleihen jedem Essbereich Wärme und Charakter, während seine Vielseitigkeit und Praktikabilität es zu einem Grundnahrungsmittel in vielen Küchen und Esszimmern machen.",
           },
@@ -300,24 +291,20 @@ describe(`with marquisTray preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Marquis Tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Marquis Tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Marquis Tablett",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -325,24 +312,20 @@ describe(`with marquisTray preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "marquis-tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "marquis-tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "marquis-tablett",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/maya-pillow-cover.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/maya-pillow-cover.spec.ts
@@ -274,12 +274,10 @@ describe(`with mayaPillowCover preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedding",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -287,17 +285,14 @@ describe(`with mayaPillowCover preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A microfiber brown pillowcase is a soft and comfortable pillow cover made from synthetic fibers. The microfiber material is designed to be soft and silky to the touch, providing a comfortable and cozy sleeping experience.  The brown color of the pillowcase is typically warm and inviting, creating a cozy and relaxing atmosphere in a bedroom. It can also be a versatile color that matches well with a variety of other colors and decor styles.  Microfiber pillowcases are known for their durability and easy care. They are typically resistant to wrinkles and shrinkage, making them ideal for busy households. They are also hypoallergenic, making them a great option for people with allergies or sensitivities.  Overall, a microfiber brown pillowcase is a practical and comfortable choice for any bedroom. It is soft, durable, and easy to care for, providing a cozy and inviting sleeping environment for a restful night's sleep.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A microfiber brown pillowcase is a soft and comfortable pillow cover made from synthetic fibers. The microfiber material is designed to be soft and silky to the touch, providing a comfortable and cozy sleeping experience.  The brown color of the pillowcase is typically warm and inviting, creating a cozy and relaxing atmosphere in a bedroom. It can also be a versatile color that matches well with a variety of other colors and decor styles.  Microfiber pillowcases are known for their durability and easy care. They are typically resistant to wrinkles and shrinkage, making them ideal for busy households. They are also hypoallergenic, making them a great option for people with allergies or sensitivities.  Overall, a microfiber brown pillowcase is a practical and comfortable choice for any bedroom. It is soft, durable, and easy to care for, providing a cozy and inviting sleeping environment for a restful night's sleep.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein brauner Mikrofaser-Kissenbezug ist ein weicher und bequemer Kissenbezug aus synthetischen Fasern. Das Mikrofasermaterial fühlt sich weich und seidig an und bietet ein komfortables und gemütliches Schlaferlebnis.  Die braune Farbe des Kissenbezugs ist typisch warm und einladend und schafft eine gemütliche und entspannende Atmosphäre in einem Schlafzimmer. Es kann auch eine vielseitige Farbe sein, die gut zu einer Vielzahl anderer Farben und Dekorstile passt.  Kissenbezüge aus Mikrofaser sind bekannt für ihre Strapazierfähigkeit und Pflegeleichtigkeit. Sie sind in der Regel knitter- und schrumpffrei und somit ideal für vielbeschäftigte Haushalte. Sie sind auch hypoallergen, was sie zu einer großartigen Option für Menschen mit Allergien oder Empfindlichkeiten macht.  Insgesamt ist ein brauner Kissenbezug aus Mikrofaser eine praktische und bequeme Wahl für jedes Schlafzimmer. Es ist weich, strapazierfähig und pflegeleicht und bietet eine gemütliche und einladende Schlafumgebung für einen erholsamen Schlaf.",
           },
@@ -394,24 +389,20 @@ describe(`with mayaPillowCover preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Maya Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Maya Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Maya Kissenbezug",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -419,24 +410,20 @@ describe(`with mayaPillowCover preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "maya-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "maya-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "maya-kissenbezug",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/meadow-rug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/meadow-rug.spec.ts
@@ -370,17 +370,14 @@ describe(`with meadowRug preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "rugs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -388,17 +385,14 @@ describe(`with meadowRug preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A plush area rug is a type of rug that is designed to be soft and comfortable underfoot. Plush rugs are characterized by their thick pile. The fibers are densely packed together, giving the rug a lush and luxurious feel.   Because of their softness and comfort, plush area rugs are often used in bedrooms, living rooms, and other areas where people spend a lot of time sitting or lounging on the floor. They are also a popular choice for nurseries and children's rooms, as they provide a safe and comfortable play area for kids.  Overall, a plush area rug is a cozy and inviting addition to any home. Its soft texture and luxurious feel make it a popular choice for those who want to create a warm and inviting atmosphere in their living space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Plüschteppich ist eine Art von Teppich, der weich und bequem unter den Füßen liegt. Plüschteppiche zeichnen sich durch ihren dichten Flor aus. Die Fasern sind dicht gepackt und verleihen dem Teppich ein üppiges und luxuriöses Gefühl. Aufgrund ihrer Weichheit und ihres Komforts werden Plüschteppiche häufig in Schlafzimmern, Wohnzimmern und anderen Bereichen verwendet, in denen die Menschen viel Zeit sitzend oder faulenzend auf dem Boden verbringen. Sie sind auch eine beliebte Wahl für Kindergärten und Kinderzimmer, da sie einen sicheren und bequemen Spielbereich für Kinder bieten. Insgesamt ist ein Plüschteppich eine gemütliche und einladende Ergänzung für jedes Zuhause. Seine weiche Textur und sein luxuriöses Gefühl machen ihn zu einer beliebten Wahl für alle, die eine warme und einladende Atmosphäre in ihrem Wohnraum schaffen wollen.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A plush area rug is a type of rug that is designed to be soft and comfortable underfoot. Plush rugs are characterized by their thick pile. The fibers are densely packed together, giving the rug a lush and luxurious feel.   Because of their softness and comfort, plush area rugs are often used in bedrooms, living rooms, and other areas where people spend a lot of time sitting or lounging on the floor. They are also a popular choice for nurseries and children's rooms, as they provide a safe and comfortable play area for kids.  Overall, a plush area rug is a cozy and inviting addition to any home. Its soft texture and luxurious feel make it a popular choice for those who want to create a warm and inviting atmosphere in their living space.",
           },
@@ -495,24 +489,20 @@ describe(`with meadowRug preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Meadow Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Wiesenteppich",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Meadow Rug",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -520,24 +510,20 @@ describe(`with meadowRug preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "meadow-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "meadow-teppich",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "meadow-rug",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/minimalist-cedar-nightstand.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/minimalist-cedar-nightstand.spec.ts
@@ -197,37 +197,30 @@ describe(`with minimalistCedarNightstand preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "tables",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-minimalist",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "storage--tables",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
@@ -235,17 +228,14 @@ describe(`with minimalistCedarNightstand preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The minimalist cedar nightstand is designed to provide a simple and functional surface for placing items next to a bed. The nightstand features a clean and sleek design with minimal decorative elements, in keeping with the minimalist aesthetic.  The nightstand is made from natural cedar wood, which is known for its durability, resistance to decay, and attractive grain patterns. The wood is finished with a light stain or clear coating to bring out the natural beauty of the wood.  Overall, a minimalist cedar nightstand is a stylish and functional addition to any bedroom. Its clean and simple design complements a variety of decor styles, and the natural beauty of the cedar wood adds warmth and texture to the space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Der minimalistische Nachttisch aus Zedernholz bietet eine einfache und funktionelle Ablagefläche für Gegenstände neben dem Bett. Der Nachttisch zeichnet sich durch ein klares und schlichtes Design mit minimalen dekorativen Elementen aus, ganz im Sinne der minimalistischen Ästhetik. Der Nachttisch ist aus natürlichem Zedernholz gefertigt, das für seine Langlebigkeit, Fäulnisbeständigkeit und attraktive Maserung bekannt ist. Das Holz ist mit einer hellen Beize oder einem Klarlack behandelt, um die natürliche Schönheit des Holzes hervorzuheben. Insgesamt ist ein minimalistischer Nachttisch aus Zedernholz eine stilvolle und funktionelle Ergänzung für jedes Schlafzimmer. Sein klares und einfaches Design passt zu einer Vielzahl von Einrichtungsstilen, und die natürliche Schönheit des Zedernholzes verleiht dem Raum Wärme und Textur.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The minimalist cedar nightstand is designed to provide a simple and functional surface for placing items next to a bed. The nightstand features a clean and sleek design with minimal decorative elements, in keeping with the minimalist aesthetic.  The nightstand is made from natural cedar wood, which is known for its durability, resistance to decay, and attractive grain patterns. The wood is finished with a light stain or clear coating to bring out the natural beauty of the wood.  Overall, a minimalist cedar nightstand is a stylish and functional addition to any bedroom. Its clean and simple design complements a variety of decor styles, and the natural beauty of the cedar wood adds warmth and texture to the space.",
           },
@@ -354,24 +344,20 @@ describe(`with minimalistCedarNightstand preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Minimalist Cedar Nightstand",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Minimalistischer Zedernholz Nachttisch",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Minimalist Cedar Nightstand",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -379,24 +365,20 @@ describe(`with minimalistCedarNightstand preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "minimalist-cedar-nightstand",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "minimalistischer-nachttisch-aus-zedernholz",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "minimalist-cedar-nightstand",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/minimalist-modern-side-table.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/minimalist-modern-side-table.spec.ts
@@ -329,32 +329,26 @@ describe(`with minimalistModernSideTable preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "tables",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-minimalist",
             "typeId": "category",
           },
@@ -362,17 +356,14 @@ describe(`with minimalistModernSideTable preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A minimalist side table with a round top and 4 tapered legs at a slant is a simple and stylish piece of furniture that can add a touch of contemporary elegance to any living space. The table features a round or circular top that is made of wood.  The top of the table is supported by four tapered legs that are set at a slight angle, giving the table a unique and modern look. The legs are made of wood.  The minimalist design of the side table emphasizes simplicity and functionality, with a clean and uncluttered look that is both stylish and practical. The table's compact size makes it an ideal choice for small living spaces or as an accent piece in a larger room.  The table can be used to display decorative items such as vases, picture frames, or sculptures, or as a functional surface for drinks, snacks, or books. Its simple and unobtrusive design allows it to blend seamlessly with a variety of interior design styles, from modern and contemporary to traditional and rustic.  Overall, a minimalist side table with a round top and 4 tapered legs at a slant is a stylish and versatile piece of furniture that can add a touch of sophistication to any living space. Its sleek and simple design, combined with its functional features, make it a practical and stylish choice for any home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein minimalistischer Beistelltisch mit runder Platte und 4 schräg gestellten, konischen Beinen ist ein einfaches und stilvolles Möbelstück, das jedem Wohnraum einen Hauch zeitgenössischer Eleganz verleihen kann. Der Tisch hat eine runde oder kreisförmige Platte aus Holz. Die Tischplatte wird von vier leicht schräg gestellten, konischen Beinen getragen, die dem Tisch einen einzigartigen und modernen Look verleihen. Die Beine sind aus Holz gefertigt. Das minimalistische Design des Beistelltischs unterstreicht die Schlichtheit und Funktionalität, mit einem klaren und übersichtlichen Look, der sowohl stilvoll als auch praktisch ist. Die kompakte Größe des Tisches macht ihn zu einer idealen Wahl für kleine Wohnräume oder als Akzent in einem größeren Raum. Der Tisch kann zur Präsentation von Dekorationsgegenständen wie Vasen, Bilderrahmen oder Skulpturen oder als funktionale Ablagefläche für Getränke, Snacks oder Bücher genutzt werden. Durch sein schlichtes und unaufdringliches Design fügt er sich nahtlos in eine Vielzahl von Einrichtungsstilen ein, von modern und zeitgenössisch bis hin zu traditionell und rustikal. Insgesamt ist der minimalistische Beistelltisch mit runder Platte und 4 schräg gestellten, konischen Beinen ein stilvolles und vielseitiges Möbelstück, das jedem Wohnraum einen Hauch von Raffinesse verleihen kann. Sein schlankes und einfaches Design in Kombination mit seinen funktionalen Eigenschaften machen ihn zu einer praktischen und stilvollen Wahl für jedes Zuhause.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A minimalist side table with a round top and 4 tapered legs at a slant is a simple and stylish piece of furniture that can add a touch of contemporary elegance to any living space. The table features a round or circular top that is made of wood.  The top of the table is supported by four tapered legs that are set at a slight angle, giving the table a unique and modern look. The legs are made of wood.  The minimalist design of the side table emphasizes simplicity and functionality, with a clean and uncluttered look that is both stylish and practical. The table's compact size makes it an ideal choice for small living spaces or as an accent piece in a larger room.  The table can be used to display decorative items such as vases, picture frames, or sculptures, or as a functional surface for drinks, snacks, or books. Its simple and unobtrusive design allows it to blend seamlessly with a variety of interior design styles, from modern and contemporary to traditional and rustic.  Overall, a minimalist side table with a round top and 4 tapered legs at a slant is a stylish and versatile piece of furniture that can add a touch of sophistication to any living space. Its sleek and simple design, combined with its functional features, make it a practical and stylish choice for any home.",
           },
@@ -477,24 +468,20 @@ describe(`with minimalistModernSideTable preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Minimalist Modern Side Table",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Minimalistischer Moderner Beistelltisch",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Minimalist Modern Side Table",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -502,24 +489,20 @@ describe(`with minimalistModernSideTable preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "minimalist-modern-side-table",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "minimalistischer-moderner-beistelltisch",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "minimalist-modern-side-table",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-black-coaster.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-black-coaster.spec.ts
@@ -181,17 +181,14 @@ describe(`with modernBlackCoaster preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bar-accessories",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -199,17 +196,14 @@ describe(`with modernBlackCoaster preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A round black coaster is a small, flat disc-shaped object, which is placed under a drinking glass or cup to protect the surface of a table or other furniture from water rings or spills. The coaster is circular in shape and has a solid black color, giving it a sleek and minimalist appearance. Its surface is smooth to provide a non-slip grip for the glass or cup. The edges include a stitching ornamentation, adding to the coaster's aesthetic appeal. Overall, a round black coaster is a functional and stylish accessory that is perfect for any home or office setting.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein runder schwarzer Untersetzer ist ein kleines, flaches, scheibenförmiges Objekt, das unter ein Trinkglas oder eine Tasse gestellt wird, um die Oberfläche eines Tisches oder anderer Möbel vor Wasserringen oder Verschüttungen zu schützen. Der Untersetzer hat eine runde Form und ist einfarbig schwarz, was ihm ein schlichtes und minimalistisches Aussehen verleiht. Seine Oberfläche ist glatt, damit das Glas oder die Tasse rutschfest steht. Die Ränder sind mit einer Nahtverzierung versehen, die die Ästhetik des Untersetzers unterstreicht. Insgesamt ist ein runder schwarzer Untersetzer ein funktionelles und stilvolles Accessoire, das sich perfekt für jedes Zuhause oder Büro eignet.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A round black coaster is a small, flat disc-shaped object, which is placed under a drinking glass or cup to protect the surface of a table or other furniture from water rings or spills. The coaster is circular in shape and has a solid black color, giving it a sleek and minimalist appearance. Its surface is smooth to provide a non-slip grip for the glass or cup. The edges include a stitching ornamentation, adding to the coaster's aesthetic appeal. Overall, a round black coaster is a functional and stylish accessory that is perfect for any home or office setting.",
           },
@@ -314,24 +308,20 @@ describe(`with modernBlackCoaster preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Modern Black Coaster",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Moderner schwarzer Untersetzer",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Modern Black Coaster",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -339,24 +329,20 @@ describe(`with modernBlackCoaster preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "modern-black-coaster",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "moderner-schwarzer-untersetzer",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "modern-black-coaster",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-bookcase.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-bookcase.spec.ts
@@ -184,32 +184,26 @@ describe(`with modernBookcase preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-modernist",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "storage--tables",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
@@ -217,17 +211,14 @@ describe(`with modernBookcase preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This Modern bookcase is designed with a simple and sleek look that blends well with modern decor. It has clean lines. The bookcase is made of wood and has a mahogany finish.  The shelves are open and spacious, providing ample space to store and display books, decorative objects, and other items.  In addition to its functional purpose, a minimalist bookcase also serves as a decorative piece of furniture. It is designed to blend seamlessly with its surroundings, without drawing too much attention to itself. As such, it is an excellent choice for those who want a stylish yet unobtrusive storage solution.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieses moderne Bücherregal hat ein einfaches und elegantes Design, das sich gut in die moderne Einrichtung einfügt. Es hat klare Linien. Das Bücherregal ist aus Holz gefertigt und mahagonifarben lackiert. Die offenen und geräumigen Regalböden bieten reichlich Platz zum Aufbewahren und Ausstellen von Büchern, Dekorationsobjekten und anderen Gegenständen. Ein minimalistisches Bücherregal erfüllt nicht nur einen funktionalen Zweck, sondern dient auch als dekoratives Möbelstück. Es ist so konzipiert, dass es sich nahtlos in seine Umgebung einfügt, ohne zu viel Aufmerksamkeit auf sich zu ziehen. Daher ist es eine ausgezeichnete Wahl für alle, die eine stilvolle, aber unauffällige Aufbewahrungslösung suchen.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This Modern bookcase is designed with a simple and sleek look that blends well with modern decor. It has clean lines. The bookcase is made of wood and has a mahogany finish.  The shelves are open and spacious, providing ample space to store and display books, decorative objects, and other items.  In addition to its functional purpose, a minimalist bookcase also serves as a decorative piece of furniture. It is designed to blend seamlessly with its surroundings, without drawing too much attention to itself. As such, it is an excellent choice for those who want a stylish yet unobtrusive storage solution.",
           },
@@ -324,24 +315,20 @@ describe(`with modernBookcase preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Modern Bookcase",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Modernes Bücherregal",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Modern Bookcase",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -349,24 +336,20 @@ describe(`with modernBookcase preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "modern-bookcase",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "modernes-bcherregal",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "modern-bookcase",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-ceramic-plate.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-ceramic-plate.spec.ts
@@ -185,32 +185,26 @@ describe(`with modernCeramicPlate preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "plates",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serving-platters",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serveware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "cheese-trays",
             "typeId": "category",
           },
@@ -218,17 +212,14 @@ describe(`with modernCeramicPlate preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A ceramic dinner plate is a classic and versatile dish that is used to serve a variety of meals.   The plate has a flat, circular surface with a slightly raised lip around the edges to prevent food from spilling over.   Ceramic dinner plates are ideal for serving a variety of dishes, including entrees, sides, salads, and desserts. They can be used in both casual and formal settings, and are a popular choice in restaurants and homes alike.  Ceramic dinner plates are durable and easy to clean, making them a practical choice for everyday use. They can be washed in a dishwasher or hand washed with soap and water.  Overall, a ceramic dinner plate is a classic and functional choice for serving food. Its simplicity and durability make it a staple in many kitchens and dining rooms, and its versatility makes it suitable for a range of dining occasions.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Keramikteller ist ein klassischer und vielseitiger Teller, der zum Servieren einer Vielzahl von Speisen verwendet wird. Der Teller hat eine flache, runde Oberfläche mit einer leicht erhöhten Lippe an den Rändern, um ein Überschwappen der Speisen zu verhindern. Keramische Essteller eignen sich ideal zum Servieren einer Vielzahl von Gerichten, darunter Vorspeisen, Beilagen, Salate und Desserts. Sie können sowohl in zwanglosem als auch in formellem Rahmen verwendet werden und sind sowohl in Restaurants als auch in Privathaushalten eine beliebte Wahl.  Keramische Essteller sind langlebig und leicht zu reinigen, was sie zu einer praktischen Wahl für den täglichen Gebrauch macht. Sie können in der Spülmaschine oder von Hand mit Wasser und Seife gereinigt werden. Insgesamt ist ein Keramikteller eine klassische und funktionelle Wahl für das Servieren von Speisen. Seine Schlichtheit und Langlebigkeit machen ihn zu einem Grundnahrungsmittel in vielen Küchen und Esszimmern, und seine Vielseitigkeit macht ihn für eine Reihe von Essanlässen geeignet.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A ceramic dinner plate is a classic and versatile dish that is used to serve a variety of meals.   The plate has a flat, circular surface with a slightly raised lip around the edges to prevent food from spilling over.   Ceramic dinner plates are ideal for serving a variety of dishes, including entrees, sides, salads, and desserts. They can be used in both casual and formal settings, and are a popular choice in restaurants and homes alike.  Ceramic dinner plates are durable and easy to clean, making them a practical choice for everyday use. They can be washed in a dishwasher or hand washed with soap and water.  Overall, a ceramic dinner plate is a classic and functional choice for serving food. Its simplicity and durability make it a staple in many kitchens and dining rooms, and its versatility makes it suitable for a range of dining occasions.",
           },
@@ -325,24 +316,20 @@ describe(`with modernCeramicPlate preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Modern Ceramic Plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Moderne Keramikplatte",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Modern Ceramic Plate",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -350,24 +337,20 @@ describe(`with modernCeramicPlate preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "modern-ceramic-plate",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "moderne-keramikplatte",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "modern-ceramic-plate",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-glam-dresser.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-glam-dresser.spec.ts
@@ -202,27 +202,22 @@ describe(`with modernGlamDresser preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-modernist",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "storage--tables",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
@@ -230,17 +225,14 @@ describe(`with modernGlamDresser preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A modern glam dresser is a stylish and elegant piece of furniture that combines modern design with glamorous accents. It features clean lines, sleek surfaces, and metallic finishes, creating a chic and sophisticated look that adds a touch of luxury to any bedroom.  The dresser is made of high-quality materials. The drawers are spacious and easy to open and close, providing ample storage space for clothing, accessories, and other items.  The dresser also features glamorous metal accents handles, adding a touch of elegance and sophistication to the piece. The overall design of the dresser is sleek and minimalist, with an emphasis on clean lines and simple shapes.  A modern glam dresser can be a beautiful addition to any bedroom, adding a touch of luxury and sophistication to the space. Its clean lines, metallic finishes, and glamorous accents create a modern and elegant look that can complement a variety of decor styles.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Eine moderne glamouröse Kommode ist ein stilvolles und elegantes Möbelstück, das modernes Design mit glamourösen Akzenten verbindet. Sie zeichnet sich durch klare Linien, glatte Oberflächen und Metallic-Finish aus, wodurch ein schickes und anspruchsvolles Aussehen entsteht, das jedem Schlafzimmer einen Hauch von Luxus verleiht. Die Kommode ist aus hochwertigen Materialien gefertigt. Die Schubladen sind geräumig und lassen sich leicht öffnen und schließen und bieten reichlich Stauraum für Kleidung, Accessoires und andere Gegenstände. Die Kommode verfügt außerdem über glamouröse Metallgriffe, die dem Möbelstück einen Hauch von Eleganz und Raffinesse verleihen. Das Gesamtdesign der Kommode ist schlank und minimalistisch, mit einem Schwerpunkt auf klaren Linien und einfachen Formen. Eine moderne, glamouröse Kommode ist eine schöne Ergänzung für jedes Schlafzimmer und verleiht dem Raum einen Hauch von Luxus und Raffinesse. Die klaren Linien, die metallischen Oberflächen und die glamourösen Akzente sorgen für einen modernen und eleganten Look, der eine Vielzahl von Einrichtungsstilen ergänzen kann.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A modern glam dresser is a stylish and elegant piece of furniture that combines modern design with glamorous accents. It features clean lines, sleek surfaces, and metallic finishes, creating a chic and sophisticated look that adds a touch of luxury to any bedroom.  The dresser is made of high-quality materials. The drawers are spacious and easy to open and close, providing ample storage space for clothing, accessories, and other items.  The dresser also features glamorous metal accents handles, adding a touch of elegance and sophistication to the piece. The overall design of the dresser is sleek and minimalist, with an emphasis on clean lines and simple shapes.  A modern glam dresser can be a beautiful addition to any bedroom, adding a touch of luxury and sophistication to the space. Its clean lines, metallic finishes, and glamorous accents create a modern and elegant look that can complement a variety of decor styles.",
           },
@@ -353,24 +345,20 @@ describe(`with modernGlamDresser preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Modern Glam Dresser",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Moderne glamouröse Kommode",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Modern Glam Dresser",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -378,24 +366,20 @@ describe(`with modernGlamDresser preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "modern-glam-dresser",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "moderne-glamourse-kommode",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "modern-glam-dresser",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-gold-coffee-table.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-gold-coffee-table.spec.ts
@@ -236,27 +236,22 @@ describe(`with modernGoldCoffeeTable preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "tables",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-modernist",
             "typeId": "category",
           },
@@ -264,17 +259,14 @@ describe(`with modernGoldCoffeeTable preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A modern gold coffee table with 2 tiers of quartz table tops is a stunning and stylish piece of furniture that can elevate the look of any living room or sitting area. The table is characterized by a sleek and streamlined design, with clean lines and minimalistic details.  The coffee table features a sturdy metal frame that is finished in a luxurious gold color, providing a touch of sophistication and glamour. The frame is designed to support two tiers of table tops, both made of high-quality quartz material. The quartz table tops are cut in a rectangular shape, with a smooth and glossy surface that adds a touch of elegance to the table.  The two tiers of table tops provide ample storage and display space, allowing you to showcase decorative items such as books, candles, or vases, while still providing plenty of room for drinks and snacks. The two-tier design also adds visual interest and dimension to the table, creating a unique and eye-catching look.  The modern gold coffee table is a versatile piece of furniture that can complement a range of interior design styles, from contemporary and minimalist to more traditional and eclectic. It can be paired with a variety of seating options, from sofas and chairs to benches and stools, to create a cohesive and stylish living space.  Overall, a modern gold coffee table is a chic and elegant piece of furniture that can add a touch of luxury and sophistication to any living room or sitting area. Its sleek design, high-quality materials, and practical features make it a functional and stylish choice for any home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Der moderne goldene Couchtisch mit 2 Ebenen aus Quarzplatten ist ein atemberaubendes und stilvolles Möbelstück, das jedes Wohnzimmer oder jeden Sitzbereich aufwerten kann. Der Tisch zeichnet sich durch ein schlankes und stromlinienförmiges Design aus, mit klaren Linien und minimalistischen Details.  Der Couchtisch verfügt über ein robustes Metallgestell, das in einer luxuriösen Goldfarbe ausgeführt ist und einen Hauch von Raffinesse und Glamour vermittelt. Das Gestell ist so konzipiert, dass es zwei Ebenen von Tischplatten trägt, die beide aus hochwertigem Quarzmaterial bestehen. Die Quarz-Tischplatten sind rechteckig geschnitten und haben eine glatte und glänzende Oberfläche, die dem Tisch einen Hauch von Eleganz verleiht. Die zwei Ebenen der Tischplatten bieten reichlich Ablage- und Ausstellungsfläche, so dass Sie dekorative Gegenstände wie Bücher, Kerzen oder Vasen präsentieren können, während Sie gleichzeitig genügend Platz für Getränke und Snacks haben. Das zweistufige Design verleiht dem Tisch auch visuelles Interesse und Dimensionen und schafft einen einzigartigen und auffälligen Look. Der moderne Couchtisch in Gold ist ein vielseitiges Möbelstück, das zu einer Reihe von Einrichtungsstilen passt, von modern und minimalistisch bis hin zu traditionell und eklektisch. Er kann mit einer Vielzahl von Sitzgelegenheiten kombiniert werden, von Sofas und Stühlen bis hin zu Bänken und Hockern, um einen zusammenhängenden und stilvollen Wohnbereich zu schaffen. Insgesamt ist ein moderner goldener Couchtisch ein schickes und elegantes Möbelstück, das jedem Wohnzimmer oder jeder Sitzecke einen Hauch von Luxus und Raffinesse verleihen kann. Sein schlankes Design, die hochwertigen Materialien und die praktischen Funktionen machen ihn zu einer funktionalen und stilvollen Wahl für jedes Zuhause.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A modern gold coffee table with 2 tiers of quartz table tops is a stunning and stylish piece of furniture that can elevate the look of any living room or sitting area. The table is characterized by a sleek and streamlined design, with clean lines and minimalistic details.  The coffee table features a sturdy metal frame that is finished in a luxurious gold color, providing a touch of sophistication and glamour. The frame is designed to support two tiers of table tops, both made of high-quality quartz material. The quartz table tops are cut in a rectangular shape, with a smooth and glossy surface that adds a touch of elegance to the table.  The two tiers of table tops provide ample storage and display space, allowing you to showcase decorative items such as books, candles, or vases, while still providing plenty of room for drinks and snacks. The two-tier design also adds visual interest and dimension to the table, creating a unique and eye-catching look.  The modern gold coffee table is a versatile piece of furniture that can complement a range of interior design styles, from contemporary and minimalist to more traditional and eclectic. It can be paired with a variety of seating options, from sofas and chairs to benches and stools, to create a cohesive and stylish living space.  Overall, a modern gold coffee table is a chic and elegant piece of furniture that can add a touch of luxury and sophistication to any living room or sitting area. Its sleek design, high-quality materials, and practical features make it a functional and stylish choice for any home.",
           },
@@ -403,24 +395,20 @@ describe(`with modernGoldCoffeeTable preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Modern Gold Coffee Table",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Moderner Gold Couchtisch",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Modern Gold Coffee Table",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -428,24 +416,20 @@ describe(`with modernGoldCoffeeTable preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "modern-gold-coffee-table",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "moderner-couchtisch-in-gold",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "modern-gold-coffee-table",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-landscape-painting.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-landscape-painting.spec.ts
@@ -152,17 +152,14 @@ describe(`with modernLandscapePainting preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "home-accents",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -170,17 +167,14 @@ describe(`with modernLandscapePainting preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A modern cubist landscape painting is a striking and dynamic work of art that combines elements of traditional landscape painting with the fractured and abstract style of cubism. The painting is created with oil paints on canvas, and features a range of bold colors and geometric shapes.  The composition of the painting is a landscape scene, depicting a natural setting. However, the scene is fragmented and abstracted, with overlapping planes of color and geometric shapes that distort and fracture the landscape.  The use of color in the painting is vibrant and bold, with strong contrasts between light and dark areas. The artist may have used a variety of techniques, such as layering, blending, or stippling, to create a dynamic and visually interesting piece.  The modern and abstract nature of the painting makes it a perfect addition to contemporary interior design schemes.  Overall, a modern cubist landscape painting is a bold and innovative work of art that can add a sense of energy and dynamism to any space. Its fragmented and abstracted composition invites viewers to interpret and connect with the painting in their own way, while the use of bold colors and geometric shapes creates a sense of drama and excitement.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein modernes kubistisches Landschaftsgemälde ist ein eindrucksvolles und dynamisches Kunstwerk, das Elemente der traditionellen Landschaftsmalerei mit dem gebrochenen und abstrakten Stil des Kubismus verbindet. Das Gemälde wurde mit Ölfarben auf Leinwand gemalt und weist eine Reihe kräftiger Farben und geometrischer Formen auf. Die Komposition des Gemäldes ist eine Landschaftsszene, die eine natürliche Umgebung darstellt. Die Szene ist jedoch fragmentiert und abstrahiert, mit sich überlagernden Farbflächen und geometrischen Formen, die die Landschaft verzerren und zerbrechen. Die Farbgebung des Gemäldes ist lebhaft und kräftig, mit starken Kontrasten zwischen hellen und dunklen Bereichen. Der Künstler hat möglicherweise eine Reihe von Techniken angewandt, wie z. B. Schichtung, Überblendung oder Tupfen, um ein dynamisches und visuell interessantes Werk zu schaffen. Der moderne und abstrakte Charakter des Gemäldes macht es zu einer perfekten Ergänzung für zeitgenössische Innenarchitekturen. Insgesamt ist ein modernes kubistisches Landschaftsgemälde ein kühnes und innovatives Kunstwerk, das jedem Raum ein Gefühl von Energie und Dynamik verleihen kann. Die fragmentierte und abstrahierte Komposition lädt den Betrachter dazu ein, das Gemälde auf seine eigene Weise zu interpretieren und mit ihm in Verbindung zu treten, während die Verwendung kräftiger Farben und geometrischer Formen ein Gefühl von Dramatik und Aufregung erzeugt.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A modern cubist landscape painting is a striking and dynamic work of art that combines elements of traditional landscape painting with the fractured and abstract style of cubism. The painting is created with oil paints on canvas, and features a range of bold colors and geometric shapes.  The composition of the painting is a landscape scene, depicting a natural setting. However, the scene is fragmented and abstracted, with overlapping planes of color and geometric shapes that distort and fracture the landscape.  The use of color in the painting is vibrant and bold, with strong contrasts between light and dark areas. The artist may have used a variety of techniques, such as layering, blending, or stippling, to create a dynamic and visually interesting piece.  The modern and abstract nature of the painting makes it a perfect addition to contemporary interior design schemes.  Overall, a modern cubist landscape painting is a bold and innovative work of art that can add a sense of energy and dynamism to any space. Its fragmented and abstracted composition invites viewers to interpret and connect with the painting in their own way, while the use of bold colors and geometric shapes creates a sense of drama and excitement.",
           },
@@ -265,24 +259,20 @@ describe(`with modernLandscapePainting preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Modern Landscape Painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Moderne Landschaftsmalerei",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Modern Landscape Painting",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -290,24 +280,20 @@ describe(`with modernLandscapePainting preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "modern-landscape-painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "moderne-landschaftsmalerei",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "modern-landscape-painting",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-three-seater-sofa.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-three-seater-sofa.spec.ts
@@ -227,27 +227,22 @@ describe(`with modernThreeSeaterSofa preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "sofas",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-modernist",
             "typeId": "category",
           },
@@ -255,17 +250,14 @@ describe(`with modernThreeSeaterSofa preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A three seater sofa in modern style with bolster cushions is a sleek and stylish piece of furniture that can add a touch of contemporary sophistication to any living space. The sofa features a wooden frame that is covered in soft and durable upholstery.  The sofa's design is characterized by clean lines and simple shapes, with a low profile that creates a modern and minimalist look. The backrest and seat cushions are attached to the frame, with a seamless and streamlined appearance that enhances the sofa's sleek aesthetic.  The sofa is often equipped with bolster cushions, which are long, cylindrical cushions that can be used as armrests or to support the lower back while seated. The bolster cushions are covered in the same upholstery fabric as the rest of the sofa, creating a cohesive and coordinated look.  The four legs of the sofa are made of wood, with a simple and unadorned design that complements the sofa's modern aesthetic.  The three-seater size of the sofa provides ample seating space for three people, making it an ideal choice for a small to medium-sized living room or family room. The sofa can be paired with a range of accent chairs, coffee tables, and other furniture pieces to create a cohesive and stylish living space.  Overall, a three seater sofa in modern style is a sleek and sophisticated piece of furniture that can add a touch of contemporary style to any living space. Its clean lines, simple shapes, and minimalistic design make it a versatile and stylish choice for any modern home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das Dreisitzer-Sofa im modernen Stil mit Nackenkissen ist ein elegantes und stilvolles Möbelstück, das jedem Wohnraum einen Hauch von zeitgenössischer Raffinesse verleihen kann. Das Sofa besteht aus einem Holzrahmen, der mit einer weichen und strapazierfähigen Polsterung überzogen ist. Das Design des Sofas zeichnet sich durch klare Linien und einfache Formen aus, mit einem niedrigen Profil, das einen modernen und minimalistischen Look erzeugt. Die Rückenlehne und die Sitzkissen sind mit dem Rahmen verbunden, so dass ein nahtloses und stromlinienförmiges Erscheinungsbild entsteht, das die schlichte Ästhetik des Sofas unterstreicht. Das Sofa ist häufig mit Nackenkissen ausgestattet. Das sind lange, zylindrische Kissen, die als Armlehnen oder zur Unterstützung des unteren Rückens beim Sitzen verwendet werden können. Die Nackenkissen sind mit dem gleichen Bezugsstoff wie der Rest des Sofas bezogen, wodurch ein einheitliches und abgestimmtes Aussehen entsteht. Die vier Beine des Sofas sind aus Holz und haben ein einfaches und schnörkelloses Design, das die moderne Ästhetik des Sofas ergänzt. Die Größe des Sofas als Dreisitzer bietet ausreichend Platz für drei Personen und ist damit die ideale Wahl für ein kleines bis mittelgroßes Wohnzimmer oder ein Familienzimmer. Das Sofa kann mit einer Reihe von Akzentstühlen, Couchtischen und anderen Möbelstücken kombiniert werden, um einen zusammenhängenden und stilvollen Wohnraum zu schaffen. Insgesamt ist ein Dreisitzer-Sofa im modernen Stil ein elegantes und anspruchsvolles Möbelstück, das jedem Wohnraum einen Hauch von zeitgenössischem Stil verleihen kann. Seine klaren Linien, einfachen Formen und sein minimalistisches Design machen es zu einer vielseitigen und stilvollen Wahl für jedes moderne Zuhause.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A three seater sofa in modern style with bolster cushions is a sleek and stylish piece of furniture that can add a touch of contemporary sophistication to any living space. The sofa features a wooden frame that is covered in soft and durable upholstery.  The sofa's design is characterized by clean lines and simple shapes, with a low profile that creates a modern and minimalist look. The backrest and seat cushions are attached to the frame, with a seamless and streamlined appearance that enhances the sofa's sleek aesthetic.  The sofa is often equipped with bolster cushions, which are long, cylindrical cushions that can be used as armrests or to support the lower back while seated. The bolster cushions are covered in the same upholstery fabric as the rest of the sofa, creating a cohesive and coordinated look.  The four legs of the sofa are made of wood, with a simple and unadorned design that complements the sofa's modern aesthetic.  The three-seater size of the sofa provides ample seating space for three people, making it an ideal choice for a small to medium-sized living room or family room. The sofa can be paired with a range of accent chairs, coffee tables, and other furniture pieces to create a cohesive and stylish living space.  Overall, a three seater sofa in modern style is a sleek and sophisticated piece of furniture that can add a touch of contemporary style to any living space. Its clean lines, simple shapes, and minimalistic design make it a versatile and stylish choice for any modern home.",
           },
@@ -394,24 +386,20 @@ describe(`with modernThreeSeaterSofa preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Modern Three Seater Sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Modernes Dreisitzer-Sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Modern Three Seater Sofa",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -419,24 +407,20 @@ describe(`with modernThreeSeaterSofa preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "modern-three-seater-sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "modernes-dreisitzer-sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "modern-three-seater-sofa",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-upholstered-queen-bed.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-upholstered-queen-bed.spec.ts
@@ -203,27 +203,22 @@ describe(`with modernUpholsteredQueenBed preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "beds",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-modernist",
             "typeId": "category",
           },
@@ -231,17 +226,14 @@ describe(`with modernUpholsteredQueenBed preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A queen bed upholstered with velvet fabric and brass nails and tufting is a luxurious and elegant piece of furniture that can add a touch of glamour and sophistication to any bedroom. The bed features a wooden frame that is covered with soft and plush velvet upholstery.  The headboard of the bed is the focal point of the design, featuring a tufted or quilted pattern that creates a plush and inviting surface to lean against. The tufting is accentuated with brass nailhead trim, which adds a touch of metallic shine and texture to the design.  The footboard and side rails of the bed are also upholstered in the same velvet fabric and trimmed with brass nailheads, creating a cohesive and stylish look. The legs of the bed are wood.  The queen size of the bed provides ample space for a comfortable night's sleep, while the luxurious velvet upholstery and brass accents add an element of glamour and sophistication to the room. The bed can be paired with a range of bedding and accessories, such as plush pillows and soft blankets, to create a cozy and inviting atmosphere.  Overall, a queen bed upholstered with velvet fabric and brass nails and tufting is a stunning and stylish piece of furniture that can transform any bedroom into a luxurious and elegant space. Its plush upholstery, intricate tufting, and metallic accents make it a standout piece that is sure to impress and delight.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein mit Samtstoff gepolstertes Bett mit Messingnägeln und Tufting ist ein luxuriöses und elegantes Möbelstück, das jedem Schlafzimmer einen Hauch von Glamour und Raffinesse verleihen kann. Das Bett besteht aus einem Holzrahmen, der mit einem weichen und plüschigen Samtbezug überzogen ist. Das Kopfteil des Bettes ist der Mittelpunkt des Designs und weist ein getuftetes oder gestepptes Muster auf, das eine weiche und einladende Oberfläche zum Anlehnen bietet. Die Tuftings sind mit Messingnägeln akzentuiert, die dem Design einen Hauch von metallischem Glanz und Textur verleihen. Das Fußteil und die Seitengitter des Bettes sind ebenfalls mit demselben Samtstoff bezogen und mit Messingnagelköpfen verziert, wodurch ein einheitliches und stilvolles Erscheinungsbild entsteht. Die Beine des Bettes sind aus Holz. Die Größe des Bettes bietet reichlich Platz für eine komfortable Nachtruhe, während die luxuriöse Samtpolsterung und die Messingakzente dem Raum einen Hauch von Glamour und Raffinesse verleihen. Das Bett kann mit einer Reihe von Bettwaren und Accessoires, wie z. B. Plüschkissen und weichen Decken, kombiniert werden, um eine gemütliche und einladende Atmosphäre zu schaffen. Insgesamt ist ein mit Samtstoff gepolstertes Bett mit Messingnägeln und Tufting ein atemberaubendes und stilvolles Möbelstück, das jedes Schlafzimmer in einen luxuriösen und eleganten Raum verwandeln kann. Die plüschige Polsterung, die raffinierten Tuftings und die metallischen Akzente machen es zu einem herausragenden Möbelstück, das Sie sicher beeindrucken und begeistern wird.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A queen bed upholstered with velvet fabric and brass nails and tufting is a luxurious and elegant piece of furniture that can add a touch of glamour and sophistication to any bedroom. The bed features a wooden frame that is covered with soft and plush velvet upholstery.  The headboard of the bed is the focal point of the design, featuring a tufted or quilted pattern that creates a plush and inviting surface to lean against. The tufting is accentuated with brass nailhead trim, which adds a touch of metallic shine and texture to the design.  The footboard and side rails of the bed are also upholstered in the same velvet fabric and trimmed with brass nailheads, creating a cohesive and stylish look. The legs of the bed are wood.  The queen size of the bed provides ample space for a comfortable night's sleep, while the luxurious velvet upholstery and brass accents add an element of glamour and sophistication to the room. The bed can be paired with a range of bedding and accessories, such as plush pillows and soft blankets, to create a cozy and inviting atmosphere.  Overall, a queen bed upholstered with velvet fabric and brass nails and tufting is a stunning and stylish piece of furniture that can transform any bedroom into a luxurious and elegant space. Its plush upholstery, intricate tufting, and metallic accents make it a standout piece that is sure to impress and delight.",
           },
@@ -346,24 +338,20 @@ describe(`with modernUpholsteredQueenBed preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Modern Upholstered Queen Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Modernes gepolstertes Queensize-Bett",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Modern Upholstered Queen Bed",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -371,24 +359,20 @@ describe(`with modernUpholsteredQueenBed preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "modern-upholstered-queen-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "modernes-gepolstertes-queensize-bett",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "modern-upholstered-queen-bed",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-upholstered-twin-bed.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/modern-upholstered-twin-bed.spec.ts
@@ -643,27 +643,22 @@ describe(`with modernUpholsteredTwinBed preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "beds",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-modernist",
             "typeId": "category",
           },
@@ -671,17 +666,14 @@ describe(`with modernUpholsteredTwinBed preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A twin size bed with fabric upholstery in a modern style is a sleek and stylish piece of furniture that can add a touch of sophistication to any bedroom. The bed typically features a simple and minimalistic design, with clean lines and geometric shapes that are characteristic of modern style.  The frame of the bed is made from wood, with a low profile that creates a sleek and contemporary look. The fabric upholstery covers the headboard, footboard, and side rails of the bed, providing a soft and comfortable surface to lean against or rest on.  The size of the bed is twin, which makes it an ideal choice for smaller bedrooms or guest rooms. It can be paired with a range of bedding and accessories to create a cohesive and stylish look that reflects your personal style.  Overall, a twin size bed with fabric upholstery in a modern style is a sleek and sophisticated piece of furniture that can elevate the look and feel of any bedroom. Its simple yet stylish design, combined with its comfortable and soft upholstery, make it a perfect place to rest and relax in style.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Doppelbett mit Stoffbezug im modernen Stil ist ein elegantes und stilvolles Möbelstück, das jedem Schlafzimmer einen Hauch von Raffinesse verleihen kann. Das Bett zeichnet sich durch ein einfaches und minimalistisches Design aus, mit klaren Linien und geometrischen Formen, die für den modernen Stil charakteristisch sind. Der Rahmen des Bettes ist aus Holz gefertigt und hat ein niedriges Profil, das einen schlanken und modernen Look erzeugt. Das Kopfteil, das Fußteil und die Seitengitter des Bettes sind mit Stoff bezogen und bieten eine weiche und bequeme Oberfläche zum Anlehnen und Ausruhen. Das Bett hat eine Größe von zwei Einzelbetten und ist daher ideal für kleinere Schlafzimmer oder Gästezimmer. Es kann mit einer Reihe von Bettwaren und Accessoires kombiniert werden, um einen zusammenhängenden und stilvollen Look zu schaffen, der Ihren persönlichen Stil widerspiegelt. Insgesamt ist ein Doppelbett mit Stoffbezug im modernen Stil ein elegantes und raffiniertes Möbelstück, das jedes Schlafzimmer aufwerten kann. Das schlichte, aber stilvolle Design in Kombination mit der bequemen und weichen Polsterung machen es zu einem perfekten Ort, um sich stilvoll auszuruhen und zu entspannen.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A twin size bed with fabric upholstery in a modern style is a sleek and stylish piece of furniture that can add a touch of sophistication to any bedroom. The bed typically features a simple and minimalistic design, with clean lines and geometric shapes that are characteristic of modern style.  The frame of the bed is made from wood, with a low profile that creates a sleek and contemporary look. The fabric upholstery covers the headboard, footboard, and side rails of the bed, providing a soft and comfortable surface to lean against or rest on.  The size of the bed is twin, which makes it an ideal choice for smaller bedrooms or guest rooms. It can be paired with a range of bedding and accessories to create a cohesive and stylish look that reflects your personal style.  Overall, a twin size bed with fabric upholstery in a modern style is a sleek and sophisticated piece of furniture that can elevate the look and feel of any bedroom. Its simple yet stylish design, combined with its comfortable and soft upholstery, make it a perfect place to rest and relax in style.",
           },
@@ -802,24 +794,20 @@ describe(`with modernUpholsteredTwinBed preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Modern Upholstered Twin Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Modernes gepolstertes Doppelbett",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Modern Upholstered Twin Bed",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -827,24 +815,20 @@ describe(`with modernUpholsteredTwinBed preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "modern-upholstered-twin-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "modernes-gepolstertes-einzelbett",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "modern-upholstered-twin-bed",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/nala-two-seater-sofa.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/nala-two-seater-sofa.spec.ts
@@ -972,32 +972,26 @@ describe(`with nalaTwoSeaterSofa preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "sofas",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-traditionalist",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
@@ -1005,17 +999,14 @@ describe(`with nalaTwoSeaterSofa preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This modern 2-seater sofa is a stylish and comfortable addition to any living space. The sofa features a sleek and minimalistic design, with clean lines and a contemporary aesthetic. It is upholstered in high-quality cotton fabric, which is soft to the touch and easy to clean. The two seat cushions are plush and supportive, offering a comfortable place to sit and relax. The backrest is well-padded, providing ample back support, while the armrests are gently curved for a comfortable and relaxed feel. The sofa's frame is made from sturdy wood, ensuring it will last for years to come. With a modern and minimalist style, this sofa can fit in seamlessly with any modern decor, while the comfortable and high-quality upholstery makes it a great place to relax and unwind.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieses moderne 2-Sitzer-Sofa ist eine stilvolle und komfortable Ergänzung für jeden Wohnbereich. Das Sofa hat ein schlichtes und minimalistisches Design mit klaren Linien und einer zeitgenössischen Ästhetik. Es ist mit einem hochwertigen Baumwollstoff gepolstert, der sich weich anfühlt und leicht zu reinigen ist. Die beiden Sitzkissen sind weich und stützend und bieten einen bequemen Platz zum Sitzen und Entspannen. Die Rückenlehne ist gut gepolstert und stützt den Rücken, während die Armlehnen sanft geschwungen sind, um ein bequemes und entspanntes Gefühl zu vermitteln. Das Gestell des Sofas ist aus robustem Holz oder Metall gefertigt, so dass es viele Jahre halten wird. Mit seinem modernen und minimalistischen Stil fügt sich dieses Sofa nahtlos in jede moderne Einrichtung ein, während die bequeme und hochwertige Polsterung es zu einem großartigen Ort zum Entspannen und Relaxen macht.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This modern 2-seater sofa is a stylish and comfortable addition to any living space. The sofa features a sleek and minimalistic design, with clean lines and a contemporary aesthetic. It is upholstered in high-quality cotton fabric, which is soft to the touch and easy to clean. The two seat cushions are plush and supportive, offering a comfortable place to sit and relax. The backrest is well-padded, providing ample back support, while the armrests are gently curved for a comfortable and relaxed feel. The sofa's frame is made from sturdy wood, ensuring it will last for years to come. With a modern and minimalist style, this sofa can fit in seamlessly with any modern decor, while the comfortable and high-quality upholstery makes it a great place to relax and unwind.",
           },
@@ -1132,24 +1123,20 @@ describe(`with nalaTwoSeaterSofa preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Nala Two-Seater Sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Nala Zweisitzer-Sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Nala Two-Seater Sofa",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -1157,24 +1144,20 @@ describe(`with nalaTwoSeaterSofa preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "nala-two-seater-sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "nala-zweisitzer-sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "nala-two-seater-sofa",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/natura-rug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/natura-rug.spec.ts
@@ -171,17 +171,14 @@ describe(`with naturaRug preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "rugs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -189,17 +186,14 @@ describe(`with naturaRug preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A round area rug made of natural fibers is a type of rug that is circular in shape and made from materials that are found in nature. Natural fibers commonly used for this type of rug include jute, sisal, seagrass, and bamboo.  These rugs have a rustic and organic feel due to the use of natural materials, which can add warmth and texture to a space. The neutral tones of these fibers also make them versatile and able to complement a range of decor styles, from bohemian to coastal to farmhouse.  The texture and thickness of a round area rug made of natural fibers can vary depending on the material used. For example, jute and sisal have a rougher texture and thinner pile, while seagrass and bamboo have a smoother texture and thicker pile.  The construction of these rugs is often done by hand, which adds to their unique and one-of-a-kind quality. The weaving or braiding technique used to create the rug can also add visual interest to the design, such as with a herringbone or chevron pattern.  A round area rug made of natural fibers can be used in a variety of spaces, from living rooms to bedrooms to dining areas. They are especially popular in bohemian and coastal decor styles, where they can add a relaxed and laid-back vibe to the space.  Overall, a round area rug made of natural fibers is a stylish and eco-friendly choice for anyone looking to add texture and warmth to their home decor.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein runder Teppich aus Naturfasern ist ein kreisförmiger Teppich, der aus Materialien hergestellt wird, die in der Natur vorkommen. Zu den Naturfasern, die üblicherweise für diese Art von Teppichen verwendet werden, gehören Jute, Sisal, Seegras und Bambus. Durch die Verwendung natürlicher Materialien haben diese Teppiche einen rustikalen und organischen Charakter, der einem Raum Wärme und Struktur verleihen kann. Die neutralen Farbtöne dieser Fasern machen sie außerdem vielseitig einsetzbar und passen zu einer Reihe von Einrichtungsstilen, von Bohème über Küsten- bis hin zu Landhausstil. Die Textur und Dicke eines runden Teppichs aus Naturfasern kann je nach verwendetem Material variieren. Jute und Sisal haben beispielsweise eine rauere Struktur und einen dünneren Flor, während Seegras und Bambus eine glattere Textur und einen dickeren Flor haben.  Die Herstellung dieser Teppiche erfolgt häufig in Handarbeit, was zu ihrer Einzigartigkeit beiträgt. Auch die Web- oder Flechttechnik, mit der der Teppich hergestellt wird, kann das Design optisch aufwerten, z. B. durch ein Fischgräten- oder Chevron-Muster.  Ein runder Teppich aus Naturfasern kann in einer Vielzahl von Räumen verwendet werden, vom Wohnzimmer über das Schlafzimmer bis zum Essbereich. Besonders beliebt sind sie im Bohème- und Küsten-Stil, wo sie dem Raum eine entspannte und lockere Atmosphäre verleihen können. Insgesamt ist ein runder Teppich aus Naturfasern eine stilvolle und umweltfreundliche Wahl für alle, die ihrer Einrichtung Textur und Wärme verleihen möchten.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A round area rug made of natural fibers is a type of rug that is circular in shape and made from materials that are found in nature. Natural fibers commonly used for this type of rug include jute, sisal, seagrass, and bamboo.  These rugs have a rustic and organic feel due to the use of natural materials, which can add warmth and texture to a space. The neutral tones of these fibers also make them versatile and able to complement a range of decor styles, from bohemian to coastal to farmhouse.  The texture and thickness of a round area rug made of natural fibers can vary depending on the material used. For example, jute and sisal have a rougher texture and thinner pile, while seagrass and bamboo have a smoother texture and thicker pile.  The construction of these rugs is often done by hand, which adds to their unique and one-of-a-kind quality. The weaving or braiding technique used to create the rug can also add visual interest to the design, such as with a herringbone or chevron pattern.  A round area rug made of natural fibers can be used in a variety of spaces, from living rooms to bedrooms to dining areas. They are especially popular in bohemian and coastal decor styles, where they can add a relaxed and laid-back vibe to the space.  Overall, a round area rug made of natural fibers is a stylish and eco-friendly choice for anyone looking to add texture and warmth to their home decor.",
           },
@@ -296,24 +290,20 @@ describe(`with naturaRug preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Natura Rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Natura Teppich",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Natura Rug",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -321,24 +311,20 @@ describe(`with naturaRug preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "natura-rug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "natura-teppich",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "natura-rug",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/opal-king-bed.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/opal-king-bed.spec.ts
@@ -172,17 +172,14 @@ describe(`with opalKingBed preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "beds",
             "typeId": "category",
           },
@@ -190,17 +187,14 @@ describe(`with opalKingBed preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A modern king bed with a tufted headboard is a stylish and elegant piece of furniture that can bring a touch of luxury and sophistication to any bedroom. The mattress platform is large enough to accommodate a king-size mattress, and the entire bed is designed with clean, sleek lines that give it a modern look.  The tufted headboard is the centerpiece of the bed and is often the most eye-catching feature. It is made of soft, durable fabric that is tufted in a square pattern. The tufted design gives the headboard a plush, cushioned appearance, making it comfortable for sitting up in bed to read or watch TV.  The overall design of the bed is modern, emphasizing the beauty of the tufted headboard.   Overall, a modern king bed with a tufted headboard is a statement piece that can add both style and comfort to any bedroom.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein modernes Kingsize-Bett mit getuftetem Kopfteil ist ein stilvolles und elegantes Möbelstück, das einen Hauch von Luxus und Raffinesse in jedes Schlafzimmer bringen kann. Die Matratzenplattform ist groß genug, um eine Kingsize-Matratze aufzunehmen, und das gesamte Bett ist mit klaren, schlanken Linien gestaltet, die ihm einen modernen Look verleihen. Das getuftete Kopfteil ist das Herzstück des Bettes und oft der Blickfang schlechthin. Es ist aus weichem, strapazierfähigem Stoff gefertigt, der in einem quadratischen Muster getuftet ist. Das getuftete Design verleiht dem Kopfteil ein plüschiges, gepolstertes Aussehen und macht es bequem, wenn man im Bett sitzt, um zu lesen oder fernzusehen. Das Gesamtdesign des Bettes ist modern und unterstreicht die Schönheit des getufteten Kopfteils. Insgesamt ist ein modernes Doppelbett mit getuftetem Kopfteil ein Highlight, das jedes Schlafzimmer mit Stil und Komfort bereichert.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A modern king bed with a tufted headboard is a stylish and elegant piece of furniture that can bring a touch of luxury and sophistication to any bedroom. The mattress platform is large enough to accommodate a king-size mattress, and the entire bed is designed with clean, sleek lines that give it a modern look.  The tufted headboard is the centerpiece of the bed and is often the most eye-catching feature. It is made of soft, durable fabric that is tufted in a square pattern. The tufted design gives the headboard a plush, cushioned appearance, making it comfortable for sitting up in bed to read or watch TV.  The overall design of the bed is modern, emphasizing the beauty of the tufted headboard.   Overall, a modern king bed with a tufted headboard is a statement piece that can add both style and comfort to any bedroom.",
           },
@@ -297,24 +291,20 @@ describe(`with opalKingBed preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Opal King Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Opal King Bett",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Opal King Bed",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -322,24 +312,20 @@ describe(`with opalKingBed preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "opal-king-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "opal-kingsize-bett",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "opal-king-bed",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/orion-double-bed.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/orion-double-bed.spec.ts
@@ -191,17 +191,14 @@ describe(`with orionDoubleBed preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "beds",
             "typeId": "category",
           },
@@ -209,17 +206,14 @@ describe(`with orionDoubleBed preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A queen bed with a tufted headboard and platform and steel legs is a modern and stylish piece of furniture. The headboard is tall and wide, featuring a tufted design. The fabric used for the headboard is soft and luxurious, providing a comfortable place to lean against when sitting up in bed.  The bed is raised off the ground on a platform, which is supported by sleek and sturdy steel legs. The platform provides a solid and stable foundation for the mattress, while also giving the bed a clean and minimalist look.   Overall, this queen bed is a beautiful and functional piece that would be perfect for a modern bedroom with a minimalist or industrial aesthetic.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Queensize-Bett mit getuftetem Kopfteil und Podest und Stahlfüßen ist ein modernes und stilvolles Möbelstück. Das Kopfteil ist hoch und breit und verfügt über ein getuftetes Design. Der für das Kopfteil verwendete Stoff ist weich und luxuriös und bietet einen bequemen Platz zum Anlehnen, wenn man sich im Bett aufrichtet. Das Bett steht auf einem Podest, das von schlanken und stabilen Stahlbeinen getragen wird. Das Podest bietet eine solide und stabile Grundlage für die Matratze und verleiht dem Bett gleichzeitig einen klaren und minimalistischen Look. Insgesamt ist dieses Bett ein schönes und funktionales Möbelstück, das sich perfekt für ein modernes Schlafzimmer mit minimalistischer oder industrieller Ästhetik eignet.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A queen bed with a tufted headboard and platform and steel legs is a modern and stylish piece of furniture. The headboard is tall and wide, featuring a tufted design. The fabric used for the headboard is soft and luxurious, providing a comfortable place to lean against when sitting up in bed.  The bed is raised off the ground on a platform, which is supported by sleek and sturdy steel legs. The platform provides a solid and stable foundation for the mattress, while also giving the bed a clean and minimalist look.   Overall, this queen bed is a beautiful and functional piece that would be perfect for a modern bedroom with a minimalist or industrial aesthetic.",
           },
@@ -324,24 +318,20 @@ describe(`with orionDoubleBed preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Orion Double Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Orion Doppelbett",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Orion Double Bed",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -349,24 +339,20 @@ describe(`with orionDoubleBed preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "orion-double-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "orion-doppelbett",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "orion-double-bed",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/patterned-pillow-cover.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/patterned-pillow-cover.spec.ts
@@ -283,12 +283,10 @@ describe(`with patternedPillowCover preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedding",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -296,17 +294,14 @@ describe(`with patternedPillowCover preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "An art deco velvet pillow cover with geometric design is a luxurious and stylish accessory for any room in the home. It is made from soft, plush velvet fabric that feels soft and smooth to the touch. The velvet has a rich, lustrous sheen that adds an elegant and sophisticated touch to the pillow cover.  The pillow cover features a geometric design that is inspired by the art deco style of the early 20th century. The design includes bold and angular shapes.  The pillow cover is often used as a decorative accent for a bed, sofa, or accent chair, and can add a touch of glamour and sophistication to any room in the home. It can be paired with other art deco-inspired accessories, such as lamps, vases, and wall art, to create a cohesive and stylish look.  The velvet fabric is durable and easy to clean, and can be spot cleaned with a damp cloth or sponge. It should be air-dried and fluffed periodically to maintain its shape and texture.  Overall, an art deco velvet pillow cover with geometric design is a luxurious and stylish accessory that can enhance the beauty and comfort of any room in the home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Art-Deco-Samtkissenbezug mit geometrischem Muster ist ein luxuriöses und stilvolles Accessoire für jeden Raum in Ihrem Zuhause. Er ist aus weichem, plüschigem Samtstoff gefertigt, der sich weich und glatt anfühlt. Der Samt hat einen reichen, schimmernden Glanz, der dem Kissenbezug eine elegante und anspruchsvolle Note verleiht. Der Kissenbezug weist ein geometrisches Design auf, das vom Art-déco-Stil des frühen 20. Jahrhunderts inspiriert ist. Jahrhunderts inspiriert ist. Das Design umfasst kühne und eckige Formen. Der Kissenbezug wird oft als dekorativer Akzent für ein Bett, ein Sofa oder einen Sessel verwendet und kann jedem Raum im Haus einen Hauch von Glamour und Raffinesse verleihen. Er lässt sich mit anderen vom Art déco inspirierten Accessoires wie Lampen, Vasen und Wandbildern kombinieren, um ein stimmiges und stilvolles Gesamtbild zu schaffen. Der Samtstoff ist strapazierfähig und pflegeleicht und kann mit einem feuchten Tuch oder Schwamm abgewischt werden. Er sollte regelmäßig an der Luft getrocknet und aufgefächert werden, damit er seine Form und Struktur behält.  Insgesamt ist ein Art-Déco-Samtkissenbezug mit geometrischem Muster ein luxuriöses und stilvolles Accessoire, das die Schönheit und den Komfort eines jeden Raums im Haus verbessern kann.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "An art deco velvet pillow cover with geometric design is a luxurious and stylish accessory for any room in the home. It is made from soft, plush velvet fabric that feels soft and smooth to the touch. The velvet has a rich, lustrous sheen that adds an elegant and sophisticated touch to the pillow cover.  The pillow cover features a geometric design that is inspired by the art deco style of the early 20th century. The design includes bold and angular shapes.  The pillow cover is often used as a decorative accent for a bed, sofa, or accent chair, and can add a touch of glamour and sophistication to any room in the home. It can be paired with other art deco-inspired accessories, such as lamps, vases, and wall art, to create a cohesive and stylish look.  The velvet fabric is durable and easy to clean, and can be spot cleaned with a damp cloth or sponge. It should be air-dried and fluffed periodically to maintain its shape and texture.  Overall, an art deco velvet pillow cover with geometric design is a luxurious and stylish accessory that can enhance the beauty and comfort of any room in the home.",
           },
@@ -407,24 +402,20 @@ describe(`with patternedPillowCover preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Patterned Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Gemusterter Kissenbezug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Patterned Pillow Cover",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -432,24 +423,20 @@ describe(`with patternedPillowCover preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "patterned-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "gemusterte-kissenhlle",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "patterned-pillow-cover",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/pink-abstract-painting.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/pink-abstract-painting.spec.ts
@@ -149,17 +149,14 @@ describe(`with pinkAbstractPainting preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "home-accents",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -167,17 +164,14 @@ describe(`with pinkAbstractPainting preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A pink abstract painting is a vibrant and eye-catching work of art that can evoke a range of emotions and interpretations. The painting is created with acrylic paints on canvas.  The composition of the painting is abstract, with no recognizable objects or figures. The use of pink in the painting may be symbolic, representing love, femininity, or energy.  The painting can be hung on a wall as part of a gallery grouping or as a statement piece that dominates the room. The pink color scheme of the painting can create a powerful focal point, drawing the eye towards it and creating a sense of energy.  Overall, a pink abstract painting is a bold and expressive work of art that can add a sense of vitality and excitement to any space. Its vibrant color scheme and abstract composition can create a sense of mystery and intrigue, inviting viewers to interpret and connect with the painting in their own way.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein rosafarbenes abstraktes Gemälde ist ein lebhaftes und auffälliges Kunstwerk, das eine Reihe von Emotionen und Interpretationen hervorrufen kann. Das Gemälde wurde mit Acrylfarben auf Leinwand gemalt. Die Komposition des Gemäldes ist abstrakt und enthält keine erkennbaren Objekte oder Figuren. Die Verwendung von Rosa auf dem Gemälde kann symbolisch sein und Liebe, Weiblichkeit oder Energie darstellen. Das Gemälde kann als Teil einer Galeriegruppe oder als raumbeherrschendes Einzelstück an die Wand gehängt werden. Das Rosa des Gemäldes kann einen starken Fokuspunkt bilden, der das Auge auf das Bild lenkt und ein Gefühl von Energie erzeugt. Insgesamt ist ein rosafarbenes abstraktes Gemälde ein kühnes und ausdrucksstarkes Kunstwerk, das jedem Raum ein Gefühl von Vitalität und Aufregung verleihen kann. Die lebendige Farbgebung und die abstrakte Komposition können ein geheimnisvolles Gefühl und Faszination erzeugen und den Betrachter dazu einladen, das Gemälde auf seine eigene Weise zu interpretieren und sich mit ihm zu verbinden.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A pink abstract painting is a vibrant and eye-catching work of art that can evoke a range of emotions and interpretations. The painting is created with acrylic paints on canvas.  The composition of the painting is abstract, with no recognizable objects or figures. The use of pink in the painting may be symbolic, representing love, femininity, or energy.  The painting can be hung on a wall as part of a gallery grouping or as a statement piece that dominates the room. The pink color scheme of the painting can create a powerful focal point, drawing the eye towards it and creating a sense of energy.  Overall, a pink abstract painting is a bold and expressive work of art that can add a sense of vitality and excitement to any space. Its vibrant color scheme and abstract composition can create a sense of mystery and intrigue, inviting viewers to interpret and connect with the painting in their own way.",
           },
@@ -262,24 +256,20 @@ describe(`with pinkAbstractPainting preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Pink Abstract Painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Abstrakte Rosa Malerei",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Pink Abstract Painting",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -287,24 +277,20 @@ describe(`with pinkAbstractPainting preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "pink-abstract-painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "rosa-abstrakte-malerei",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "pink-abstract-painting",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/purple-landscape-painting.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/purple-landscape-painting.spec.ts
@@ -152,17 +152,14 @@ describe(`with purpleLandscapePainting preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "home-accents",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -170,17 +167,14 @@ describe(`with purpleLandscapePainting preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A purple landscape painting on canvas is a visually stunning work of art that can evoke a range of emotions and feelings. The painting is created with oil paints on a stretched canvas, and features a range of shades of purple, from deep indigo to light lavender.  The composition of the painting is a landscape scene, depicting a natural setting such as a forest, mountain range, or field. The use of purple in the painting may be symbolic, representing creativity, spirituality, or mystery.  The artist may have used a variety of techniques, such as layering, blending, or stippling, to create a dynamic and visually interesting piece. The texture of the painting may also be emphasized, with visible brushstrokes or thick impasto areas.  The painting can be hung on a wall as part of a gallery grouping or as a statement piece that dominates the room. The purple color scheme of the painting can create a powerful focal point, drawing the eye towards it and creating a sense of drama.  Overall, a purple landscape painting on canvas is a captivating and expressive work of art that can add a sense of wonder and enchantment to any space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein violettes Landschaftsgemälde auf Leinwand ist ein visuell beeindruckendes Kunstwerk, das eine Reihe von Emotionen und Gefühlen hervorrufen kann. Das Gemälde wurde mit Ölfarben auf einer aufgespannten Leinwand gemalt und zeigt eine Reihe von Lila-Tönen, von tiefem Indigo bis zu hellem Lavendel. Die Komposition des Gemäldes ist eine Landschaftsszene, die eine natürliche Umgebung wie einen Wald, eine Bergkette oder ein Feld darstellt. Die Verwendung von Violett auf dem Gemälde kann symbolisch sein und für Kreativität, Spiritualität oder Geheimnisse stehen. Der Künstler schafft durch eine Vielzahl von Techniken, wie z. B. Schichtung, Überblendung oder Tupfen, ein dynamisches und visuell interessantes Werk. Die Textur des Gemäldes wird durch sichtbare Pinselstriche und dicke Impasto-Bereiche hervorgehoben. Das Gemälde kann als Teil einer Galeriegruppe oder als raumbeherrschendes Kunstwerk an die Wand gehängt werden. Das violette Farbschema des Gemäldes kann einen starken Fokuspunkt bilden, der den Blick auf das Bild lenkt und ein Gefühl der Dramatik erzeugt.  Insgesamt ist ein lilafarbenes Landschaftsgemälde auf Leinwand ein fesselndes und ausdrucksstarkes Kunstwerk, das jedem Raum ein Gefühl der Verwunderung und Verzauberung verleihen kann.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A purple landscape painting on canvas is a visually stunning work of art that can evoke a range of emotions and feelings. The painting is created with oil paints on a stretched canvas, and features a range of shades of purple, from deep indigo to light lavender.  The composition of the painting is a landscape scene, depicting a natural setting such as a forest, mountain range, or field. The use of purple in the painting may be symbolic, representing creativity, spirituality, or mystery.  The artist may have used a variety of techniques, such as layering, blending, or stippling, to create a dynamic and visually interesting piece. The texture of the painting may also be emphasized, with visible brushstrokes or thick impasto areas.  The painting can be hung on a wall as part of a gallery grouping or as a statement piece that dominates the room. The purple color scheme of the painting can create a powerful focal point, drawing the eye towards it and creating a sense of drama.  Overall, a purple landscape painting on canvas is a captivating and expressive work of art that can add a sense of wonder and enchantment to any space.",
           },
@@ -265,24 +259,20 @@ describe(`with purpleLandscapePainting preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Purple Landscape Painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Lila Landschaftsmalerei",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Purple Landscape Painting",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -290,24 +280,20 @@ describe(`with purpleLandscapePainting preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "purple-landscape-painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "lila-landschaftsmalerei",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "purple-landscape-painting",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/purple-minimalist-abstract-painting.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/purple-minimalist-abstract-painting.spec.ts
@@ -161,17 +161,14 @@ describe(`with purpleMinimalistAbstractPainting preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "home-accents",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -179,17 +176,14 @@ describe(`with purpleMinimalistAbstractPainting preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A purple minimalist abstract painting is a simple and elegant work of art that relies on the use of minimal elements and a limited color palette to create a striking visual impact. The painting is created with acrylic paints on canvas.  The color scheme of the painting is predominantly purple, with little or no use of other colors. The use of purple in the painting may be symbolic, representing creativity, spirituality, or mystery.  The painting can be hung on a wall as part of a gallery grouping. The minimalist nature of the painting allows it to blend seamlessly with a variety of interior design styles and color schemes.  Overall, a purple minimalist abstract painting is a sophisticated and understated work of art that can add a sense of serenity and harmony to any space. Its simple composition and limited color palette can create a calming and meditative atmosphere, while the use of purple adds a sense of mystery and depth to the painting.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein lilafarbenes minimalistisches abstraktes Gemälde ist ein einfaches und elegantes Kunstwerk, das durch die Verwendung minimaler Elemente und einer begrenzten Farbpalette eine beeindruckende visuelle Wirkung erzielt. Das Gemälde wurde mit Acrylfarben auf Leinwand gemalt. Das Farbschema des Gemäldes ist überwiegend violett, mit wenig bis gar keiner Verwendung anderer Farben. Die Verwendung von Violett in dem Gemälde kann symbolisch sein und Kreativität, Spiritualität oder Geheimnisse darstellen. Das Gemälde kann als Teil einer Galeriegruppe an die Wand gehängt werden. Der minimalistische Charakter des Gemäldes erlaubt es, es nahtlos mit einer Vielzahl von Einrichtungsstilen und Farbschemata zu kombinieren. Insgesamt ist ein lilafarbenes, minimalistisches, abstraktes Gemälde ein raffiniertes und unaufdringliches Kunstwerk, das jedem Raum ein Gefühl von Gelassenheit und Harmonie verleihen kann. Die einfache Komposition und die begrenzte Farbpalette können eine beruhigende und meditative Atmosphäre schaffen, während die Verwendung von Lila dem Gemälde ein Gefühl von Geheimnis und Tiefe verleiht.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A purple minimalist abstract painting is a simple and elegant work of art that relies on the use of minimal elements and a limited color palette to create a striking visual impact. The painting is created with acrylic paints on canvas.  The color scheme of the painting is predominantly purple, with little or no use of other colors. The use of purple in the painting may be symbolic, representing creativity, spirituality, or mystery.  The painting can be hung on a wall as part of a gallery grouping. The minimalist nature of the painting allows it to blend seamlessly with a variety of interior design styles and color schemes.  Overall, a purple minimalist abstract painting is a sophisticated and understated work of art that can add a sense of serenity and harmony to any space. Its simple composition and limited color palette can create a calming and meditative atmosphere, while the use of purple adds a sense of mystery and depth to the painting.",
           },
@@ -278,24 +272,20 @@ describe(`with purpleMinimalistAbstractPainting preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Purple Minimalist Abstract Painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Lila Minimalistische Abstrakte Malerei",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Purple Minimalist Abstract Painting",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -303,24 +293,20 @@ describe(`with purpleMinimalistAbstractPainting preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "purple-minimalist-abstract-painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "lila-minimalistische-abstrakte-malerei",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "purple-minimalist-abstract-painting",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/rattan-lounge-chair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/rattan-lounge-chair.spec.ts
@@ -196,17 +196,14 @@ describe(`with rattanLoungeChair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -214,17 +211,14 @@ describe(`with rattanLoungeChair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Rattan Lounge Chair is designed to provide comfortable seating for relaxing and lounging. The chair features a sturdy frame made of rattan, with a woven pattern of rattan fibers forming the seat and backrest.  The chair comes with additional cushioning for extra comfort, made from soft cotton fabric. The cushions are removable, allowing for easy cleaning or replacement.  The design of the rattan lounge chair is inspired by tropical or bohemian styles, with a natural and earthy look. The chair features intricate woven patterns or geometric shapes, creating a visually interesting texture.  The rattan material used in the construction of the chair is known for its durability and resistance to wear and tear. It is also lightweight, making it easy to move the chair around the room.  Overall, a rattan lounge chair is a stylish and comfortable addition to any living room or outdoor space. Its natural materials and unique design create a relaxed and inviting atmosphere, making it the perfect place to unwind and enjoy some peace and quiet.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Rattan Lounge Chair is designed to provide comfortable seating for relaxing and lounging. The chair features a sturdy frame made of rattan, with a woven pattern of rattan fibers forming the seat and backrest.  The chair comes with additional cushioning for extra comfort, made from soft cotton fabric. The cushions are removable, allowing for easy cleaning or replacement.  The design of the rattan lounge chair is inspired by tropical or bohemian styles, with a natural and earthy look. The chair features intricate woven patterns or geometric shapes, creating a visually interesting texture.  The rattan material used in the construction of the chair is known for its durability and resistance to wear and tear. It is also lightweight, making it easy to move the chair around the room.  Overall, a rattan lounge chair is a stylish and comfortable addition to any living room or outdoor space. Its natural materials and unique design create a relaxed and inviting atmosphere, making it the perfect place to unwind and enjoy some peace and quiet.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Der Loungesessel aus Rattan bietet eine bequeme Sitzgelegenheit zum Entspannen. Das Webmuster aus Rattanfasern bildet die Sitzfläche und Rückenlehne, die von einem stabilen Rattangestell gehalten werden. Die Polsterung aus weichem Baumwollstoff sorgt für zusätzlichen Sitzkomfort. Die Kissen sind abnehmbar, was die Reinigung oder einen Austausch erleichtert.  Das Design des Rattan-Loungesessels ist vom tropischen Ambiente des Bohemian-Looks inspiriert und zeigt sich in erdigen Tönen. Das komplexe Webmuster mit seinen geometrischen Formen bildet ein optisches Highlight. Das für die Konstruktion des Sitzmöbels verwendete Rattanmaterial ist langlebig, verschleißfest und leicht. Der Sessel kann somit flexibel in jeden Innen- oder Außenbereich integriert werden. Seine natürlichen Materialien und sein einzigartiges Design schaffen eine entspannte und einladende Atmosphäre zum Relaxen.",
           },
@@ -337,24 +331,20 @@ describe(`with rattanLoungeChair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Rattan Lounge Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Rattan Lounge Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Loungesessel aus Rattan",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -362,24 +352,20 @@ describe(`with rattanLoungeChair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "rattan-lounge-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "rattan-lounge-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "rattan-loungesessel",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/raven-bowl.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/raven-bowl.spec.ts
@@ -175,22 +175,18 @@ describe(`with ravenBowl preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bowls",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
@@ -198,17 +194,14 @@ describe(`with ravenBowl preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This bowl is a dish designed to serve soup and other liquid-based foods. It is a square-shaped bowl with four straight sides and a flat bottom, creating a modern and contemporary look for dining.  Overall, a square soup bowl is a functional and stylish choice for serving soup and other liquid-based foods. Its unique shape and contemporary design make it a popular choice for those who appreciate modern aesthetics and practicality.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This bowl is a dish designed to serve soup and other liquid-based foods. It is a square-shaped bowl with four straight sides and a flat bottom, creating a modern and contemporary look for dining.  Overall, a square soup bowl is a functional and stylish choice for serving soup and other liquid-based foods. Its unique shape and contemporary design make it a popular choice for those who appreciate modern aesthetics and practicality.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Die Schüssel >Raven< wurde zum Servieren von Suppen und anderer Flüssigspeisen designt. Die quadratische Form aus vier geraden Seiten und einem flachen Boden verleiht dem Suppentellerl einen modernen und zeitgemäßen Look.  Durch die einzigartige Form und das zeitgemäße Design ist >Raven< eine beliebte Wahl für all diejenigen, die Ästhetik und Praktikabilität auf ihrem Esstisch schätzen.",
           },
@@ -305,24 +298,20 @@ describe(`with ravenBowl preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Raven Bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Raven Bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Suppenschüssel >Raven<",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -330,24 +319,20 @@ describe(`with ravenBowl preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "raven-bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "raven-bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "rabenschssel",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/rectangle-serving-tray.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/rectangle-serving-tray.spec.ts
@@ -153,22 +153,18 @@ describe(`with rectangleServingTray preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "serving-platters",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serveware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -176,17 +172,14 @@ describe(`with rectangleServingTray preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This wooden serving tray is a versatile and functional item that can be used in a variety of settings. The wooden material used in the tray provides a warm and natural aesthetic, adding a touch of rustic charm to any setting.  Wooden serving trays are easy to clean and maintain. They can be wiped down with a damp cloth and mild detergent, and should be dried thoroughly after use to prevent any moisture from being trapped inside.  Overall, a wooden serving tray is a practical and attractive item that adds a touch of natural elegance to any setting. Its durability, versatility, and range of designs make it a popular choice for serving and displaying food, drinks, and other items.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This wooden serving tray is a versatile and functional item that can be used in a variety of settings. The wooden material used in the tray provides a warm and natural aesthetic, adding a touch of rustic charm to any setting.  Wooden serving trays are easy to clean and maintain. They can be wiped down with a damp cloth and mild detergent, and should be dried thoroughly after use to prevent any moisture from being trapped inside.  Overall, a wooden serving tray is a practical and attractive item that adds a touch of natural elegance to any setting. Its durability, versatility, and range of designs make it a popular choice for serving and displaying food, drinks, and other items.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das Serviertablett aus Holz ist ein vielseitiger und funktionaler Gegenstand, der in einer Vielzahl von Gelegenheiten zum Einsatz kommt. Das für das Tablett verwendete Holz mit seiner warmen und natürlichen Ästhetik sorgt für den rustikalen Charme. Holztabletts sind leicht zu reinigen und zu pflegen. Sie können mit einem feuchten Tuch und einem milden Reinigungsmittel abgewischt werden. Nach dem Gebrauch sollten sie gründlich getrocknet werden, damit keine Feuchtigkeit im Inneren eingeschlossen wird. Ein Serviertablett aus Holz ist ein praktisches und zugleich attraktives Designelement, das jedes Ambiente mit seiner natürlichen Eleganz komplementiert. Es ist langlebig und vielseitig einsetzbar zum Servieren und Präsentieren von Speisen und Getränken, oder aber als Designelement zum Hervorheben einzelner Gegenstände.",
           },
@@ -271,24 +264,20 @@ describe(`with rectangleServingTray preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Rectangle Serving Tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Rectangle Serving Tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Rechteckiges Serviertablett",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -296,24 +285,20 @@ describe(`with rectangleServingTray preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "rectangle-serving-tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "rectangle-serving-tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "rechteckiges-serviertablett",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/red-modern-painting.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/red-modern-painting.spec.ts
@@ -148,17 +148,14 @@ describe(`with redModernPainting preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "home-accents",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -166,17 +163,14 @@ describe(`with redModernPainting preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A red modern painting on canvas is a bold and striking piece of art that can add a contemporary flair to any room. The painting is created with acrylic paints on a stretched canvas, and features a range of shades of red.  The size of the painting can vary, from a small piece that can be hung on a wall as part of a gallery grouping, to a large statement piece that dominates the room. The red color scheme of the painting can create a powerful focal point, drawing the eye towards it and creating a sense of drama.  The style of the painting is contemporary, with a focus on expressing emotions and ideas through color and form. The red color may be symbolic, representing passion, strength, or energy, depending on the artist's intentions.  Overall, a red modern painting on canvas is a vibrant and expressive work of art that can add a sense of drama and excitement to any space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A red modern painting on canvas is a bold and striking piece of art that can add a contemporary flair to any room. The painting is created with acrylic paints on a stretched canvas, and features a range of shades of red.  The size of the painting can vary, from a small piece that can be hung on a wall as part of a gallery grouping, to a large statement piece that dominates the room. The red color scheme of the painting can create a powerful focal point, drawing the eye towards it and creating a sense of drama.  The style of the painting is contemporary, with a focus on expressing emotions and ideas through color and form. The red color may be symbolic, representing passion, strength, or energy, depending on the artist's intentions.  Overall, a red modern painting on canvas is a vibrant and expressive work of art that can add a sense of drama and excitement to any space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das rote moderne Gemälde aus Acrylfarben auf Leinwand ist ein kühnes und markantes Kunst-Statement, das jedem Raum ein zeitgenössisches Flair verleiht. Die Größenwirkung des Gemäldes kann variiert werden, indem es entweder mit mehreren Kunstwerken zusammen oder aber als eigenständiges Statement Piece aufgehängt wird. Das rote Farbschema des Gemäldes kann eine optische Spannung schaffen und ein Gefühl von Dramatik erzeugen. Der zeitgenössische Stil des Gemäldes legt seinen Schwerpunkt darauf, Emotionen und Ideen durch Farbe und Form auszudrücken. Die rote Farbe kann symbolisch gedeutet und als Leidenschaft, Stärke oder Energie ausgelegt werden. Die rote moderne Malerei auf Leinwand ist insgesamt ein lebendiges und ausdrucksstarkes Kunstwerk, das jedem Raum ein Gefühl von Dramatik und Aufregung verleiht.",
           },
@@ -261,24 +255,20 @@ describe(`with redModernPainting preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Red Modern Painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Red Modern Painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Rotes modernes Gemälde",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -286,24 +276,20 @@ describe(`with redModernPainting preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "red-modern-painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "red-modern-painting",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "rote-moderne-malerei",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/round-serving-tray.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/round-serving-tray.spec.ts
@@ -172,27 +172,22 @@ describe(`with roundServingTray preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "plates",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serving-platters",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serveware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "cheese-trays",
             "typeId": "category",
           },
@@ -200,17 +195,14 @@ describe(`with roundServingTray preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This Round Serving Tray is a versatile and durable item that can be used in a variety of settings. The wooden material used in the tray provides a warm and natural aesthetic, adding a touch of rustic charm to any setting.  Round wooden serving trays are easy to clean and maintain. They can be wiped down with a damp cloth and mild detergent, and should be dried thoroughly after use to prevent any moisture from being trapped inside.  Overall, a round wooden serving tray is a practical and attractive item that adds a touch of natural elegance to any setting. Its durability, versatility, and range of designs make it a popular choice for serving and displaying food, drinks, and other items.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This Round Serving Tray is a versatile and durable item that can be used in a variety of settings. The wooden material used in the tray provides a warm and natural aesthetic, adding a touch of rustic charm to any setting.  Round wooden serving trays are easy to clean and maintain. They can be wiped down with a damp cloth and mild detergent, and should be dried thoroughly after use to prevent any moisture from being trapped inside.  Overall, a round wooden serving tray is a practical and attractive item that adds a touch of natural elegance to any setting. Its durability, versatility, and range of designs make it a popular choice for serving and displaying food, drinks, and other items.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das runde Serviertablett aus Holz ist ein vielseitiger und langlebiger Gegenstand, der in einer Vielzahl von Gelegenheiten zum Einsatz kommt. Das für das Tablett verwendete Holz mit seiner warmen und natürlichen Ästhetik sorgt für den rustikalen Charme. Runde Holztabletts sind leicht zu reinigen und zu pflegen. Sie können mit einem feuchten Tuch und einem milden Reinigungsmittel abgewischt werden. Nach dem Gebrauch sollten sie gründlich getrocknet werden, damit keine Feuchtigkeit im Inneren eingeschlossen wird. Ein rundes Serviertablett aus Holz ist ein praktisches und zugleich attraktives Designelement, das jedes Ambiente mit seiner natürlichen Eleganz komplementiert. Es ist langlebig und vielseitig einsetzbar zum Servieren und Präsentieren von Speisen und Getränken, oder aber als Designelement zum Hervorheben einzelner Gegenstände.",
           },
@@ -307,24 +299,20 @@ describe(`with roundServingTray preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Round Serving Tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Round Serving Tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Rundes Serviertablett",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -332,24 +320,20 @@ describe(`with roundServingTray preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "round-serving-tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "round-serving-tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "rundes-serviertablett",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/rumi-chair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/rumi-chair.spec.ts
@@ -187,17 +187,14 @@ describe(`with rumiChair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -205,17 +202,14 @@ describe(`with rumiChair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A lilac velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The lilac color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the lilac velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A lilac velvet chair with a brass frame is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The lilac color of the velvet fabric is soft and delicate, adding a touch of femininity to the overall look of the chair.  The brass frame of the chair is sturdy and durable, providing a solid foundation for the seating area. The brass color of the frame adds a touch of warmth and sophistication to the overall look of the chair. The combination of the lilac velvet and brass frame creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein malvenfarbener Samtstuhl mit Messingrahmen ist ein elegantes und luxuriöses Möbelstück. Das weiche, plüschige Samtmaterial des Stuhls sorgt für ein bequemes und gemütliches Sitzerlebnis. Die lila Farbe des Samtstoffs ist sanft und zart und verleiht dem Gesamtbild des Stuhls einen Hauch von Weiblichkeit.  Der Messingrahmen des Stuhls ist robust und langlebig und bietet eine solide Grundlage für den Sitzbereich. Die Messingfarbe des Gestells verleiht dem Gesamtbild des Stuhls einen Hauch von Wärme und Raffinesse. Die Kombination aus fliederfarbenem Samt und Messingrahmen schafft einen auffälligen Kontrast und macht diesen Stuhl zu einem Statement Piece in jedem Raum. Die Rückenlehne des Stuhls ist hoch und geschwungen im Design, sodass sie Rücken und Schultern zu stützt. Der Stuhl ist sowohl auf Stil als auch auf Komfort ausgelegt, was ihn zu einer großartigen Ergänzung für jedes Wohnzimmer, Schlafzimmer oder Büro macht.",
           },
@@ -320,24 +314,20 @@ describe(`with rumiChair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Rumi Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Rumi Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Stuhl >Rumi<",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -345,24 +335,20 @@ describe(`with rumiChair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "rumi-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "rumi-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "rumi-stuhl",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/rustic-bowl.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/rustic-bowl.spec.ts
@@ -133,17 +133,14 @@ describe(`with rusticBowl preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This square wooden bowl is versatile and can be used for a variety of purposes, from serving salads and snacks to holding fruits and vegetables. It is ideal for casual or rustic dining settings and can add a touch of warmth and natural beauty to any table.  The square wooden bowl is a practical and stylish choice for serving and holding food. Its natural beauty and durability make it a popular choice for many different types of cuisine and dining occasions.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This square wooden bowl is versatile and can be used for a variety of purposes, from serving salads and snacks to holding fruits and vegetables. It is ideal for casual or rustic dining settings and can add a touch of warmth and natural beauty to any table.  The square wooden bowl is a practical and stylish choice for serving and holding food. Its natural beauty and durability make it a popular choice for many different types of cuisine and dining occasions.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Diese quadratische Holzschale bietet vielfältige Einsatzmöglichkeiten - vom Servieren von Salaten und Snacks bis hin zum Aufbewahren von Obst und Gemüse. Sie fügt sich ideal in jede ungezwungene oder rustikale Speiseumgebungen ein und verleiht jedem Tisch einen Hauch von Wärme und natürlicher Schönheit. Die quadratische Holzschale ist eine praktische und stilvolle Wahl zum Servieren und Aufbewahren von Speisen. Ihre natürliche Schönheit und Langlebigkeit bietet verschiedene Einsatzmöglichkeiten in der Küche und als Servierobjekt bei unterschiedlichen Anlässen.",
           },
@@ -228,24 +225,20 @@ describe(`with rusticBowl preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Rustic Bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Rustic Bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Rustikale Schale",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -253,24 +246,20 @@ describe(`with rusticBowl preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "rustic-bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "rustic-bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "rustikale-schale",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/rustic-country-dresser.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/rustic-country-dresser.spec.ts
@@ -203,17 +203,14 @@ describe(`with rusticCountryDresser preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "storage--tables",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
@@ -221,17 +218,14 @@ describe(`with rusticCountryDresser preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A rustic country dresser with ample storage is a charming and practical piece of furniture that can add warmth and character to any bedroom or living space. The dresser features a sturdy wooden frame and a vintage look that is both rustic and inviting.  The dresser is equipped with a range of drawers in various sizes, providing ample storage space for clothing, linens, and other items. The drawers are constructed with dovetail joints and gliding hardware, ensuring that they are durable and easy to use. The drawer fronts are adorned with rustic metal pulls, adding to the charm and character of the piece.  The top of the dresser provides additional storage space, allowing you to display decorative items, such as vases, candles, or picture frames.   Overall, a rustic country dresser with ample storage is a practical and stylish piece of furniture that can add warmth and character to any bedroom or living space. Its sturdy construction, ample storage space, and charming design make it a functional and beautiful addition to any home with a rustic or country decor style.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A rustic country dresser with ample storage is a charming and practical piece of furniture that can add warmth and character to any bedroom or living space. The dresser features a sturdy wooden frame and a vintage look that is both rustic and inviting.  The dresser is equipped with a range of drawers in various sizes, providing ample storage space for clothing, linens, and other items. The drawers are constructed with dovetail joints and gliding hardware, ensuring that they are durable and easy to use. The drawer fronts are adorned with rustic metal pulls, adding to the charm and character of the piece.  The top of the dresser provides additional storage space, allowing you to display decorative items, such as vases, candles, or picture frames.   Overall, a rustic country dresser with ample storage is a practical and stylish piece of furniture that can add warmth and character to any bedroom or living space. Its sturdy construction, ample storage space, and charming design make it a functional and beautiful addition to any home with a rustic or country decor style.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Die rustikale Landhauskommode mit viel Stauraum ist ein charmantes und praktisches Möbelstück, das jedem Schlafzimmer oder Wohnzimmer Wärme und Charakter verleiht. Die stabile Kommode mit Holzrahmen ist im Vintage-Look gehalten und wirkt sowohl rustikal als auch einladend.  Die Kommode ist mit einer Reihe von Schubladen in verschiedenen Größen ausgestattet, die ausreichend Stauraum für Kleidung, Bettwäsche und andere Gegenstände bieten. Die Schubladen sind mit Schwalbenschwanzverbindungen und Gleitbeschlägen konstruiert, um sicherzustellen, dass sie langlebig und einfach zu bedienen sind. Die Schubladenfronten sind mit rustikalen Metallgriffen geschmückt, die den Charme und Charakter des Möbelstücks noch verstärken. Die Platte der Kommode bietet zusätzlichen Stauraum für dekorative Gegenstände wie Vasen, Kerzen oder Bilderrahmen.  Eine rustikale Landhauskommode schafft auf praktische und stilvolle Weise Stauraum für und verleiht jedem Schlaf- oder Wohnraum gleichzeitig Wärme und Charme. Die robuste Konstruktion und das schlichte Design machen sie zu einer funktionalen und schönen Ergänzung für jedes Zuhause mit rustikalem oder ländlichem Einrichtungsstil.",
           },
@@ -352,24 +346,20 @@ describe(`with rusticCountryDresser preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Rustic Country Dresser",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Rustic Country Dresser",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Rustikale Landhauskommode",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -377,24 +367,20 @@ describe(`with rusticCountryDresser preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "rustic-country-dresser",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "rustic-country-dresser",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "rustikale-landhauskommode",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/rustic-country-queen-bed.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/rustic-country-queen-bed.spec.ts
@@ -199,22 +199,18 @@ describe(`with rusticCountryQueenBed preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "beds",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
@@ -222,17 +218,14 @@ describe(`with rusticCountryQueenBed preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A rustic queen bed with a suede headboard is a beautiful and comfortable piece of furniture that can add warmth and texture to any bedroom. The bed features a sturdy wooden frame and a vintage look that is both rustic and inviting.  The headboard of the bed is upholstered in soft suede fabric, providing a comfortable and stylish backrest for reading or relaxing in bed. The suede material also adds a tactile and luxurious feel to the bed, creating a cozy and inviting atmosphere in the bedroom.  The bed comes with a sturdy wooden slat system that provides excellent support for the mattress and ensures a comfortable and restful night's sleep.  The rustic queen bed with a suede headboard is designed to be both functional and stylish. The bed comes with a matching dresser to create a cohesive and stylish bedroom decor.  Overall, a rustic queen bed with a suede headboard is a beautiful and comfortable piece of furniture that can add warmth and texture to any bedroom. Its sturdy construction, comfortable design, and charming rustic style make it a functional and beautiful addition to any home with a rustic or country decor style.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A rustic queen bed with a suede headboard is a beautiful and comfortable piece of furniture that can add warmth and texture to any bedroom. The bed features a sturdy wooden frame and a vintage look that is both rustic and inviting.  The headboard of the bed is upholstered in soft suede fabric, providing a comfortable and stylish backrest for reading or relaxing in bed. The suede material also adds a tactile and luxurious feel to the bed, creating a cozy and inviting atmosphere in the bedroom.  The bed comes with a sturdy wooden slat system that provides excellent support for the mattress and ensures a comfortable and restful night's sleep.  The rustic queen bed with a suede headboard is designed to be both functional and stylish. The bed comes with a matching dresser to create a cohesive and stylish bedroom decor.  Overall, a rustic queen bed with a suede headboard is a beautiful and comfortable piece of furniture that can add warmth and texture to any bedroom. Its sturdy construction, comfortable design, and charming rustic style make it a functional and beautiful addition to any home with a rustic or country decor style.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das rustikale Queensize-Bett mit dem Kopfteil aus Wildleder ist ein schönes und komfortables Möbelstück, das jedem Schlafzimmer Wärme und Struktur verleiht. Das Bett hat einen stabilen Holzrahmen im Vintage-Look, der zum Relaxen einlädt.  Das Kopfteil des Bettes ist mit weichem Wildleder bezogen und bietet eine bequeme und stilvolle Rückenlehne zum Lesen oder Entspannen im Bett. Das Wildledermaterial verleiht dem Bett luxuriöses Gefühl zum Anfassen und schafft eine gemütliche und einladende Atmosphäre im Schlafzimmer.  Der stabile Holzlattenrost des Betts bietet eine solide Grundlage für die Matratze und somit für einen komfortablen und erholsamen Schlaf.  Das rustikale Queensize-Bett mit Kopfteil aus Wildleder ist sowohl funktional als auch stilvoll designt. Zu dem Bett gibt es eine passende Kommode, mit der ein zusammenhängendes und stilvolles Schlafzimmerdekor geschaffen werden kann.  Ein rustikales Queensize-Bett mit einem Kopfteil aus Wildleder ist ein schönes und komfortables Möbelstück, das Wärme und Textur in jedes Schlafzimmer bringt. Seine robuste Konstruktion, sein komfortables Design und der charmant-rustikale Charakter machen es zu einer funktionalen und schönen Ergänzung für jedes Zuhause im angesagten Landhausstil.",
           },
@@ -337,24 +330,20 @@ describe(`with rusticCountryQueenBed preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Rustic Country Queen Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Rustic Country Queen Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Rustikales Queensize-Bett im Landhausstil",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -362,24 +351,20 @@ describe(`with rusticCountryQueenBed preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "rustic-country-queen-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "rustic-country-queen-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "rustikales-country-queen-bett",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/rustic-oven-casserole.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/rustic-oven-casserole.spec.ts
@@ -162,17 +162,14 @@ describe(`with rusticOvenCasserole preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Die rustikale Keramik-Kasserolle eignet sich ideal zum Backen oder Braten von Aufläufen, Eintöpfen oder anderen Ofengerichten. Im traditionellen Stil gehalten, hat die Ofenform ein rustikales Aussehen, ist in erdigen Farben und mit strukturierter Oberfläche und unebenen Rändern gestaltet.  Die Dicke des Materials macht sie langlebig und temperaturfest, sodass Risse und Absplitterungen ausgeschlossen werden können. Das Material ist zudem so beständig, dass es nicht auf saure oder scharfe Speisen reagiert. Die Aromen der Gerichte bleiben somit jederzeit unverändert.  Das Design der Keramikform sorgt für rustikalen Charme in der Küche und im Essbereich. Besonders in der kalten Jahreszeit eignet sich die Ofenform außerdem ideal zum Servieren warmer und herzhafter Speisen.  Für die Reinigung der rustikalen Servierform empfiehlt es sich, sie nach vollständigem Abkühlen mit warmem Seifenwasser zu waschen. Sie sollte vor der Lagerung gründlich getrocknet werden, um zu verhindern, dass Feuchtigkeit im Inneren eingeschlossen wird.  Eine rustikale Auflaufform aus Keramik ist ein praktisches und ästhetisch ansprechendes Kochgeschirr, das jeder Küche einen Hauch von Wärme und Charakter verleiht. Die robuste Machart und das klassische Design machen sie zum Must-have der Küchenausstattung für Hobbyköche und Köche gleichermaßen.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A rustic ceramic oven casserole is a cooking dish made of ceramic that is designed to be used in the oven for baking or roasting casseroles, stews, or other dishes. It has a traditional and rustic look, often featuring earthy colors, textured surfaces, and uneven edges.  The ceramic material is thick and durable, allowing it to withstand high temperatures in the oven without cracking or chipping. It is also non-reactive, meaning it won't interact with acidic or spicy foods, ensuring that the flavors of the dish remain intact.  The rustic design of the ceramic oven casserole adds a touch of warmth and charm to the kitchen and dining area. It is perfect for serving hot and hearty meals, particularly during colder months.  To clean a rustic ceramic oven casserole, it is recommended to let it cool down after use before washing it with warm, soapy water. It should be dried thoroughly before storing to prevent any moisture from being trapped inside.  Overall, a rustic ceramic oven casserole is a practical and aesthetically pleasing cooking dish that adds a touch of warmth and character to any kitchen. Its sturdy construction and classic design make it a staple for home cooks and chefs alike.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A rustic ceramic oven casserole is a cooking dish made of ceramic that is designed to be used in the oven for baking or roasting casseroles, stews, or other dishes. It has a traditional and rustic look, often featuring earthy colors, textured surfaces, and uneven edges.  The ceramic material is thick and durable, allowing it to withstand high temperatures in the oven without cracking or chipping. It is also non-reactive, meaning it won't interact with acidic or spicy foods, ensuring that the flavors of the dish remain intact.  The rustic design of the ceramic oven casserole adds a touch of warmth and charm to the kitchen and dining area. It is perfect for serving hot and hearty meals, particularly during colder months.  To clean a rustic ceramic oven casserole, it is recommended to let it cool down after use before washing it with warm, soapy water. It should be dried thoroughly before storing to prevent any moisture from being trapped inside.  Overall, a rustic ceramic oven casserole is a practical and aesthetically pleasing cooking dish that adds a touch of warmth and character to any kitchen. Its sturdy construction and classic design make it a staple for home cooks and chefs alike.",
           },
@@ -269,24 +266,20 @@ describe(`with rusticOvenCasserole preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Rustic Oven Casserole",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Rustic Oven Casserole",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Rustikale Auflaufform",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -294,24 +287,20 @@ describe(`with rusticOvenCasserole preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "rustic-oven-casserole",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "rustic-oven-casserole",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "rustikaler-ofentopf",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/rye-whiskey-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/rye-whiskey-glass.spec.ts
@@ -153,17 +153,14 @@ describe(`with ryeWhiskeyGlass preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -171,17 +168,14 @@ describe(`with ryeWhiskeyGlass preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Rye Whiskey Glass is designed specifically for enjoying whiskey or other spirits. It has a short, wide shape with a thick, heavy base that provides stability and balance.  The design of the whiskey glass is intended to enhance the drinking experience by allowing the whiskey's aroma and flavor to be fully appreciated. The wide opening of the glass allows the drinker to fully appreciate the color, clarity, and texture of the whiskey, while the heavy base helps to keep the drink from spilling or tipping over.  Overall, the Rye Whiskey Glass  is a classic and timeless type of drinking glass that is ideal for savoring the rich flavor and aroma of fine whiskey. Its simple yet elegant design makes it a popular choice for whiskey connoisseurs and casual drinkers alike.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Rye Whiskey Glass is designed specifically for enjoying whiskey or other spirits. It has a short, wide shape with a thick, heavy base that provides stability and balance.  The design of the whiskey glass is intended to enhance the drinking experience by allowing the whiskey's aroma and flavor to be fully appreciated. The wide opening of the glass allows the drinker to fully appreciate the color, clarity, and texture of the whiskey, while the heavy base helps to keep the drink from spilling or tipping over.  Overall, the Rye Whiskey Glass  is a classic and timeless type of drinking glass that is ideal for savoring the rich flavor and aroma of fine whiskey. Its simple yet elegant design makes it a popular choice for whiskey connoisseurs and casual drinkers alike.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das Rye-Whiskyglas wurde speziell für den Genuss von Whisky und anderen Spirituosen entwickelt. Es hat eine breite Form mit einer dickglasigen, schweren Basis, die für Stabilität und Gleichgewicht sorgt.  Das Design des Whiskyglases ist auf ein verbessertes Trinkerlebnis abgestimmt, bei dem die Aromen der Geschmack des Whiskys im Mittelpunkt stehen. Die breite Öffnung des Glases ermöglicht es dem Genießer, die Farbe, Klarheit und Textur des Whiskys voll und ganz wahrzunehmen, während der schwere Boden für Stabilität beim Abstellen sorgt.  Insgesamt ist das Rye-Whiskyglas ein klassisches und zeitloses Trinkglas, das sich ideal eignet, um den reichen Geschmack und das Aroma von feinem Whisky zu genießen. Sein schlichtes, aber elegantes Design macht es zu einer beliebten Wahl für Whiskykenner und Gelegenheitsgenießer gleichermaßen.",
           },
@@ -274,24 +268,20 @@ describe(`with ryeWhiskeyGlass preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Rye Whiskey Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Rye Whiskey Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Rye-Whiskyglas",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -299,24 +289,20 @@ describe(`with ryeWhiskeyGlass preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "rye-whiskey-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "rye-whiskey-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "roggen-whisky-glas",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/sally-armchair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/sally-armchair.spec.ts
@@ -188,17 +188,14 @@ describe(`with sallyArmchair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -206,17 +203,14 @@ describe(`with sallyArmchair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A tufted armchair with wooden legs is an elegant and comfortable piece of furniture. The chair features a deep seat and a high backrest, which are both padded and upholstered with soft and plush material. The tufted design creates a sophisticated and timeless look, while the wooden legs adding a touch of softness and warmth. The legs are thin and tapered, giving the chair a sleek and modern appearance. The armrests are curved and plush, providing both comfort and support for the arms. Overall, a tufted armchair with brass legs is a stylish and comfortable addition to any living space or lounge area.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A tufted armchair with wooden legs is an elegant and comfortable piece of furniture. The chair features a deep seat and a high backrest, which are both padded and upholstered with soft and plush material. The tufted design creates a sophisticated and timeless look, while the wooden legs adding a touch of softness and warmth. The legs are thin and tapered, giving the chair a sleek and modern appearance. The armrests are curved and plush, providing both comfort and support for the arms. Overall, a tufted armchair with brass legs is a stylish and comfortable addition to any living space or lounge area.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser getuftete Sessel mit Holzbeinen ist ein elegantes und bequemes Sitzmöbel. Der Lounge-Sessel verfügt über eine tiefe gepolsterte Sitzfläche mit hoher Rückenlehne, die beide mit weichem Plüschmaterial bezogen sind. Das getuftete Design sorgt für einen raffinierten und dennoch zeitlosen Look, der von der Wärme der abgerundet wird. Die Beine des Lounge-Möbels sind schmal und verjüngt, was dem Stuhl ein leichtes und modernes Aussehen verleiht. Die Armlehnen sind gebogen und weich und bieten sowohl Komfort als auch Halt für die Arme. Ein getufteter Sessel mit Holzbeinen ist eine stilvolle und bequeme Ergänzung für jeden Wohn- oder Lounge-Bereich.",
           },
@@ -321,24 +315,20 @@ describe(`with sallyArmchair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sally Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Sally Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Sessel >Sally<",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -346,24 +336,20 @@ describe(`with sallyArmchair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sally-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "sally-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "sally-sessel",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/sand-tea-cup.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/sand-tea-cup.spec.ts
@@ -171,17 +171,14 @@ describe(`with sandTeaCup preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -189,17 +186,14 @@ describe(`with sandTeaCup preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Sand Tea Cup is a type of drinking vessel that is designed to hold and serve tea and/or coffee. It has a cylindrical or slightly tapered shape, with a capacity of around 8 to 16 ounces, and is a light brownish color.  The mug is made of ceramic. The body of the mug is smooth-sided, with a wide opening that makes it easy to pour and drink coffee or tea.  The handle of the mug is designed to be easy to grip, with a comfortable shape and a size that fits most hands. The bottom of the mug is typically flat, with a stable base that helps to prevent tipping and spilling.  The Sand Tea Cup is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, this mug is a practical and functional type of drinking vessel that is ideal for enjoying a hot drink at home or at work. Its neutral color and simple design make it a popular choice for coffee lovers who prefer a classic and understated look.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Sand Tea Cup is a type of drinking vessel that is designed to hold and serve tea and/or coffee. It has a cylindrical or slightly tapered shape, with a capacity of around 8 to 16 ounces, and is a light brownish color.  The mug is made of ceramic. The body of the mug is smooth-sided, with a wide opening that makes it easy to pour and drink coffee or tea.  The handle of the mug is designed to be easy to grip, with a comfortable shape and a size that fits most hands. The bottom of the mug is typically flat, with a stable base that helps to prevent tipping and spilling.  The Sand Tea Cup is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, this mug is a practical and functional type of drinking vessel that is ideal for enjoying a hot drink at home or at work. Its neutral color and simple design make it a popular choice for coffee lovers who prefer a classic and understated look.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Die sandfarbene Tasse ist mit ihrer zylindrischen oder leicht konischen Form und einem Fassungsvermögen von etwa 8 bis 16 Unzen das ideale Trinkgefäß für jeden Tee- oder Kaffeeliebhaber.  Der Keramikbecher hat glatte Seiten und eine breite Öffnung, die das Eingießen und den Genuss von Kaffee oder Tee erleichtern.  Der Henkel der Tasse ist so konzipiert, dass er für jede Handgröße angenehm zu greifen ist und bequem in der Hand liegt. Der Boden des Henkeltasse ist flach und stabil, um ein Umkippen und Verschütten zu verhindern.  Die hellbraune Teetasse ist leicht zu reinigen und zu pflegen. Sie kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Die Tasse ist ein praktisches und funktionelles Trinkgefäß, das sich ideal für den Genuss von Heißgetränken Zuhause oder auf der Arbeit eignet. Die neutrale Farbe und das schlichte Design machen sie zu einer beliebten Wahl für alle Tee- und Kaffeeliebhaber, die einen klassischen und minimalistischen Look bevorzugen.",
           },
@@ -296,24 +290,20 @@ describe(`with sandTeaCup preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sand Tea Cup",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Sand Tea Cup",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Sandfarbene Tasse",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -321,24 +311,20 @@ describe(`with sandTeaCup preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sand-tea-cup",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "sand-tea-cup",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "sand-teetasse",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/serenity-queen-bed.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/serenity-queen-bed.spec.ts
@@ -172,17 +172,14 @@ describe(`with serenityQueenBed preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "beds",
             "typeId": "category",
           },
@@ -190,17 +187,14 @@ describe(`with serenityQueenBed preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A queen bed with an industrial pillow headboard has a unique and edgy look. The headboard is covered in a sturdy beige canvas. The headboard includes leather straps that give it an industrial look with exposed screws and bolts. The frame is also covered in the same canvas as the headboard. The bed has a simple, minimalist design with a wood frame and straight lines to complement the bold statement of the headboard. Overall, this type of bed would be perfect for someone who wants to add a touch of industrial style to their bedroom décor.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A queen bed with an industrial pillow headboard has a unique and edgy look. The headboard is covered in a sturdy beige canvas. The headboard includes leather straps that give it an industrial look with exposed screws and bolts. The frame is also covered in the same canvas as the headboard. The bed has a simple, minimalist design with a wood frame and straight lines to complement the bold statement of the headboard. Overall, this type of bed would be perfect for someone who wants to add a touch of industrial style to their bedroom décor.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das Queensize-Bett mit gepolstertem Kopfteil im industriellen Look hat ein einzigartiges und kantigen Design. Das Kopfteil ist mit einem robusten beigefarbenen Stoff bezogen und ist mit Lederriemen versehen, die ihm zusammen mit den freiliegenden Schrauben ein industrielles Aussehen verleihen. Der Rahmen ist mit dem gleichen Stoff wie das Kopfteil bespannt. Das französische Bett hat ein schlichtes, minimalistisches Design unterstützt durch den Holzrahmen und den geraden Linien, die das Statement des Kopfteils abrunden. Das Bett eignet sich ideal für all diejenigen, die ihrem Schlafzimmerdekor einen Hauch von industriellem Charme verleihen möchten.",
           },
@@ -297,24 +291,20 @@ describe(`with serenityQueenBed preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Serenity Queen Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Serenity Queen Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Queensize-Bett >Serenity<",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -322,24 +312,20 @@ describe(`with serenityQueenBed preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "serenity-queen-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "serenity-queen-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "gelassenheit-queen-bett",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/silky-pillow-cover.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/silky-pillow-cover.spec.ts
@@ -168,12 +168,10 @@ describe(`with silkyPillowCover preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bedding",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -181,17 +179,14 @@ describe(`with silkyPillowCover preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A silk pillowcase is a luxurious and soft pillow cover made from natural silk fibers. Silk is a natural protein fiber that is produced by certain insect larvae, including the silkworm. The fibers are known for their softness, smoothness, and natural shine, giving silk pillowcases a luxurious and elegant look and feel.  Silk pillowcases are known for their many benefits for the skin and hair. The smooth texture of silk helps reduce friction and irritation on the skin, reducing the risk of wrinkles and fine lines. It also helps prevent hair breakage and frizz, leaving hair looking smoother and more manageable.  Silk pillowcases require some special care, as they are delicate and can easily be damaged by harsh detergents or rough handling. They should be washed by hand or in a gentle cycle with mild detergent, and dried flat or hung to dry.  Overall, a silk pillowcase is a luxurious and elegant choice for any bedroom. Its many benefits for the skin and hair, as well as its soft and smooth texture, make it a popular choice among those looking for a comfortable and indulgent sleeping experience.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A silk pillowcase is a luxurious and soft pillow cover made from natural silk fibers. Silk is a natural protein fiber that is produced by certain insect larvae, including the silkworm. The fibers are known for their softness, smoothness, and natural shine, giving silk pillowcases a luxurious and elegant look and feel.  Silk pillowcases are known for their many benefits for the skin and hair. The smooth texture of silk helps reduce friction and irritation on the skin, reducing the risk of wrinkles and fine lines. It also helps prevent hair breakage and frizz, leaving hair looking smoother and more manageable.  Silk pillowcases require some special care, as they are delicate and can easily be damaged by harsh detergents or rough handling. They should be washed by hand or in a gentle cycle with mild detergent, and dried flat or hung to dry.  Overall, a silk pillowcase is a luxurious and elegant choice for any bedroom. Its many benefits for the skin and hair, as well as its soft and smooth texture, make it a popular choice among those looking for a comfortable and indulgent sleeping experience.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Der Seidenbezug ist ein luxuriöser und weicher Kissenbezug aus natürlichen Seidenfasern. Seide ist eine natürliche Proteinfaser, die von bestimmten Insektenlarven, einschließlich der Seidenraupe, produziert wird. Die Fasern sind für ihre Weichheit, Geschmeidigkeit und ihren natürlichen Glanz bekannt und verleihen Seidenkissenbezügen ihr luxuriöses und elegantes Aussehen und Gefühl.  Seidenkissenbezüge sind bekannt für die vielen Vorteile für Haut und Haar. Die glatte Textur von Seide trägt dazu bei, Reibung und Irritationen auf der Haut zu reduzieren und das Risiko von Falten und feinen Linien zu verringern. Sie hilft auch dabei, Haarbruch und Frizz zu verhindern, wodurch das Haar glatter und geschmeidiger aussieht.  Kissenbezüge aus Seide erfordern besondere Pflege, da sie empfindlich sind und leicht durch scharfe Reinigungsmittel oder grobe Behandlung beschädigt werden können. Sie sollten von Hand oder im Schonwaschgang mit Feinwaschmittel gewaschen und liegend getrocknet oder zum Trocknen aufgehängt werden.  Ein Kissenbezug aus Seide ist eine luxuriöse und elegante Wahl für jedes Schlafzimmer. Seine vielen Vorteile für Haut und Haar sowie seine weiche und glatte Textur machen es zu einer beliebten Wahl für diejenigen, die ein komfortables und verwöhnendes Schlaferlebnis suchen.",
           },
@@ -288,24 +283,20 @@ describe(`with silkyPillowCover preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Silky Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Silky Pillow Cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Kissenbezug aus Seide",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -313,24 +304,20 @@ describe(`with silkyPillowCover preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "silky-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "silky-pillow-cover",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "seidige-kissenhlle",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/sipper-coffee-mug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/sipper-coffee-mug.spec.ts
@@ -172,17 +172,14 @@ describe(`with sipperCoffeeMug preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -190,17 +187,14 @@ describe(`with sipperCoffeeMug preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Sipper Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Sipper Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Sipper Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Sipper Coffee Mug is made from ceramic. The design of the mug is intended to make it easy to hold and drink from, with a handle on one side for comfortable grip.  The mug is plain, but its basic design is generally simple and functional. The body of the mug is often smooth-sided, with a wide opening that makes it easy to pour and drink coffee.  The Sipper Coffee Mug is easy to clean and maintain. It can be washed by hand or in a dishwasher, and should be dried thoroughly to prevent water spots or residue from forming.  Overall, the Sipper Coffee Mug is a practical and functional type of drinking vessel that is ideal for enjoying a cup of coffee at home or at work. Its basic design and ease of use make it a popular choice for coffee lovers of all types.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Die Sipper-Tasse besteht aus Keramik und besticht durch ihr schlichtes Design mit seitlichem Henkel, der ein bequemes Halten und Trinken ermöglicht.  Das grundlegende Design ist minimalistisch und funktional. Der Körper des Bechers ist glatt abgerundet und hat eine breite Trinköffnung, die das Eingießen und Trinken von Heißgetränken erleichtert.  Der Sipper-Kaffeebecher ist leicht zu reinigen und zu pflegen. Er kann von Hand oder in der Spülmaschine gewaschen werden und sollte gründlich getrocknet werden, um Wasserflecken oder Rückstände zu vermeiden.  Die Sipper-Kaffeetasse ein praktisches und funktionelles Trinkgefäß, das sich ideal für den Tee- oder Kaffeegenuss zu Hause oder auf der Arbeit eignet. Ihr schlichtes Design und die benutzerfreundliche Handhabung machen sie zu einer beliebten Wahl für Kaffeeliebhaber aller Art.",
           },
@@ -297,24 +291,20 @@ describe(`with sipperCoffeeMug preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sipper Coffee Mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Sipper Coffee Mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Sipper-Kaffeetasse",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -322,24 +312,20 @@ describe(`with sipperCoffeeMug preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sipper-coffee-mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "sipper-coffee-mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "sipper-kaffeetasse",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/slate-armchair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/slate-armchair.spec.ts
@@ -169,17 +169,14 @@ describe(`with slateArmchair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -187,17 +184,14 @@ describe(`with slateArmchair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das minimalistische Sitzmöbel mit Ottomane besticht durch sein schlankes und schlichtes Design, bei dem klare Linien und Funktionalität im Vordergrund stehen. Die Ottomane ist passend zu dem Lounge-Möbel designt und bietet erweiterten Sitzkomfort. Das Polstermöbel ist mit seinen neutralen Farben und schlichten Mustern minimalistisch gehalten. Das Design ist von der modernen Ästhetik inspiriert und legt seinen Fokus auf Schlichtheit und Funktionalität. Das Ergebnis ist ein bequemer und stilvoller Sessel, der sich problemlos in eine Vielzahl von Einrichtungsstilen einfügt.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A minimalist chair with ottoman is a sleek and simple design that emphasizes clean lines and functionality. The ottoman is a matching piece, providing a place for the user to prop up their feet and relax. The upholstery is minimal, with neutral colors and simple patterns. The design is inspired by mid-century modern aesthetics, with a focus on simplicity and functionality. The result is a comfortable and stylish chair that fits seamlessly into a variety of interior design styles.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A minimalist chair with ottoman is a sleek and simple design that emphasizes clean lines and functionality. The ottoman is a matching piece, providing a place for the user to prop up their feet and relax. The upholstery is minimal, with neutral colors and simple patterns. The design is inspired by mid-century modern aesthetics, with a focus on simplicity and functionality. The result is a comfortable and stylish chair that fits seamlessly into a variety of interior design styles.",
           },
@@ -298,24 +292,20 @@ describe(`with slateArmchair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Slate Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Slate Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Sessel aus Schiefer",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -323,24 +313,20 @@ describe(`with slateArmchair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "slate-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "slate-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "sessel-aus-schiefer",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/small-wooden-bowl.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/small-wooden-bowl.spec.ts
@@ -188,27 +188,22 @@ describe(`with smallWoodenBowl preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bowls",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serving-platters",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serveware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
@@ -216,17 +211,14 @@ describe(`with smallWoodenBowl preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This wooden bowl is designed to hold small servings of food or other small items. It is ideal for serving small portions of food, such as nuts, candies, dips, or sauces.  It can also be used as a decorative item, as its natural material and unique texture add warmth and character to any setting. It can be used as a standalone piece or as part of a larger set, and can be styled with other wooden pieces to create a cohesive look.  The bowl is easy to clean and maintain, and can be washed with soap and water or wiped clean with a damp cloth. It should be allowed to dry thoroughly before use to prevent warping or cracking.  Overall, a small round wooden bowl is a versatile and functional dish that adds a touch of natural warmth and character to any setting. Its simplicity and durability make it a staple in many kitchens and dining rooms.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This wooden bowl is designed to hold small servings of food or other small items. It is ideal for serving small portions of food, such as nuts, candies, dips, or sauces.  It can also be used as a decorative item, as its natural material and unique texture add warmth and character to any setting. It can be used as a standalone piece or as part of a larger set, and can be styled with other wooden pieces to create a cohesive look.  The bowl is easy to clean and maintain, and can be washed with soap and water or wiped clean with a damp cloth. It should be allowed to dry thoroughly before use to prevent warping or cracking.  Overall, a small round wooden bowl is a versatile and functional dish that adds a touch of natural warmth and character to any setting. Its simplicity and durability make it a staple in many kitchens and dining rooms.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Diese Holzschale ist so konzipiert, dass sie kleinere Snacks oder andere Gegenstände fassen kann. Sie eignet sich ideal zum Servieren kleiner Portionen wie Nüsse, Bonbons, Dips oder Saucen.  Sie kann aber auch als Dekorationsartikel verwendet werden, da ihr natürliches Material und die einzigartige Textur jeder Umgebung Wärme und Charakter verleihen. Die Schale kann eigenständig oder als Teil eines größeren Sets ihre Wirkung entfalten. Sie kann zudem mit anderen Holz-Accessoires gestylt werden, um einen zusammenhängenden Look zu schaffen.  Die Schale ist leicht zu reinigen und zu pflegen und kann mit Wasser und Seife gewaschen oder mit einem feuchten Tuch abgewischt werden. Sie sollte vor Gebrauch gründlich trocknen, um ein Verziehen oder Reißen zu vermeiden.  Eine kleine runde Holzschale ist ein vielseitiges und funktionales Geschirr- oder Dekorations-Element, das jeder Umgebung einen Hauch von natürlicher Wärme und Charakter verleiht. Die Schlichtheit und Haltbarkeit machen sie zur perfekten Ergänzung in vielen Küchen und Esszimmern.",
           },
@@ -339,24 +331,20 @@ describe(`with smallWoodenBowl preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Small Wooden Bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Small Wooden Bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Kleine Holzschale",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -364,24 +352,20 @@ describe(`with smallWoodenBowl preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "small-wooden-bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "small-wooden-bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "kleine-holzschale",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/sparkle-champagne-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/sparkle-champagne-glass.spec.ts
@@ -146,17 +146,14 @@ describe(`with sparkleChampagneGlass preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -164,17 +161,14 @@ describe(`with sparkleChampagneGlass preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein konisches Champagnerglas, auch als Champagnerflöte bekannt, ist eine Art Stielglas, das speziell entwickelt wurde, um das Trinkerlebnis beim Genießen von Champagner oder Sekt zu steigern. Das Glas hat einen hohen, schmalen Kelch, der sich nach oben hin verjüngt, sodass das Aufsteigen die Bläschen an die Oberfläche des Getränks gut beobachtet werden kann.  Der hohe, schlanke Stiel des Glases schafft genug Raum zwischen Hand und Getränk und verhindert so, dass der Champagner durch Körperwärme die Temperatur ändert. Der Fuß des Glases ist typischerweise breit und flach und sorgt für Stabilität und Balance.  Das Design des konisch zulaufenden Sektglases soll das Aroma und den Geschmack des Getränks verstärken. Der schmale Kelch konzentriert die Bläschen und das Aroma des Champagners und lenkt ihn zur Nase hin. Dies steigert das Aroma und den Geschmack des Champagners.  Das konische Sektglas wird typischerweise zum Servieren von Sekt oder anderen Schaumweinen verwendet, kann aber auch für andere kohlensäurehaltige Getränke oder Cocktails verwendet werden. Es ist leicht zu reinigen und zu pflegen und kann von Hand oder in der Spülmaschine gewaschen werden.  Das konische Champagnerglas ein stilvolles und elegantes Stielglas, das speziell entwickelt wurde, um dem Genuss von Champagner oder Sekt zu steigern. Sein einzigartiges Design und die Liebe zum Detail machen es zu einer beliebten Wahl für besondere Anlässe und Feiern.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A tapered champagne glass, also known as a champagne flute, is a type of stemware that is specifically designed to enhance the experience of drinking champagne or sparkling wine. The glass has a tall, narrow bowl that tapers towards the top, allowing the drinker to see the bubbles rising to the surface of the drink.  The tall, slender stem of the glass helps to keep the drinker's hand away from the bowl, preventing the champagne from being warmed by body heat. The base of the glass is typically wide and flat, providing stability and balance.  The design of the tapered champagne glass is intended to enhance the aroma and flavor of the drink. The narrow bowl concentrates the bubbles and the aroma of the champagne, directing it towards the drinker's nose. This allows the drinker to fully appreciate the aroma and flavor of the champagne.  The tapered champagne glass is typically used for serving champagne or other sparkling wines, but may also be used for other carbonated drinks or cocktails. It is easy to clean and maintain, and can be washed by hand or in a dishwasher.  Overall, the tapered champagne glass is a stylish and elegant piece of stemware that is specifically designed to enhance the experience of drinking champagne or sparkling wine. Its unique design and attention to detail make it a popular choice for special occasions and celebrations.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A tapered champagne glass, also known as a champagne flute, is a type of stemware that is specifically designed to enhance the experience of drinking champagne or sparkling wine. The glass has a tall, narrow bowl that tapers towards the top, allowing the drinker to see the bubbles rising to the surface of the drink.  The tall, slender stem of the glass helps to keep the drinker's hand away from the bowl, preventing the champagne from being warmed by body heat. The base of the glass is typically wide and flat, providing stability and balance.  The design of the tapered champagne glass is intended to enhance the aroma and flavor of the drink. The narrow bowl concentrates the bubbles and the aroma of the champagne, directing it towards the drinker's nose. This allows the drinker to fully appreciate the aroma and flavor of the champagne.  The tapered champagne glass is typically used for serving champagne or other sparkling wines, but may also be used for other carbonated drinks or cocktails. It is easy to clean and maintain, and can be washed by hand or in a dishwasher.  Overall, the tapered champagne glass is a stylish and elegant piece of stemware that is specifically designed to enhance the experience of drinking champagne or sparkling wine. Its unique design and attention to detail make it a popular choice for special occasions and celebrations.",
           },
@@ -259,24 +253,20 @@ describe(`with sparkleChampagneGlass preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sparkle Champagne Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Sparkle Champagne Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Champagnerglas",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -284,24 +274,20 @@ describe(`with sparkleChampagneGlass preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sparkle-champagne-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "sparkle-champagne-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "funkelndes-champagnerglas",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/square-bamboo-coaster.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/square-bamboo-coaster.spec.ts
@@ -160,17 +160,14 @@ describe(`with squareBambooCoaster preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-accessories",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
@@ -178,17 +175,14 @@ describe(`with squareBambooCoaster preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Der quadratische Untersetzer aus Bambus besteht aus einer kleinen Matte mit großer Wirkung, da sie Oberflächen vor Wasserflecken oder Beschädigungen durch Trinkgläser oder Tassen schützt. Er besteht aus natürlichem Bambusmaterial und hat eine glatte Oberfläche. Der Untersetzer hat eine quadratische Form mit leicht abgerundeten Kanten und misst etwa 3,5 Zoll x 3,5 Zoll. Seine leichte und strapazierfähige Beschaffenheit macht ihn zu einer beliebten Wahl für legere und formelle Anlässe gleichermaßen.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A square bamboo coaster is a small mat used to protect surfaces from water stains or damage caused by drinking glasses or mugs. It is made of natural bamboo material and has a smooth surface. The coaster is square in shape with slightly rounded edges, and measures approximately 3.5 inches by 3.5 inches. Its lightweight and durable nature make it a popular choice for casual and formal occasions alike.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A square bamboo coaster is a small mat used to protect surfaces from water stains or damage caused by drinking glasses or mugs. It is made of natural bamboo material and has a smooth surface. The coaster is square in shape with slightly rounded edges, and measures approximately 3.5 inches by 3.5 inches. Its lightweight and durable nature make it a popular choice for casual and formal occasions alike.",
           },
@@ -277,24 +271,20 @@ describe(`with squareBambooCoaster preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Square Bamboo Coaster",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Square Bamboo Coaster",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Quadratischer Untersetzer aus Bambus",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -302,24 +292,20 @@ describe(`with squareBambooCoaster preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "square-bamboo-coaster",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "square-bamboo-coaster",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "quadratischer-untersetzer-aus-bambus",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/steel-hip-flask.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/steel-hip-flask.spec.ts
@@ -145,17 +145,14 @@ describe(`with steelHipFlask preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bar-accessories",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -163,17 +160,14 @@ describe(`with steelHipFlask preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A steel hip flask is a small, curved, and flat container made of stainless steel. It is designed to hold and transport a small amount of alcoholic beverage, usually around 6-10 ounces. The flask has a hinged or screw-top lid that allows for easy opening and closing, as well as a small opening for pouring or drinking the contents. The exterior of the flask is smooth. Hip flasks are often carried in a pocket or purse for discreet consumption of alcohol while on-the-go.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Der Flachmann aus Stahl ist ein kleiner, gebogener und flacher Behälter aus Edelstahl. Er ist so konzipiert, dass er eine kleine Menge alkoholischer Getränke aufnehmen und transportieren kann, normalerweise umfasst er etwa 6 bis 10 Unzen. Der Flachmann hat einen Scharnier- oder Schraubdeckel, der ein einfaches Öffnen und Schließen ermöglicht, sowie eine kleine Öffnung zum Ausgießen oder Trinken des Inhalts. Die Außenseite des Trinkbehälters ist glatt. Flachmänner werden oft in einer Tasche oder Handtasche getragen und eignen sich ideal für den diskreten Konsum von Alkohol unterwegs.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A steel hip flask is a small, curved, and flat container made of stainless steel. It is designed to hold and transport a small amount of alcoholic beverage, usually around 6-10 ounces. The flask has a hinged or screw-top lid that allows for easy opening and closing, as well as a small opening for pouring or drinking the contents. The exterior of the flask is smooth. Hip flasks are often carried in a pocket or purse for discreet consumption of alcohol while on-the-go.",
           },
@@ -258,24 +252,20 @@ describe(`with steelHipFlask preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Steel Hip Flask",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Steel Hip Flask",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Flachmann aus Stahl",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -283,24 +273,20 @@ describe(`with steelHipFlask preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "steel-hip-flask",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "steel-hip-flask",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "flachmann-aus-stahl",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/stone-serving-tray.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/stone-serving-tray.spec.ts
@@ -173,32 +173,26 @@ describe(`with stoneServingTray preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serveware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "cheese-trays",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serving-platters",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bakeware",
             "typeId": "category",
           },
@@ -206,17 +200,14 @@ describe(`with stoneServingTray preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Stone Serving Tray is made of natural stone that is designed to serve and display food. The tray is made of sturdy slate.  The weight and texture of the stone material provide stability and a sense of luxury to the tray, making it ideal for serving a variety of items, including cheese, fruits or bread. The tray's natural stone material also makes it an excellent choice for use in outdoor settings, such as a picnic or barbecue.  A stone serving tray is easy to clean and maintain. It can be washed with soap and water, and should be dried thoroughly after use to prevent any moisture from being trapped inside.  Overall, a stone serving tray is a functional and aesthetically pleasing item that adds a touch of natural elegance to any setting. Its durability, stability and unique design make it a popular choice for serving and displaying food and beverages.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieses Serviertablett besteht aus Naturstein und wurde zum Servieren und Präsentieren von Speisen designt. Das Tablett besteht aus stabilem Schiefer.  Das Gewicht und die Textur des Steinmaterials verleihen dem Tablett Stabilität und ein Gefühl von Luxus. Sie machen es darüber hinaus zum idealen Utensil zum Servieren einer Vielzahl von Speisen, wie zum Beispiel Käse, Obst oder Brot. Das Natursteinmaterial des Tabletts macht es zudem zu einer ausgezeichneten Wahl für den Einsatz im Freien, z. B. bei einem Picknick oder beim Grillen.  Ein Serviertablett aus Stein ist leicht zu reinigen und zu pflegen. Es kann mit Wasser und Seife gewaschen werden und sollte nach Gebrauch gründlich getrocknet werden, um das Eindringen von Feuchtigkeit ins Innere zu vermeiden.  Ein Serviertablett aus Stein ist ein funktionales und ästhetisch ansprechendes Element, das jeder Umgebung einen Hauch von natürlicher Eleganz verleiht. Seine Haltbarkeit, Stabilität und sein einzigartiges Design machen es zu einer beliebten Wahl zum Servieren und Präsentieren von Speisen und Getränken.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Stone Serving Tray is made of natural stone that is designed to serve and display food. The tray is made of sturdy slate.  The weight and texture of the stone material provide stability and a sense of luxury to the tray, making it ideal for serving a variety of items, including cheese, fruits or bread. The tray's natural stone material also makes it an excellent choice for use in outdoor settings, such as a picnic or barbecue.  A stone serving tray is easy to clean and maintain. It can be washed with soap and water, and should be dried thoroughly after use to prevent any moisture from being trapped inside.  Overall, a stone serving tray is a functional and aesthetically pleasing item that adds a touch of natural elegance to any setting. Its durability, stability and unique design make it a popular choice for serving and displaying food and beverages.",
           },
@@ -309,24 +300,20 @@ describe(`with stoneServingTray preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Stone Serving Tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Stone Serving Tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Serviertablett aus Stein",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -334,24 +321,20 @@ describe(`with stoneServingTray preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "stone-serving-tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "stone-serving-tray",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "serviertablett-aus-stein",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/stout-beer-glass.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/stout-beer-glass.spec.ts
@@ -145,17 +145,14 @@ describe(`with stoutBeerGlass preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -163,17 +160,14 @@ describe(`with stoutBeerGlass preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A stout beer glass, also known as a "pint glass," is a type of drinking glass that is designed specifically for serving and enjoying stout beers. It has a short, wide shape with a thick, heavy base that provides stability and balance.  The design of the stout beer glass is intended to enhance the drinking experience by allowing the full range of flavors and aromas of the beer to be appreciated. The wide opening of the glass allows the drinker to fully appreciate the color and clarity of the beer, while the heavy base helps to keep the beer from spilling or tipping over.  Overall, a stout beer glass is a classic and timeless type of drinking glass that is ideal for savoring the rich flavor and aroma of fine stout beers. Its simple yet elegant design makes it a popular choice for beer lovers and casual drinkers alike.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Ein Stout-Bierglas, auch als "Pintglas" bekannt, ist ein Trinkglas, das speziell zum Servieren und Genießen von Starkbieren entwickelt wurde. Es hat eine kurze, breite Form mit einem dicken, schweren Boden, der für Stabilität und Gleichgewicht sorgt.  Das Design des Stout-Bierglases unterstützt das Trinkerlebnis, indem es die volle Geschmacks- und Aromenvielfalt des Bieres zur Geltung bringt. Die breite Öffnung des Glases lässt die Farbe und Klarheit des Bieres erkennen, während der schwere Boden dazu beiträgt, dass das Bier nicht verschüttet oder umkippt.  Ein Pintglas ist ein klassisches und zeitloses Trinkglas, das sich ideal eignet, um den reichen Geschmack und das Aroma feiner Stout-Biere zu genießen. Sein einfaches aber elegantes Design macht es zu einer beliebten Wahl für Bierliebhaber und Gelegenheitsgeniesser gleichermaßen.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A stout beer glass, also known as a "pint glass," is a type of drinking glass that is designed specifically for serving and enjoying stout beers. It has a short, wide shape with a thick, heavy base that provides stability and balance.  The design of the stout beer glass is intended to enhance the drinking experience by allowing the full range of flavors and aromas of the beer to be appreciated. The wide opening of the glass allows the drinker to fully appreciate the color and clarity of the beer, while the heavy base helps to keep the beer from spilling or tipping over.  Overall, a stout beer glass is a classic and timeless type of drinking glass that is ideal for savoring the rich flavor and aroma of fine stout beers. Its simple yet elegant design makes it a popular choice for beer lovers and casual drinkers alike.",
           },
@@ -258,24 +252,20 @@ describe(`with stoutBeerGlass preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Stout Beer Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Stout Beer Glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Stout-Bierglas",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -283,24 +273,20 @@ describe(`with stoutBeerGlass preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "stout-beer-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "stout-beer-glass",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "starkes-bierglas",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/sunnai-glass-bowl.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/sunnai-glass-bowl.spec.ts
@@ -237,22 +237,18 @@ describe(`with sunnaiGlassBowl preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bowls",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bakeware",
             "typeId": "category",
           },
@@ -260,7 +256,6 @@ describe(`with sunnaiGlassBowl preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "These glass bowls are ideal for serving a variety of foods, including salads, fruits, desserts, and snacks. They are a popular choice for formal dinner parties and special occasions, as well as for everyday use.
 
@@ -269,7 +264,6 @@ describe(`with sunnaiGlassBowl preset`, () => {
       Overall, a glass bowl used for serving food is a beautiful and practical choice for presenting and serving food. Its transparency and simplicity make it a versatile and timeless piece that can be used for a variety of occasions and settings.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "These glass bowls are ideal for serving a variety of foods, including salads, fruits, desserts, and snacks. They are a popular choice for formal dinner parties and special occasions, as well as for everyday use.
 
@@ -278,7 +272,6 @@ describe(`with sunnaiGlassBowl preset`, () => {
       Overall, a glass bowl used for serving food is a beautiful and practical choice for presenting and serving food. Its transparency and simplicity make it a versatile and timeless piece that can be used for a variety of occasions and settings.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Diese Glasschalen eignen sich ideal zum Servieren einer Vielzahl von Speisen, darunter Salate, Obst, Desserts und Snacks. Sie sind eine beliebte Wahl für formelle Dinnerpartys und besondere Anlässe sowie für den täglichen Gebrauch.
 
@@ -368,24 +361,20 @@ describe(`with sunnaiGlassBowl preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sunnai Glass Bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Sunnai Glass Bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Glasschale >Sunnai<",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "product-sets",
           "typeId": "product-type",
         },
@@ -393,24 +382,20 @@ describe(`with sunnaiGlassBowl preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sunnai-glass-bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "sunnai-glass-bowl",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "sunnai-glaskugel",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/sweet-pea-candle.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/sweet-pea-candle.spec.ts
@@ -180,17 +180,14 @@ describe(`with sweetPeaCandle preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "home-accents",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -198,17 +195,14 @@ describe(`with sweetPeaCandle preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A small sweet pea scented candle is a charming and delightful addition to any home. The candle is small in size, making it perfect for use on a tabletop or desk.  The candle is made from high-quality wax, which is infused with the sweet and delicate fragrance of sweet pea. The scent is fresh and floral, reminiscent of a blooming garden in the springtime.  The candle is presented in a glass container, which helps to protect the flame and also adds a decorative touch to the candle.   When lit, the candle will release a gentle and pleasant aroma, filling the room with the sweet and soothing fragrance of sweet pea. The scent can help to create a relaxing and calming atmosphere, making it perfect for use during a yoga practice, a bubble bath, or a cozy night in.  A sweet pea scented candle is a delightful and charming addition to any home, bringing a touch of nature and tranquility to your living space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Die kleine Kerze mit der Duftnote Schleierkraut oder Duftwicke ist eine charmante und hübsche Ergänzung für jedes Zuhause. Die Größe der Kerze macht sie zum perfekten Accessoire auf einem Tisch oder Schreibtisch.  Die Kerze besteht aus hochwertigem Wachs, das mit den süßen und zarten Noten der Duftwicke durchdrungen ist. Der Duft ist frisch und blumig und erinnert an einen blühenden Garten im Frühling.  Die Kerze wird in einem Glasbehälter präsentiert, der zum Schutz der Flamme beiträgt und der Kerze eine dekorative Note verleiht.  Wenn die Kerze angezündet wird, verströmt sie ein sanftes und angenehmes Aroma und erfüllt den Raum mit dem süßen und beruhigenden Duft von Schleierkraut. Der Duft schafft eine entspannende und beruhigende Atmosphäre und eignen sich gut für die Verwendung während einer Yogastunde, eines Schaumbads oder zur Einstimmung in einen erholsamen Schlaf.  Eine Kerze mit dem Aroma der Duftwicke ist eine hübsche und charmante Ergänzung für jedes Zuhause und bringt einen Hauch von Natur und Ruhe in jeden Wohnraum.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A small sweet pea scented candle is a charming and delightful addition to any home. The candle is small in size, making it perfect for use on a tabletop or desk.  The candle is made from high-quality wax, which is infused with the sweet and delicate fragrance of sweet pea. The scent is fresh and floral, reminiscent of a blooming garden in the springtime.  The candle is presented in a glass container, which helps to protect the flame and also adds a decorative touch to the candle.   When lit, the candle will release a gentle and pleasant aroma, filling the room with the sweet and soothing fragrance of sweet pea. The scent can help to create a relaxing and calming atmosphere, making it perfect for use during a yoga practice, a bubble bath, or a cozy night in.  A sweet pea scented candle is a delightful and charming addition to any home, bringing a touch of nature and tranquility to your living space.",
           },
@@ -317,24 +311,20 @@ describe(`with sweetPeaCandle preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Sweet Pea Candle",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Sweet Pea Candle",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Kerze Duftwicke",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -342,24 +332,20 @@ describe(`with sweetPeaCandle preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "sweat-pea-candle",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "sweat-pea-candle",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "kerze-der-sen-erbse",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/tan-queen-bed.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/tan-queen-bed.spec.ts
@@ -188,17 +188,14 @@ describe(`with tanQueenBed preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "beds",
             "typeId": "category",
           },
@@ -206,17 +203,14 @@ describe(`with tanQueenBed preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A queen bed with a padded leather headboard is a stylish and sophisticated piece of furniture. The headboard is tall and wide, featuring a padded design with luxurious leather upholstery that provides a comfortable place to lean against when sitting up in bed. The leather is soft and supple, adding a touch of elegance and refinement to the bed.  The bed frame is made of sturdy wood and is finished in a complementary color to the leather headboard. The bed also has a platform base, providing a solid foundation for the mattress while also eliminating the need for a box spring.  This type of bed is often favored in contemporary or transitional design styles and can be paired with a range of bedding and decor to create a luxurious and inviting sleeping space. Overall, a queen bed with a padded leather headboard is a statement piece that adds both comfort and style to any bedroom.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das Queensize-Bett mit gepolstertem Kopfteil aus Leder ist ein stilvolles und raffiniertes Möbelstück. Das Kopfteil ist hoch und breit und bietet ein gepolstertes Design mit luxuriösem Lederbezug, das es zu einen bequemen Platz zum Anlehnen im Bett macht. Das Leder ist weich und geschmeidig und verleiht dem Bett einen Hauch von Eleganz und Raffinesse.  Das Bettgestell besteht aus stabilem Holz und ist in passender Farbe zum Lederkopfteil gehalten. Das Bett hat einen Lattenrost, der eine solide Grundlage für die Matratze bietet und dem Komfort eines Boxspringbetts gleichkommt.  Diese Art von Bett wird oft in zeitgenössischen oder Übergangsdesignstilen bevorzugt und kann mit einer Reihe von Betttextilien und Dekorationsartikeln kombiniert werden, um einen luxuriösen und einladenden Schlafbereich zu schaffen. Ein Queensize-Bett mit einem gepolsterten Kopfteil aus Leder ist ein Statement-Stück, das jedem Schlafzimmer sowohl Komfort als auch Stil verleiht.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A queen bed with a padded leather headboard is a stylish and sophisticated piece of furniture. The headboard is tall and wide, featuring a padded design with luxurious leather upholstery that provides a comfortable place to lean against when sitting up in bed. The leather is soft and supple, adding a touch of elegance and refinement to the bed.  The bed frame is made of sturdy wood and is finished in a complementary color to the leather headboard. The bed also has a platform base, providing a solid foundation for the mattress while also eliminating the need for a box spring.  This type of bed is often favored in contemporary or transitional design styles and can be paired with a range of bedding and decor to create a luxurious and inviting sleeping space. Overall, a queen bed with a padded leather headboard is a statement piece that adds both comfort and style to any bedroom.",
           },
@@ -321,24 +315,20 @@ describe(`with tanQueenBed preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Tan Queen Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Tan Queen Bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Hellbraunes Queensize-Bett",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -346,24 +336,20 @@ describe(`with tanQueenBed preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "tan-queen-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "tan-queen-bed",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "hellbraunes-queen-bett",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/teak-serving-platter.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/teak-serving-platter.spec.ts
@@ -153,22 +153,18 @@ describe(`with teakServingPlatter preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "cheese-trays",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serving-platters",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "serveware",
             "typeId": "category",
           },
@@ -176,17 +172,14 @@ describe(`with teakServingPlatter preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This wooden serving tray is a versatile and functional item that can be used in a variety of settings. The teak material used in the tray provides a warm and natural aesthetic, adding a touch of rustic charm to any setting.  Wooden serving trays are easy to clean and maintain. They can be wiped down with a damp cloth and mild detergent, and should be dried thoroughly after use to prevent any moisture from being trapped inside.  Overall, a wooden serving tray is a practical and attractive item that adds a touch of natural elegance to any setting. Its durability, versatility, and range of designs make it a popular choice for serving and displaying food, drinks, and other items.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieses Serviertablett aus Holz ist ein vielseitiger und funktionaler Artikel, der in einer Vielzahl von Umgebungen verwendet werden kann. Das für das Tablett verwendete Teakholz sorgt für eine warme und natürliche Ästhetik und verleiht jeder Umgebung einen Hauch von rustikalem Charme.  Serviertabletts aus Holz sind leicht zu reinigen und zu pflegen. Sie können mit einem feuchten Tuch und einem milden Reinigungsmittel abgewischt werden und sollten nach Gebrauch gründlich getrocknet werden, um zu verhindern, dass Feuchtigkeit im Inneren eingeschlossen wird.  Ein Serviertablett aus Holz ist ein praktisches und attraktives Element, das jedem Ambiente einen Hauch von natürlicher Eleganz verleiht. Seine Langlebigkeit und Designvielfalt machen es zu einer beliebten Wahl zum Servieren und Präsentieren von Speisen, Getränken und Gegenständen.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This wooden serving tray is a versatile and functional item that can be used in a variety of settings. The teak material used in the tray provides a warm and natural aesthetic, adding a touch of rustic charm to any setting.  Wooden serving trays are easy to clean and maintain. They can be wiped down with a damp cloth and mild detergent, and should be dried thoroughly after use to prevent any moisture from being trapped inside.  Overall, a wooden serving tray is a practical and attractive item that adds a touch of natural elegance to any setting. Its durability, versatility, and range of designs make it a popular choice for serving and displaying food, drinks, and other items.",
           },
@@ -271,24 +264,20 @@ describe(`with teakServingPlatter preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Teak Serving Platter",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Teak Serving Platter",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Servierplatte aus Teakholz",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -296,24 +285,20 @@ describe(`with teakServingPlatter preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "teak-serving-platter",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "teak-serving-platter",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "servierplatte-aus-teakholz",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/traditional-armchair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/traditional-armchair.spec.ts
@@ -197,27 +197,22 @@ describe(`with traditionalArmchair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-traditionalist",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
@@ -225,17 +220,14 @@ describe(`with traditionalArmchair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A traditional armchair with a geometric pattern has a classic design with a touch of modern flair. The chair has a wooden frame and legs. The chair has a high back, providing a comfortable place to sit and relax. The cushioning is plush, offering a soft feel to the seat and backrest. The geometric pattern adds a visual interest and texture to the overall look of the chair, providing a subtle yet eye-catching element to the decor of the room.  Overall, a traditional armchair with a geometric pattern could be a great addition to a living room, study, or bedroom, offering both comfort and style to the space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Der traditionelle Sessel mit geometrischem Muster überzeugt mit einem klassischen Design und einem Hauch von modernem Flair. Rahmen und Beine des Stuhls sind aus Holz gefertigt. Er hat eine hohe Rückenlehne, die einen bequemen Platz zum Sitzen und Entspannen bietet. Die Polsterung ist weich und bietet so Komfort im Sitz- und Rückenbereich. Das geometrische Muster verleiht dem Gesamtbild des Stuhls einen visuellen Twist. Zusammen mit seiner Textur, verleiht er dem Dekor des Raums ein subtiles und dennoch auffälliges Element.  Dieser traditionelle Sessel mit geometrischem Muster ist eine großartige Ergänzung für den Wohn-, Arbeits- oder Schlafbereich und bereichert den Raum sowohl um Komfort als auch um Stil.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A traditional armchair with a geometric pattern has a classic design with a touch of modern flair. The chair has a wooden frame and legs. The chair has a high back, providing a comfortable place to sit and relax. The cushioning is plush, offering a soft feel to the seat and backrest. The geometric pattern adds a visual interest and texture to the overall look of the chair, providing a subtle yet eye-catching element to the decor of the room.  Overall, a traditional armchair with a geometric pattern could be a great addition to a living room, study, or bedroom, offering both comfort and style to the space.",
           },
@@ -348,24 +340,20 @@ describe(`with traditionalArmchair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Traditional Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Traditional Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Traditioneller Sessel",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -373,24 +361,20 @@ describe(`with traditionalArmchair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "traditional-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "traditional-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "traditioneller-sessel",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/traditional-l-seater-sofa.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/traditional-l-seater-sofa.spec.ts
@@ -219,27 +219,22 @@ describe(`with traditionalLSeaterSofa preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "sofas",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-traditionalist",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
@@ -247,17 +242,14 @@ describe(`with traditionalLSeaterSofa preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A traditional L-shaped sofa is a comfortable and practical piece of furniture. The sofa is upholstered in a durable and high-quality fabric and features a classic and timeless design that can fit well with a variety of decor styles.  The sofa provides ample room for multiple people to sit comfortably. It also features a chaise lounge or a place to stretch out and relax. The L-shape design of the sofa maximizes seating space while also providing a comfortable and inviting space to relax and unwind.  The sofa features padded armrests and backrests, providing ample support and comfort for those who sit on it. The cushions are made of high-density foam, ensuring that they are comfortable and retain their shape over time. The sofa also comes with matching throw pillows, adding to the comfort and style of the piece.  Overall, a traditional L-shaped sofa is a comfortable and practical piece of furniture that can add both style and functionality to any living room. Its classic and timeless design, comfortable cushions, and ample seating space make it a popular choice for families and anyone who loves to entertain guests in their home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das traditionelle Ecksofa ist ein bequemes und praktisches Möbelstück. Das Sofa ist mit einem strapazierfähigen und hochwertigen Baumwollstoff bezogen und überzeugt mit einem klassischen und zeitlosen Design, das gut zu einer Vielzahl von Einrichtungsstilen passt.  Das Sofa bietet ausreichend Platz und Komfort für mehrere Personen. Es kann wie eine Chaiselongue genutzt werden und bietet einen Platz zum Ausstrecken und Entspannen. Das L-förmige Design des Sofas maximiert den Sitzplatz und bietet gleichzeitig einen komfortablen und einladenden Ort zum Entspannen und Erholen.  Das Sofa ist mit gepolsterten Armlehnen und Rückenlehnen ausgestattet, die dem Sitzenden ausreichend Halt und Komfort bieten. Die Kissen bestehen aus hochdichtem Schaumstoff, der die Form hält und das gute Sitzgefühl wahrt. Das Sofa wird darüber hinaus mit passenden Wurfkissen geliefert, die den Komfort und Stil des Sofas weiter unterstützen.  Das traditionelle L-förmiges Sofa ist ein bequemes und praktisches Möbelstück, das jedem Wohnzimmer sowohl Stil als auch Funktionalität verleiht. Sein klassisches und zeitloses Design, die bequemen Kissen und die großzügige Sitzfläche machen es zu einer beliebten Wahl für Familien und alle, die gerne Gäste in ihrem Zuhause zu empfangen.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A traditional L-shaped sofa is a comfortable and practical piece of furniture. The sofa is upholstered in a durable and high-quality fabric and features a classic and timeless design that can fit well with a variety of decor styles.  The sofa provides ample room for multiple people to sit comfortably. It also features a chaise lounge or a place to stretch out and relax. The L-shape design of the sofa maximizes seating space while also providing a comfortable and inviting space to relax and unwind.  The sofa features padded armrests and backrests, providing ample support and comfort for those who sit on it. The cushions are made of high-density foam, ensuring that they are comfortable and retain their shape over time. The sofa also comes with matching throw pillows, adding to the comfort and style of the piece.  Overall, a traditional L-shaped sofa is a comfortable and practical piece of furniture that can add both style and functionality to any living room. Its classic and timeless design, comfortable cushions, and ample seating space make it a popular choice for families and anyone who loves to entertain guests in their home.",
           },
@@ -378,24 +370,20 @@ describe(`with traditionalLSeaterSofa preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Traditional L Seater Sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Traditional L Seater Sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Traditionelles Ecksofa",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -403,24 +391,20 @@ describe(`with traditionalLSeaterSofa preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "traditional-l-seater-sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "traditional-l-seater-sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "traditionelles-l-sitzer-sofa",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/traditional-three-seater-sofa.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/traditional-three-seater-sofa.spec.ts
@@ -223,32 +223,26 @@ describe(`with traditionalThreeSeaterSofa preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "sofas",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "new-arrivals",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "the-traditionalist",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "collections",
             "typeId": "category",
           },
@@ -256,17 +250,14 @@ describe(`with traditionalThreeSeaterSofa preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A traditional three-seater sofa is a classic and elegant piece of furniture that can add a touch of sophistication to any living room or sitting area. The sofa features a sturdy wooden frame that is designed to provide durability and stability, ensuring that the sofa can withstand regular use over time.  The sofa is upholstered in a rich emerald-colored fabric, providing a vibrant and eye-catching focal point in the room. The fabric is soft and comfortable to the touch, allowing you to relax and unwind in style.  The sofa is equipped with two large cushions, which are filled with a high-quality foam material, providing excellent support and comfort for extended periods of sitting. The backrest and armrests of the sofa are filled with a soft and plush material, allowing you to sink into the sofa and relax after a long day.  The traditional three-seater sofa is a versatile piece of furniture that can complement a range of interior design styles, from classic and traditional to more modern and eclectic. It can be paired with a variety of decorative accents, such as pillows, throws, and rugs, to create a cohesive and stylish living space.  Overall, a traditional three-seater sofa in emerald fabric is a timeless and elegant piece of furniture that can provide both comfort and style to any living room or sitting area. Its classic design, high-quality materials, and practical features make it a functional and stylish choice for any home.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das traditionelle Dreisitzer-Sofa ist ein klassisches und elegantes Möbelstück, das jedem Wohnzimmer oder Sitzbereich einen Hauch von Raffinesse verleiht. Das Sofa ist mit einem robusten Holzrahmen konzipiert, der auf Langlebigkeit und Stabilität ausgelegt ist und sicherstellt, dass das Sofa einer regelmäßigen Nutzung im Laufe der Zeit standhält.  Das Sofa ist mit einem smaragdfarbenem Stoff bezogen - ein wahrer Hingucker in jedem Raum. Der Stoff fühlt sich weich und angenehm an, sodass dem stilvollen Entspannen nichts mehr im Wege steht. Das Sofa ist mit zwei großen Kissen ausgestattet, die mit hochwertigem Schaumstoffmaterial gefüllt sind und bei längerem Sitzen hervorragenden Halt und Komfort bieten. Die Rückenlehne und die Armlehnen des Sofas sind mit einem weichen und plüschigen Material gefüllt, sodass Sie nach einem langen Tag in das Sofa sinken und sich entspannen können.  Das traditionelle Dreisitzer-Sofa ist ein vielseitiges Möbelstück, das eine Reihe von Einrichtungsstilen ergänzen kann, von klassisch und traditionell bis hin zu modern. Es kann mit einer Vielzahl von dekorativen Akzenten wie Kissen, Überwürfen und Teppichen kombiniert werden, um einen zusammenhängenden und stilvollen Wohnraum zu schaffen.  Das traditionelle Dreisitzer-Sofa aus smaragdgrünem Stoff ist ein zeitloses und elegantes Möbelstück, das jedem Wohnzimmer oder Sitzbereich sowohl Komfort als auch Stil verleiht. Sein klassisches Design, die hochwertigen Materialien und seine Funktionalität machen es zu einer funktionalen und stilvollen Wahl für jedes Zuhause.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A traditional three-seater sofa is a classic and elegant piece of furniture that can add a touch of sophistication to any living room or sitting area. The sofa features a sturdy wooden frame that is designed to provide durability and stability, ensuring that the sofa can withstand regular use over time.  The sofa is upholstered in a rich emerald-colored fabric, providing a vibrant and eye-catching focal point in the room. The fabric is soft and comfortable to the touch, allowing you to relax and unwind in style.  The sofa is equipped with two large cushions, which are filled with a high-quality foam material, providing excellent support and comfort for extended periods of sitting. The backrest and armrests of the sofa are filled with a soft and plush material, allowing you to sink into the sofa and relax after a long day.  The traditional three-seater sofa is a versatile piece of furniture that can complement a range of interior design styles, from classic and traditional to more modern and eclectic. It can be paired with a variety of decorative accents, such as pillows, throws, and rugs, to create a cohesive and stylish living space.  Overall, a traditional three-seater sofa in emerald fabric is a timeless and elegant piece of furniture that can provide both comfort and style to any living room or sitting area. Its classic design, high-quality materials, and practical features make it a functional and stylish choice for any home.",
           },
@@ -387,24 +378,20 @@ describe(`with traditionalThreeSeaterSofa preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Traditional Three Seater Sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Traditional Three Seater Sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Traditionelles Dreisitzer-Sofa",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -412,24 +399,20 @@ describe(`with traditionalThreeSeaterSofa preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "traditional-three-seater-sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "traditional-three-seater-sofa",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "traditionelles-dreisitzer-sofa",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/travel-coffee-mug.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/travel-coffee-mug.spec.ts
@@ -164,17 +164,14 @@ describe(`with travelCoffeeMug preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -182,17 +179,14 @@ describe(`with travelCoffeeMug preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The Travel Coffee Mug is designed for use on the go. The mug has a capacity of around 12 to 20 ounces, and is designed to keep beverages hot or cold for an extended period of time. This is achieved through the use of insulation, which helps to maintain the temperature of the drink inside the mug.  The Travel Coffee Mug has a variety of features, including a spill-proof lid that can be securely fastened to prevent leaks or spills and a handle or grip that makes it easy to hold, even while walking or driving.  This travel coffee mug is designed to fit into standard cup holders in cars.  Overall, this travel coffee mug is a practical and convenient type of drinking vessel that is ideal for anyone who enjoys a hot or cold beverage while on the go. Its durable construction and insulated design make it a popular choice for commuters, travelers, and outdoor enthusiasts alike.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Diese praktische Reisetasse ist für unterwegs konzipiert. Der Becher hat ein Fassungsvermögen von etwa 12 bis 20 Unzen und ist so konzipiert, dass er Getränke über einen längeren Zeitraum heiß oder kalt hält. Dies wird durch die Verwendung einer Isolierschicht erreicht, die dazu beiträgt, die Temperatur des Getränks im Inneren des Bechers aufrechtzuerhalten.  Die Reisetasse hat eine Vielzahl von Funktionen, darunter einen auslaufsicheren Deckel, der sicher befestigt werden kann, um ein Auslaufen oder Verschütten zu verhindern, und einen Henkel, der das Halten auch beim Gehen oder Fahren erleichtert.  Dieser Reisekaffeebecher ist auf den Gebrauch in Kombination mit Standard-Getränkehaltern in Autos angepasst.  Die Reisetasse ist ein praktisches Trinkgefäß und der ideale Begleiter für all diejenigen, die unterwegs auf ein heißes oder kaltes Getränk nicht verzichten möchten. Seine robuste Konstruktion und sein isoliertes Design machen sie zu einer beliebten Wahl für Pendler, Reisende und Outdoor-Enthusiasten.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The Travel Coffee Mug is designed for use on the go. The mug has a capacity of around 12 to 20 ounces, and is designed to keep beverages hot or cold for an extended period of time. This is achieved through the use of insulation, which helps to maintain the temperature of the drink inside the mug.  The Travel Coffee Mug has a variety of features, including a spill-proof lid that can be securely fastened to prevent leaks or spills and a handle or grip that makes it easy to hold, even while walking or driving.  This travel coffee mug is designed to fit into standard cup holders in cars.  Overall, this travel coffee mug is a practical and convenient type of drinking vessel that is ideal for anyone who enjoys a hot or cold beverage while on the go. Its durable construction and insulated design make it a popular choice for commuters, travelers, and outdoor enthusiasts alike.",
           },
@@ -285,24 +279,20 @@ describe(`with travelCoffeeMug preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Travel Coffee Mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Travel Coffee Mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Reise-Kaffeetasse",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -310,24 +300,20 @@ describe(`with travelCoffeeMug preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "travel-coffee-mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "travel-coffee-mug",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "reise-kaffeetasse",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/turner-velvet-armchair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/turner-velvet-armchair.spec.ts
@@ -181,17 +181,14 @@ describe(`with turnerVelvetArmchair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
@@ -199,17 +196,14 @@ describe(`with turnerVelvetArmchair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A velvet chair with ebony legs is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The dark blue color of the velvet fabric is soft and delicate, adding a touch of modernity to the overall look of the chair.  The ebony legs of the chair are sturdy and durable, providing a solid foundation for the seating area. The ebony color of the frame adds a touch of sophistication to the overall look of the chair. The combination of the velvet and ebony creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The armrests are also curved, providing a comfortable place to rest the arms. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Das Samt-Sitzmöbel mit Beinen aus Ebenholz ist ein elegantes und luxuriöses Möbelstück. Das weiche, plüschige Samtmaterial des Stuhls sorgt für ein bequemes und gemütliches Sitzerlebnis. Die dunkelblaue Farbe des Samtstoffs ist weich und zart und verleiht dem Gesamtbild des Stuhls einen modernen Touch.  Die Ebenholzbeine des Sessels sind robust und langlebig und bilden eine solide Grundlage für den Sitzbereich. Die Ebenholzfarbe des Gestells verleiht dem Gesamtbild des Stuhls die gewünschte Raffinesse. Die Kombination aus Samt und Ebenholz schafft einen interessanten Kontrast und macht diesen Stuhl zu einem Statement-Piece in jedem Raum.  Der Sessel hat eine hohe Rückenlehne mit geschwungenem Design, die Rücken und Schultern stützt. Die Armlehnen sind ebenfalls gebogen und bieten eine bequeme Ablagefläche für die Arme. Der Sessel ist sowohl auf Stil als auch auf Komfort ausgelegt, was ihn zu einer großartigen Ergänzung für jedes Wohnzimmer, Schlafzimmer oder Büro macht.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A velvet chair with ebony legs is an elegant and luxurious piece of furniture. The soft, plush velvet material of the chair provides a comfortable and cozy seating experience. The dark blue color of the velvet fabric is soft and delicate, adding a touch of modernity to the overall look of the chair.  The ebony legs of the chair are sturdy and durable, providing a solid foundation for the seating area. The ebony color of the frame adds a touch of sophistication to the overall look of the chair. The combination of the velvet and ebony creates a striking contrast, making this chair a statement piece in any room.  The chair features a high backrest with a curved design, providing support for the back and shoulders. The armrests are also curved, providing a comfortable place to rest the arms. The chair is designed for both style and comfort, making it a great addition to any living room, bedroom, or office space.",
           },
@@ -314,24 +308,20 @@ describe(`with turnerVelvetArmchair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Turner Velvet Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Turner Velvet Armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Samtsessel >Turner<",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -339,24 +329,20 @@ describe(`with turnerVelvetArmchair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "turner-velvet-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "turner-velvet-armchair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "turner-samtsessel",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/vanilla-candle.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/vanilla-candle.spec.ts
@@ -156,17 +156,14 @@ describe(`with vanillaCandle preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "home-accents",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "room-decor",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "home-decor",
             "typeId": "category",
           },
@@ -174,17 +171,14 @@ describe(`with vanillaCandle preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A vanilla candle is a popular and timeless choice for adding a warm and inviting atmosphere to any home. The candle is made from high-quality wax, which is infused with the rich and creamy fragrance of vanilla.  The candle is presented in a glass container, which helps to protect the flame and also adds a decorative touch to the candle.   When lit, the candle will release a soothing and comforting aroma, filling the room with the sweet and comforting scent of vanilla. The fragrance is often associated with warmth, coziness, and relaxation, making it perfect for use during a cozy night in or for creating a calming atmosphere in a bedroom or living room.  A vanilla candle is a classic and comforting choice for adding a touch of warmth and coziness to any home. Its sweet and soothing aroma can help to create a relaxed and welcoming atmosphere, making it a popular choice for use in bedrooms, living rooms, and bathrooms.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Eine Kerze mit Vanilleduft ist eine beliebte und zeitlose Wahl, um jedem Zuhause eine warme und einladende Atmosphäre zu verleihen. Die Kerze besteht aus hochwertigem Wachs, das mit dem reichhaltigem und cremigen Vanilleduft versehen ist.  Die Kerze wird in einem Glasbehälter präsentiert, der zum Schutz der Flamme beiträgt und der Kerze auch eine dekorative Note verleiht. Angezündet verströmt sie ein beruhigendes Aroma und erfüllt den Raum mit dem süßen Duft von Vanille. Der Duft wird oft mit Wärme, Gemütlichkeit und Entspannung in Verbindung gebracht und eignet sich daher perfekt für die Einstimmung auf einen gemütlichen Abend oder um eine beruhigende Atmosphäre in einem Schlaf- oder Wohnbereich zu schaffen.  Diese Kerze ist eine klassische und beruhigende Wahl, um jedem Zuhause etwas mehr Wärme und Gemütlichkeit zu verleihen. Ihr süßes und beruhigendes Aroma trägt dazu bei, eine entspannte und einladende Atmosphäre zu schaffen, was sie zu einer beliebten Wahl für den Einsatz im Schlaf- oder Wohnbereich und in Badezimmern macht.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A vanilla candle is a popular and timeless choice for adding a warm and inviting atmosphere to any home. The candle is made from high-quality wax, which is infused with the rich and creamy fragrance of vanilla.  The candle is presented in a glass container, which helps to protect the flame and also adds a decorative touch to the candle.   When lit, the candle will release a soothing and comforting aroma, filling the room with the sweet and comforting scent of vanilla. The fragrance is often associated with warmth, coziness, and relaxation, making it perfect for use during a cozy night in or for creating a calming atmosphere in a bedroom or living room.  A vanilla candle is a classic and comforting choice for adding a touch of warmth and coziness to any home. Its sweet and soothing aroma can help to create a relaxed and welcoming atmosphere, making it a popular choice for use in bedrooms, living rooms, and bathrooms.",
           },
@@ -277,24 +271,20 @@ describe(`with vanillaCandle preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Vanilla Candle",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Vanilla Candle",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Kerze mit Vanilleduft",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -302,24 +292,20 @@ describe(`with vanillaCandle preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "vanilla-candle",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "vanilla-candle",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "vanille-kerze",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/walnut-cabinet.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/walnut-cabinet.spec.ts
@@ -180,17 +180,14 @@ describe(`with walnutCabinet preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "storage--tables",
             "typeId": "category",
           },
@@ -198,17 +195,14 @@ describe(`with walnutCabinet preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This Walnut Cabinet has many drawers, which are arranged in rows, with several drawers per row. The drawers are large and deep, allowing for ample storage space. The drawers may have simple handles.  The top of the sideboard is flat and smooth, and can be used to display decorative items such as vases or candles.   Overall, a large sideboard with many drawers is a functional and practical piece of furniture that can add style and storage to any room.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Dieser Nussbaumschrank besticht durch seine Vielzahl an Schubladen, die in Reihen angeordnet sind, mit mehreren Schubladen pro Reihe. Die Schubladen sind groß und tief und bieten viel Stauraum. Die Schubladen sind mit einfachen Griffen zu haben.  Die Oberseite des Sideboards ist flach und glatt und kann zur Präsentation von Dekorationsartikeln wie Vasen oder Kerzen verwendet werden.  Das geräumige Sideboard mit vielen Schubladen ist ein funktionales und praktisches Möbelstück, das jedem Raum Stil und Stauraum verleiht.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This Walnut Cabinet has many drawers, which are arranged in rows, with several drawers per row. The drawers are large and deep, allowing for ample storage space. The drawers may have simple handles.  The top of the sideboard is flat and smooth, and can be used to display decorative items such as vases or candles.   Overall, a large sideboard with many drawers is a functional and practical piece of furniture that can add style and storage to any room.",
           },
@@ -313,24 +307,20 @@ describe(`with walnutCabinet preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Walnut Cabinet",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Walnut Cabinet",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Sideboard aus Nussbaumholz",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -338,24 +328,20 @@ describe(`with walnutCabinet preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "walnut-cabinet",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "walnut-cabinet",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "nussbaum-schrank",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/walnut-counter-stool.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/walnut-counter-stool.spec.ts
@@ -181,27 +181,22 @@ describe(`with walnutCounterStool preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "tables",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "storage--tables",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bedroom-furniture",
             "typeId": "category",
           },
@@ -209,17 +204,14 @@ describe(`with walnutCounterStool preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "The walnut stool is made from walnut wood, which is known for its durability and strength. The stool is a simple design, with a flat top surface and four straight legs. The legs are slightly tapered for added visual interest. The walnut wood may be left in its natural state or finished with a stain or varnish to bring out the natural beauty of the wood grain. The stool has a square top. Overall, a walnut stool is a versatile and functional piece of furniture that can be used in a variety of settings.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Der Barhocker ist aus Nussbaumholz gefertigt, das für seine Langlebigkeit und Stärke bekannt ist. Der Hocker hat ein schlichtes Design mit einer flachen Oberfläche und vier geraden Beinen. Die Beine sind für zusätzliches visuelles Interesse leicht konisch zulaufend designt. Das Nussbaumholz kann in seinem natürlichen Zustand belassen oder mit einer Beize oder einem Lack veredelt werden, um die natürliche Schönheit der Holzmaserung hervorzuheben. Der Hocker hat eine quadratische Sitzfläche. Der Barocker aus Nussbaumholz ist ein vielseitiges und funktionelles Möbelstück, das in einer Vielzahl von Wohnräumen verwendet werden kann.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "The walnut stool is made from walnut wood, which is known for its durability and strength. The stool is a simple design, with a flat top surface and four straight legs. The legs are slightly tapered for added visual interest. The walnut wood may be left in its natural state or finished with a stain or varnish to bring out the natural beauty of the wood grain. The stool has a square top. Overall, a walnut stool is a versatile and functional piece of furniture that can be used in a variety of settings.",
           },
@@ -316,24 +308,20 @@ describe(`with walnutCounterStool preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Walnut Counter Stool",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Walnut Counter Stool",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Barhocker aus Nussbaumholz",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -341,24 +329,20 @@ describe(`with walnutCounterStool preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "walnut-counter-stool",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "walnut-counter-stool",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "barhocker-aus-walnussholz",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/willow-teapot.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/willow-teapot.spec.ts
@@ -149,22 +149,18 @@ describe(`with willowTeapot preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "dinnerware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-accessories",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
@@ -172,17 +168,14 @@ describe(`with willowTeapot preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "This teapot is made of fine porcelain, commonly known as bone china. It is a delicate and elegant piece of tableware that is designed to brew and serve tea.   The fine china material used in the teapot provides an excellent heat retention capacity, ensuring that the tea stays warm for an extended period. It is also non-porous, which means it does not absorb any flavors or odors from the tea, preserving the purity of the flavor.  To clean a china teapot, it is recommended to wash it by hand with a mild detergent, using a soft cloth or sponge. Harsh cleaning agents or abrasives should be avoided, as they can damage the delicate surface of the teapot.  Overall, a china teapot is a timeless and classic piece of tableware that adds a touch of elegance and sophistication to any tea party or gathering. Its delicate and intricate design, combined with its functionality and heat retention properties, make it a cherished item for tea lovers around the world.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Diese Teekanne besteht aus feinem Porzellan, allgemein bekannt als Knochenporzellan. Es ist ein zartes und elegantes Geschirr, das zum Aufbrühen und Servieren von Tee bestimmt ist.  Das für die Teekanne verwendete feine Porzellanmaterial hat ein hervorragendes Wärmespeichervermögen und sorgt dafür, dass der Tee lange warm bleibt. Es ist auch nicht porös, was bedeutet, dass es keine Aromen oder Gerüche aus dem Tee aufnimmt, wodurch die Reinheit des Geschmacks erhalten bleibt.  Zum Reinigen einer Teekanne aus Porzellan wird empfohlen, sie von Hand mit einem milden Reinigungsmittel und einem weichen Tuch oder Schwamm zu waschen. Scharfe Reinigungsmittel oder Scheuermittel sollten vermieden werden, da sie die empfindliche Oberfläche der Teekanne beschädigen können.  Die Teekanne aus Porzellan ein zeitloses und klassisches Geschirr, das jeder Teestunde oder Zusammenkunft einen Hauch von Eleganz und Raffinesse verleiht. Ihr zartes und kompliziertes Design, kombiniert mit ihrer Funktionalität und Wärmespeichereigenschaften, macht sie zum idealen Must-have für Teeliebhaber auf der ganzen Welt.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "This teapot is made of fine porcelain, commonly known as bone china. It is a delicate and elegant piece of tableware that is designed to brew and serve tea.   The fine china material used in the teapot provides an excellent heat retention capacity, ensuring that the tea stays warm for an extended period. It is also non-porous, which means it does not absorb any flavors or odors from the tea, preserving the purity of the flavor.  To clean a china teapot, it is recommended to wash it by hand with a mild detergent, using a soft cloth or sponge. Harsh cleaning agents or abrasives should be avoided, as they can damage the delicate surface of the teapot.  Overall, a china teapot is a timeless and classic piece of tableware that adds a touch of elegance and sophistication to any tea party or gathering. Its delicate and intricate design, combined with its functionality and heat retention properties, make it a cherished item for tea lovers around the world.",
           },
@@ -267,24 +260,20 @@ describe(`with willowTeapot preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Willow Teapot",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Willow Teapot",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Teekanne >Willow<",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -292,24 +281,20 @@ describe(`with willowTeapot preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "willow-teapot",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "willow-teapot",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "willow-teekanne",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/wilma-chair.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/wilma-chair.spec.ts
@@ -196,17 +196,14 @@ describe(`with wilmaChair preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "armchairs",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "living-room-furniture",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "furniture",
             "typeId": "category",
           },
@@ -214,17 +211,14 @@ describe(`with wilmaChair preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A tufted armless futon chair has a simple and modern design, featuring a cushioned seat and backrest with tufted details for added comfort and style. The chair lacks arms to allow for more flexibility and ease of use. The upholstery is made of durable fabric that is easy to clean and maintain. Overall, a tufted armless futon chair is a practical and stylish furniture piece that can be used in a variety of settings, such as a living room, bedroom, or home office.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Der getuftete armlehnenlose Futon-Stuhl hat ein einfaches und modernes Design mit gepolstertem Sitz und Rückenlehne. Das Design des Sessels verzichtet auf Armlehnen, um mehr Flexibilität beim Sitzerlebnis zu schaffen. Die Polsterung besteht aus strapazierfähigem Stoff, der leicht zu reinigen und zu pflegen ist. Der getuftete Futonstuhl ohne Armlehnen ist ein praktisches und stilvolles Möbelstück, das in einer Vielzahl von Umgebungen verwendet werden kann, z. B. im Wohn-, Schlaf- oder Arbeitsbereich.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A tufted armless futon chair has a simple and modern design, featuring a cushioned seat and backrest with tufted details for added comfort and style. The chair lacks arms to allow for more flexibility and ease of use. The upholstery is made of durable fabric that is easy to clean and maintain. Overall, a tufted armless futon chair is a practical and stylish furniture piece that can be used in a variety of settings, such as a living room, bedroom, or home office.",
           },
@@ -337,24 +331,20 @@ describe(`with wilmaChair preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Wilma Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Wilma Chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Sessel >Wilma<",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -362,24 +352,20 @@ describe(`with wilmaChair preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "wilma-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "wilma-chair",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "wilma-stuhl",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/presets/sample-data-goodstore/wine-bottle-opener.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-goodstore/wine-bottle-opener.spec.ts
@@ -156,17 +156,14 @@ describe(`with wineBottleOpener preset`, () => {
       {
         "categories": [
           {
-            "__typename": "Reference",
             "key": "bar-accessories",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "bar-and-glassware",
             "typeId": "category",
           },
           {
-            "__typename": "Reference",
             "key": "kitchen",
             "typeId": "category",
           },
@@ -174,17 +171,14 @@ describe(`with wineBottleOpener preset`, () => {
         "categoryOrderHints": undefined,
         "description": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "A wine bottle opener is a device used to remove the cork from a wine bottle. This opener features a pointed helix screw that is twisted into the cork, and a handle or lever that is used to pull the cork out of the bottle. Additional features include a bottle opener. This wine bottle opener is lever-style.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Mit diesem praktischen Korkenzieher wird das Öffnen von Weinflaschen zur leichten Übung. Der Korkenzieher hat eine spitze Spiralschraube, die in den Korken gedreht wird, und einen Griff oder Hebel, mit dem der Korken aus der Flasche gehoben wird. Ein weiteres Feature des Korkenziehers im Hebelstil ist ein Flaschenöffner.",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "A wine bottle opener is a device used to remove the cork from a wine bottle. This opener features a pointed helix screw that is twisted into the cork, and a handle or lever that is used to pull the cork out of the bottle. Additional features include a bottle opener. This wine bottle opener is lever-style.",
           },
@@ -273,24 +267,20 @@ describe(`with wineBottleOpener preset`, () => {
         "metaTitle": undefined,
         "name": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "Wine Bottle Opener",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "Wine Bottle Opener",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "Korkenzieher",
           },
         ],
         "priceMode": undefined,
         "productType": {
-          "__typename": "Reference",
           "key": "furniture-and-decor",
           "typeId": "product-type",
         },
@@ -298,24 +288,20 @@ describe(`with wineBottleOpener preset`, () => {
         "searchKeywords": undefined,
         "slug": [
           {
-            "__typename": "LocalizedString",
             "locale": "en-US",
             "value": "wine-bottle-opener",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "en-GB",
             "value": "wine-bottle-opener",
           },
           {
-            "__typename": "LocalizedString",
             "locale": "de-DE",
             "value": "wein-flaschenffner",
           },
         ],
         "state": undefined,
         "taxCategory": {
-          "__typename": "Reference",
           "key": "standard-tax",
           "typeId": "tax-category",
         },

--- a/models/product/src/product/product-draft/transformers.ts
+++ b/models/product/src/product/product-draft/transformers.ts
@@ -41,6 +41,7 @@ const transformers = {
       'taxCategory',
       'state',
     ],
+    isGraphqlDraft: true,
   }),
 };
 

--- a/models/shopping-list/package.json
+++ b/models/shopping-list/package.json
@@ -20,7 +20,7 @@
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/commons": "6.6.0",
-    "@commercetools-test-data/core": "6.6.0",
+    "@commercetools-test-data/core": "link:../../../../core",
     "@commercetools-test-data/utils": "6.6.0",
     "@commercetools/platform-sdk": "^6.0.0",
     "@faker-js/faker": "^8.0.0"

--- a/models/shopping-list/src/shopping-list-draft/builder.spec.ts
+++ b/models/shopping-list/src/shopping-list-draft/builder.spec.ts
@@ -114,17 +114,14 @@ describe('builder', () => {
           expect.objectContaining({
             locale: 'en',
             value: expect.any(String),
-            __typename: 'LocalizedString',
           }),
           expect.objectContaining({
             locale: 'de',
             value: expect.any(String),
-            __typename: 'LocalizedString',
           }),
           expect.objectContaining({
             locale: 'fr',
             value: expect.any(String),
-            __typename: 'LocalizedString',
           }),
         ]),
         anonymousId: expect.any(String),

--- a/models/shopping-list/src/shopping-list-draft/transformers.ts
+++ b/models/shopping-list/src/shopping-list-draft/transformers.ts
@@ -12,6 +12,7 @@ const transformers = {
     'graphql',
     {
       buildFields: ['name', 'slug', 'description', 'customer'],
+      isGraphqlDraft: true,
     }
   ),
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,8 +560,8 @@ importers:
         specifier: 6.6.0
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 6.6.0
-        version: link:../../core
+        specifier: link:../../../../core
+        version: link:../../../../core
       '@commercetools-test-data/product-type':
         specifier: 6.6.0
         version: link:../product-type
@@ -809,8 +809,8 @@ importers:
         specifier: 6.6.0
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 6.6.0
-        version: link:../../core
+        specifier: link:../../../../core
+        version: link:../../../../core
       '@commercetools-test-data/utils':
         specifier: 6.6.0
         version: link:../../utils


### PR DESCRIPTION
When transforming fields for graphql draft models, built fields will add a `__typename`, which is not a valid field to send in a draft and makes API's very sad and send us a `400`.  

This is the beginnings of an attempt to add a transform option `isGraphqlDraft` that would remove `typename` from any built fields if passed.