### PR TITLE
fix(shippingMethod/presets): include localized name in good store presets

### DIFF
--- a/.changeset/pretty-candles-greet.md
+++ b/.changeset/pretty-candles-greet.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/shipping-method': minor
+---
+
+Add localizedName for goodstore ShippingMethodDraft presets.

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/express.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/express.spec.ts
@@ -11,7 +11,14 @@ describe('Shipping Method with express preset', () => {
         "isDefault": false,
         "key": "express-delivery",
         "localizedDescription": undefined,
-        "localizedName": undefined,
+        "localizedName": {
+          "de": undefined,
+          "de-DE": "Express Delivery",
+          "en": undefined,
+          "en-GB": "Express Delivery",
+          "en-US": "Express Delivery",
+          "fr": undefined,
+        },
         "name": "Express Delivery",
         "predicate": undefined,
         "taxCategory": {
@@ -57,7 +64,23 @@ describe('Shipping Method with express preset', () => {
         "isDefault": false,
         "key": "express-delivery",
         "localizedDescription": undefined,
-        "localizedName": undefined,
+        "localizedName": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-US",
+            "value": "Express Delivery",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "de-DE",
+            "value": "Express Delivery",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-GB",
+            "value": "Express Delivery",
+          },
+        ],
         "name": "Express Delivery",
         "predicate": undefined,
         "taxCategory": {

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/express.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/express.ts
@@ -1,4 +1,7 @@
-import { KeyReference } from '@commercetools-test-data/commons';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
@@ -16,6 +19,13 @@ const expressShippingMethod = (): TShippingMethodDraftBuilder =>
     .empty()
     .key('express-delivery')
     .name('Express Delivery')
+    .localizedName(
+      LocalizedString.presets
+        .empty()
+        ['en-US']('Express Delivery')
+        ['de-DE']('Express Delivery')
+        ['en-GB']('Express Delivery')
+    )
     .taxCategory(
       KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/standard.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/standard.spec.ts
@@ -11,7 +11,14 @@ describe('Shipping Method with standard preset', () => {
         "isDefault": true,
         "key": "standard-delivery",
         "localizedDescription": undefined,
-        "localizedName": undefined,
+        "localizedName": {
+          "de": undefined,
+          "de-DE": "Standard Delivery",
+          "en": undefined,
+          "en-GB": "Standard Delivery",
+          "en-US": "Standard Delivery",
+          "fr": undefined,
+        },
         "name": "Standard Delivery",
         "predicate": undefined,
         "taxCategory": {
@@ -57,7 +64,23 @@ describe('Shipping Method with standard preset', () => {
         "isDefault": true,
         "key": "standard-delivery",
         "localizedDescription": undefined,
-        "localizedName": undefined,
+        "localizedName": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-US",
+            "value": "Standard Delivery",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "de-DE",
+            "value": "Standard Delivery",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-GB",
+            "value": "Standard Delivery",
+          },
+        ],
         "name": "Standard Delivery",
         "predicate": undefined,
         "taxCategory": {

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/standard.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/standard.ts
@@ -1,4 +1,7 @@
-import { KeyReference } from '@commercetools-test-data/commons';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
@@ -16,6 +19,13 @@ const standardShippingMethod = (): TShippingMethodDraftBuilder =>
     .empty()
     .key('standard-delivery')
     .name('Standard Delivery')
+    .localizedName(
+      LocalizedString.presets
+        .empty()
+        ['en-US']('Standard Delivery')
+        ['de-DE']('Standard Delivery')
+        ['en-GB']('Standard Delivery')
+    )
     .taxCategory(
       KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/usa.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/usa.spec.ts
@@ -11,7 +11,14 @@ describe('Shipping Method with USA preset', () => {
         "isDefault": false,
         "key": "us-delivery",
         "localizedDescription": undefined,
-        "localizedName": undefined,
+        "localizedName": {
+          "de": undefined,
+          "de-DE": "US Delivery",
+          "en": undefined,
+          "en-GB": "US Delivery",
+          "en-US": "US Delivery",
+          "fr": undefined,
+        },
         "name": "US Delivery",
         "predicate": undefined,
         "taxCategory": {
@@ -52,7 +59,23 @@ describe('Shipping Method with USA preset', () => {
         "isDefault": false,
         "key": "us-delivery",
         "localizedDescription": undefined,
-        "localizedName": undefined,
+        "localizedName": [
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-US",
+            "value": "US Delivery",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "de-DE",
+            "value": "US Delivery",
+          },
+          {
+            "__typename": "LocalizedString",
+            "locale": "en-GB",
+            "value": "US Delivery",
+          },
+        ],
         "name": "US Delivery",
         "predicate": undefined,
         "taxCategory": {

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/usa.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-goodstore/usa.ts
@@ -1,4 +1,7 @@
-import { KeyReference } from '@commercetools-test-data/commons';
+import {
+  KeyReference,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
 import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
@@ -16,6 +19,13 @@ const usaShippingMethod = (): TShippingMethodDraftBuilder =>
     .empty()
     .key('us-delivery')
     .name('US Delivery')
+    .localizedName(
+      LocalizedString.presets
+        .empty()
+        ['en-US']('US Delivery')
+        ['de-DE']('US Delivery')
+        ['en-GB']('US Delivery')
+    )
     .taxCategory(
       KeyReference.presets.taxCategory().key(standardTaxCategoryDraft.key!)
     )


### PR DESCRIPTION
This PR adds `localizedName` values for `en-US`, `en-GB`, and `de-DE` to the good store `ShippingMethodDraft` presets, based on the existing `name` field. 