### PR TITLE
feat(test-data): create `StandalonePrice` model and associated draft

### DIFF
--- a/.changeset/fuzzy-cats-glow.md
+++ b/.changeset/fuzzy-cats-glow.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-test-data/standalone-price': minor
+'@commercetools-test-data/commons': minor
+'@commercetools-test-data/graphql-types': minor
+---
+
+Create standalone prices model and associated draft, support channel key reference preset

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,6 +44,7 @@
 /models/shipping-method @commercetools/checkout-team-fe
 /models/shopping-list @commercetools/checkout-team-fe
 /models/staged-quote @commercetools/customers-team-fe
+/models/standalone-price @commercetools/priceless-team-fe
 /models/store @commercetools/context-team-fe
 /models/tax-category @commercetools/checkout-team-fe
 /models/zone @commercetools/checkout-team-fe

--- a/graphql-types/src/generated/settings.ts
+++ b/graphql-types/src/generated/settings.ts
@@ -113,6 +113,7 @@ export type TMcSettingsBusinessUnitsListMyViewTableInput = {
 
 export enum TMcSettingsCategoryRecommendationSearchProperty {
   Attribute = 'Attribute',
+  /** @deprecated The machine learning APIs are not available anymore. */
   MachineLearning = 'MachineLearning',
   ProductType = 'ProductType',
 }
@@ -396,6 +397,21 @@ export type TMcSettingsCustomViewPermissionDataInput = {
   oAuthScopes: Array<Scalars['String']['input']>;
 };
 
+export type TMcSettingsCustomViewQueryInput = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  where?: InputMaybe<TMcSettingsCustomViewQueryWhereInput>;
+};
+
+export type TMcSettingsCustomViewQueryWhereInput = {
+  defaultLabel?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  locators?: InputMaybe<Array<Scalars['String']['input']>>;
+  organizationId?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<TMcSettingsCustomViewType>;
+};
+
 export enum TMcSettingsCustomViewSize {
   Large = 'LARGE',
   Small = 'SMALL',
@@ -417,6 +433,15 @@ export type TMcSettingsCustomViewTypeSettings = {
 
 export type TMcSettingsCustomViewTypeSettingsInput = {
   size?: InputMaybe<TMcSettingsCustomViewSize>;
+};
+
+export type TMcSettingsCustomViewsPagedQueryResult = {
+  __typename?: 'CustomViewsPagedQueryResult';
+  count: Scalars['Int']['output'];
+  limit: Scalars['Int']['output'];
+  offset: Scalars['Int']['output'];
+  results: Array<TMcSettingsCustomView>;
+  total: Scalars['Int']['output'];
 };
 
 export type TMcSettingsCustomersListView = {
@@ -1231,6 +1256,32 @@ export type TMcSettingsMyCustomApplicationQueryWhereInput = {
   status?: InputMaybe<TMcSettingsCustomApplicationStatus>;
 };
 
+export type TMcSettingsMyCustomView = {
+  __typename?: 'MyCustomView';
+  createdAt: Scalars['DateTime']['output'];
+  defaultLabel: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  labelAllLocales: Array<TMcSettingsLocalizedField>;
+  locators: Array<Scalars['String']['output']>;
+  organizationId: Scalars['String']['output'];
+  organizationName: Scalars['String']['output'];
+  permissions: Array<TMcSettingsCustomViewPermission>;
+  status: TMcSettingsCustomViewStatus;
+  type: TMcSettingsCustomViewType;
+  typeSettings?: Maybe<TMcSettingsCustomViewTypeSettings>;
+  updatedAt: Scalars['DateTime']['output'];
+  url: Scalars['String']['output'];
+};
+
+export type TMcSettingsMyCustomViewsQueryInput = {
+  where?: InputMaybe<TMcSettingsMyCustomViewsQueryWhereInput>;
+};
+
+export type TMcSettingsMyCustomViewsQueryWhereInput = {
+  status?: InputMaybe<TMcSettingsCustomViewStatus>;
+};
+
 export type TMcSettingsNavbarMenu = {
   __typename?: 'NavbarMenu';
   createdAt: Scalars['DateTime']['output'];
@@ -1406,9 +1457,18 @@ export type TMcSettingsOrganizationExtensionForCustomApplication = {
   organizationName?: Maybe<Scalars['String']['output']>;
 };
 
+export type TMcSettingsOrganizationExtensionForCustomView = {
+  __typename?: 'OrganizationExtensionForCustomView';
+  customView?: Maybe<TMcSettingsRestrictedCustomViewForOrganization>;
+  id: Scalars['ID']['output'];
+  organizationId: Scalars['String']['output'];
+  organizationName?: Maybe<Scalars['String']['output']>;
+};
+
 export type TMcSettingsPimSearchListView = {
   __typename?: 'PimSearchListView';
   createdAt: Scalars['DateTime']['output'];
+  expandedRows: Array<Scalars['String']['output']>;
   filters?: Maybe<Array<TMcSettingsFilterValues>>;
   id: Scalars['ID']['output'];
   isActive?: Maybe<Scalars['Boolean']['output']>;
@@ -1422,6 +1482,7 @@ export type TMcSettingsPimSearchListView = {
 };
 
 export type TMcSettingsPimSearchListViewInput = {
+  expandedRows?: InputMaybe<Array<Scalars['String']['input']>>;
   filters: Array<TMcSettingsFilterValuesCreateInput>;
   nameAllLocales: Array<TMcSettingsLocalizedFieldCreateInput>;
   search?: InputMaybe<Scalars['String']['input']>;
@@ -1554,6 +1615,8 @@ export type TMcSettingsQuery = {
   allAppliedCustomViewPermissions: Array<TMcSettingsCustomViewInstallationPermission>;
   /** @deprecated Experimental feature - For internal usage only */
   allCustomApplications: TMcSettingsCustomApplicationsPagedQueryResult;
+  /** @deprecated Experimental feature - For internal usage only */
+  allCustomViews: TMcSettingsCustomViewsPagedQueryResult;
   allCustomViewsInstallationsByLocator: Array<TMcSettingsRestrictedCustomViewInstallationForProject>;
   allCustomViewsLocatorGroups: Array<TMcSettingsCustomViewLocatorGroup>;
   allFeatures: Array<TMcSettingsFeature>;
@@ -1582,12 +1645,14 @@ export type TMcSettingsQuery = {
   /** @deprecated Experimental feature - For internal usage only */
   globalOrganizationExtension?: Maybe<TMcSettingsOrganizationExtension>;
   myCustomApplications: Array<TMcSettingsMyCustomApplication>;
+  myCustomViews: Array<TMcSettingsMyCustomView>;
   orderDetailView?: Maybe<TMcSettingsOrderDetailView>;
   orderDetailViews: Array<Maybe<TMcSettingsOrderDetailView>>;
   ordersListView?: Maybe<TMcSettingsOrdersListView>;
   ordersListViews: Array<Maybe<TMcSettingsOrdersListView>>;
   organizationExtension?: Maybe<TMcSettingsOrganizationExtension>;
   organizationExtensionForCustomApplication?: Maybe<TMcSettingsOrganizationExtensionForCustomApplication>;
+  organizationExtensionForCustomView?: Maybe<TMcSettingsOrganizationExtensionForCustomView>;
   pimSearchListView?: Maybe<TMcSettingsPimSearchListView>;
   pimSearchListViews: Array<Maybe<TMcSettingsPimSearchListView>>;
   productDiscountsCustomView?: Maybe<TMcSettingsDiscountsCustomView>;
@@ -1624,6 +1689,10 @@ export type TMcSettingsQuery_AllAppliedCustomViewPermissionsArgs = {
 
 export type TMcSettingsQuery_AllCustomApplicationsArgs = {
   params?: InputMaybe<TMcSettingsCustomApplicationQueryInput>;
+};
+
+export type TMcSettingsQuery_AllCustomViewsArgs = {
+  params?: InputMaybe<TMcSettingsCustomViewQueryInput>;
 };
 
 export type TMcSettingsQuery_AllCustomViewsInstallationsByLocatorArgs = {
@@ -1683,6 +1752,10 @@ export type TMcSettingsQuery_MyCustomApplicationsArgs = {
   params?: InputMaybe<TMcSettingsMyCustomApplicationQueryInput>;
 };
 
+export type TMcSettingsQuery_MyCustomViewsArgs = {
+  params?: InputMaybe<TMcSettingsMyCustomViewsQueryInput>;
+};
+
 export type TMcSettingsQuery_OrderDetailViewArgs = {
   id: Scalars['ID']['input'];
 };
@@ -1697,6 +1770,10 @@ export type TMcSettingsQuery_OrganizationExtensionArgs = {
 
 export type TMcSettingsQuery_OrganizationExtensionForCustomApplicationArgs = {
   entryPointUriPath: Scalars['String']['input'];
+};
+
+export type TMcSettingsQuery_OrganizationExtensionForCustomViewArgs = {
+  customViewId: Scalars['String']['input'];
 };
 
 export type TMcSettingsQuery_PimSearchListViewArgs = {

--- a/models/commons/README.md
+++ b/models/commons/README.md
@@ -20,6 +20,7 @@ $ pnpm add -D @commercetools-test-data/commons
 - [Money](#money)<br>
 - [Price](#price)<br>
 - [Reference](#reference)<br>
+- [PriceTier](#pricetier)<br>
 
 ## `Address`
 
@@ -123,4 +124,15 @@ const productRef = Reference.random()
 const categoryRef = Reference.presets
   .category()
   .build<TReference<'category'>>();
+```
+
+## `PriceTier`
+
+```ts
+import { PriceTier, type TPriceTier } from '@commercetools-test-data/commons';
+
+const productRef = PriceTier.random().build<TPriceTier>();
+
+// Presets
+const categoryRef = PriceTier.presets.build<TPriceTier>();
 ```

--- a/models/commons/src/index.ts
+++ b/models/commons/src/index.ts
@@ -8,6 +8,7 @@ export * from './localized-string/types';
 export * from './money/types';
 export * from './price/types';
 export * from './reference/types';
+export * from './price-tier/types';
 
 // Export models
 export * as Address from './address';
@@ -22,3 +23,5 @@ export * as Money from './money';
 export * as Price from './price';
 export * as PriceDraft from './price/price-draft';
 export * as Reference from './reference';
+export * as PriceTier from './price-tier';
+export * as PriceTierDraft from './price-tier/price-tier-draft';

--- a/models/commons/src/key-reference/presets/channel-reference.spec.ts
+++ b/models/commons/src/key-reference/presets/channel-reference.spec.ts
@@ -1,0 +1,10 @@
+import type { TKeyReference } from '../types';
+import channelReference from './channel-reference';
+
+it('should build channel reference', () => {
+  const built = channelReference().build<TKeyReference>();
+  expect(built).toEqual({
+    key: expect.any(String),
+    typeId: 'channel',
+  });
+});

--- a/models/commons/src/key-reference/presets/channel-reference.ts
+++ b/models/commons/src/key-reference/presets/channel-reference.ts
@@ -1,0 +1,6 @@
+import KeyReference from '../builder';
+import type { TKeyReferenceBuilder } from '../types';
+
+const channel = (): TKeyReferenceBuilder => KeyReference().typeId('channel');
+
+export default channel;

--- a/models/commons/src/key-reference/presets/index.ts
+++ b/models/commons/src/key-reference/presets/index.ts
@@ -1,6 +1,7 @@
 import associateRole from './associate-role-reference';
 import businessUnit from './business-unit-reference';
 import category from './category-reference';
+import channel from './channel-reference';
 import customerGroup from './customer-group-reference';
 import customer from './customer-reference';
 import productType from './product-type-reference';
@@ -13,6 +14,7 @@ const presets = {
   associateRole,
   businessUnit,
   category,
+  channel,
   customer,
   customerGroup,
   productType,

--- a/models/commons/src/price-tier/builder.spec.ts
+++ b/models/commons/src/price-tier/builder.spec.ts
@@ -1,0 +1,57 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TPriceTier, TPriceTierGraphql } from './types';
+import * as PriceTier from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TPriceTier, TPriceTier>(
+      'default',
+      PriceTier.random(),
+      expect.objectContaining({
+        minimumQuantity: expect.any(Number),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TPriceTier, TPriceTier>(
+      'rest',
+      PriceTier.random(),
+      expect.objectContaining({
+        minimumQuantity: expect.any(Number),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TPriceTier, TPriceTierGraphql>(
+      'graphql',
+      PriceTier.random(),
+      expect.objectContaining({
+        minimumQuantity: expect.any(Number),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+          __typename: 'Money',
+        }),
+        __typename: 'ProductPriceTier',
+      })
+    )
+  );
+});

--- a/models/commons/src/price-tier/builder.ts
+++ b/models/commons/src/price-tier/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type { TPriceTier, TCreatePriceTierBuilder } from './types';
+
+const Model: TCreatePriceTierBuilder = () =>
+  Builder<TPriceTier>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/commons/src/price-tier/generator.ts
+++ b/models/commons/src/price-tier/generator.ts
@@ -1,0 +1,14 @@
+import { Generator, fake } from '@commercetools-test-data/core';
+import * as CentPrecisionMoney from '../cent-precision-money';
+import { TPriceTier } from './types';
+
+// https://docs.commercetools.com/api/types#pricetier
+
+const generator = Generator<TPriceTier>({
+  fields: {
+    minimumQuantity: fake((f) => f.number.int()),
+    value: fake(() => CentPrecisionMoney.random()),
+  },
+});
+
+export default generator;

--- a/models/commons/src/price-tier/index.ts
+++ b/models/commons/src/price-tier/index.ts
@@ -1,0 +1,3 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+export * from './types';

--- a/models/commons/src/price-tier/presets/index.ts
+++ b/models/commons/src/price-tier/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/commons/src/price-tier/price-tier-draft/builder.spec.ts
+++ b/models/commons/src/price-tier/price-tier-draft/builder.spec.ts
@@ -1,0 +1,56 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TPriceTierDraft, TPriceTierDraftGraphql } from '../types';
+import * as PriceTierDraft from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TPriceTierDraft, TPriceTierDraft>(
+      'default',
+      PriceTierDraft.random(),
+      expect.objectContaining({
+        minimumQuantity: expect.any(Number),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TPriceTierDraft, TPriceTierDraft>(
+      'rest',
+      PriceTierDraft.random(),
+      expect.objectContaining({
+        minimumQuantity: expect.any(Number),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TPriceTierDraft, TPriceTierDraftGraphql>(
+      'graphql',
+      PriceTierDraft.random(),
+      expect.objectContaining({
+        minimumQuantity: expect.any(Number),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+        __typename: 'ProductPriceTierInput',
+      })
+    )
+  );
+});

--- a/models/commons/src/price-tier/price-tier-draft/builder.ts
+++ b/models/commons/src/price-tier/price-tier-draft/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type { TCreatePriceTierDraftBuilder, TPriceTierDraft } from '../types';
+
+const Model: TCreatePriceTierDraftBuilder = () =>
+  Builder<TPriceTierDraft>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/commons/src/price-tier/price-tier-draft/generator.ts
+++ b/models/commons/src/price-tier/price-tier-draft/generator.ts
@@ -1,0 +1,14 @@
+import { fake, Generator } from '@commercetools-test-data/core';
+import * as CentPrecisionMoneyDraft from '../../cent-precision-money/cent-precision-money-draft';
+import { TPriceTierDraft } from '../types';
+
+// https://docs.commercetools.com/api/types#pricetierdraft
+
+const generator = Generator<TPriceTierDraft>({
+  fields: {
+    minimumQuantity: fake((f) => f.number.int()),
+    value: fake(() => CentPrecisionMoneyDraft.random()),
+  },
+});
+
+export default generator;

--- a/models/commons/src/price-tier/price-tier-draft/index.ts
+++ b/models/commons/src/price-tier/price-tier-draft/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/commons/src/price-tier/price-tier-draft/presets/index.ts
+++ b/models/commons/src/price-tier/price-tier-draft/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/commons/src/price-tier/price-tier-draft/transformers.ts
+++ b/models/commons/src/price-tier/price-tier-draft/transformers.ts
@@ -1,0 +1,17 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type { TPriceTierDraft, TPriceTierDraftGraphql } from '../types';
+
+const transformers = {
+  default: Transformer<TPriceTierDraft, TPriceTierDraft>('default', {
+    buildFields: ['value'],
+  }),
+  rest: Transformer<TPriceTierDraft, TPriceTierDraft>('rest', {
+    buildFields: ['value'],
+  }),
+  graphql: Transformer<TPriceTierDraft, TPriceTierDraftGraphql>('graphql', {
+    buildFields: ['value'],
+    addFields: () => ({ __typename: 'ProductPriceTierInput' }),
+  }),
+};
+
+export default transformers;

--- a/models/commons/src/price-tier/transformers.ts
+++ b/models/commons/src/price-tier/transformers.ts
@@ -1,0 +1,19 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type { TPriceTier, TPriceTierGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TPriceTier, TPriceTier>('default', {
+    buildFields: ['value'],
+  }),
+  rest: Transformer<TPriceTier, TPriceTier>('rest', {
+    buildFields: ['value'],
+  }),
+  graphql: Transformer<TPriceTier, TPriceTierGraphql>('graphql', {
+    buildFields: ['value'],
+    addFields: () => ({
+      __typename: 'ProductPriceTier',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/commons/src/price-tier/types.ts
+++ b/models/commons/src/price-tier/types.ts
@@ -1,0 +1,17 @@
+import { PriceTier, PriceTierDraft } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@commercetools-test-data/core';
+
+export type TPriceTier = PriceTier;
+export type TPriceTierDraft = PriceTierDraft;
+
+export type TPriceTierGraphql = TPriceTier & {
+  __typename: 'ProductPriceTier';
+};
+export type TPriceTierDraftGraphql = TPriceTierDraft & {
+  __typename: 'ProductPriceTierInput';
+};
+
+export type TPriceTierBuilder = TBuilder<TPriceTier>;
+export type TPriceTierDraftBuilder = TBuilder<TPriceTierDraft>;
+export type TCreatePriceTierBuilder = () => TPriceTierBuilder;
+export type TCreatePriceTierDraftBuilder = () => TPriceTierDraftBuilder;

--- a/models/standalone-price/LICENSE
+++ b/models/standalone-price/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) commercetools GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/models/standalone-price/README.md
+++ b/models/standalone-price/README.md
@@ -1,0 +1,25 @@
+# @commercetools-test-data/standalone-price
+
+This package provides the data model for the commercetools platform `StandalonePrice` type
+
+https://docs.commercetools.com/api/projects/standalone-prices
+
+# Install
+
+```bash
+$ yarn add -D @commercetools-test-data/standalone-price
+```
+
+# Usage
+
+```ts
+import type {
+  TStandalonePrice,
+  TStandalonePriceDraft,
+} from '@commercetools-test-data/standalone-price';
+import * as StandalonePrice from '@commercetools-test-data/standalone-price';
+
+const standalonePrice = StandalonePrice.random().build<TStandalonePrice>();
+const standalonePriceDraft =
+  StandalonePrice.StandalonePriceDraft.random().build<TStandalonePriceDraft>();
+```

--- a/models/standalone-price/package.json
+++ b/models/standalone-price/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/standalone-price",
-  "version": "4.4.0",
+  "version": "6.11.0",
   "description": "Data model for commercetools API StandalonePrice",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {

--- a/models/standalone-price/package.json
+++ b/models/standalone-price/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@commercetools-test-data/standalone-price",
+  "version": "4.4.0",
+  "description": "Data model for commercetools API StandalonePrice",
+  "bugs": "https://github.com/commercetools/test-data/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/test-data.git",
+    "directory": "models/standalone-price"
+  },
+  "keywords": ["javascript", "typescript", "test-data"],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/commercetools-test-data-standalone-price.cjs.js",
+  "module": "dist/commercetools-test-data-standalone-price.esm.js",
+  "files": ["dist", "package.json", "LICENSE", "README.md"],
+  "dependencies": {
+    "@babel/runtime": "^7.17.9",
+    "@babel/runtime-corejs3": "^7.17.9",
+    "@commercetools-test-data/commons": "6.11.0",
+    "@commercetools-test-data/core": "6.11.0",
+    "@commercetools-test-data/utils": "6.11.0",
+    "@commercetools-test-data/customer-group": "6.11.0",
+    "@commercetools-test-data/channel": "6.11.0",
+    "@commercetools/platform-sdk": "^7.0.0",
+    "@faker-js/faker": "^7.4.0"
+  }
+}

--- a/models/standalone-price/src/builder.spec.ts
+++ b/models/standalone-price/src/builder.spec.ts
@@ -2,7 +2,7 @@
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TStandalonePrice, TStandalonePriceGraphql } from './types';
-import * as StandalonePrice from '.';
+import { StandalonePrice } from '.';
 
 describe('builder', () => {
   it(

--- a/models/standalone-price/src/builder.spec.ts
+++ b/models/standalone-price/src/builder.spec.ts
@@ -1,0 +1,171 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TStandalonePrice, TStandalonePriceGraphql } from './types';
+import * as StandalonePrice from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TStandalonePrice, TStandalonePrice>(
+      'default',
+      StandalonePrice.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        createdAt: expect.any(String),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          anonymousId: expect.any(String),
+        }),
+        createdBy: expect.objectContaining({
+          anonymousId: expect.any(String),
+        }),
+        key: expect.any(String),
+        sku: expect.any(String),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+        country: expect.any(String),
+        customerGroup: expect.objectContaining({
+          id: expect.any(String),
+          key: expect.any(String),
+        }),
+        channel: expect.objectContaining({
+          id: expect.any(String),
+          key: expect.any(String),
+        }),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        tiers: expect.arrayContaining([
+          expect.objectContaining({
+            minimumQuantity: expect.any(Number),
+            value: expect.objectContaining({
+              type: 'centPrecision',
+              currencyCode: expect.any(String),
+              centAmount: expect.any(Number),
+              fractionDigits: expect.any(Number),
+            }),
+          }),
+        ]),
+        discounted: null,
+        staged: null,
+        active: expect.any(Boolean),
+        expiresAt: expect.any(String),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TStandalonePrice, TStandalonePrice>(
+      'rest',
+      StandalonePrice.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        createdAt: expect.any(String),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          anonymousId: expect.any(String),
+        }),
+        createdBy: expect.objectContaining({
+          anonymousId: expect.any(String),
+        }),
+        key: expect.any(String),
+        sku: expect.any(String),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+        country: expect.any(String),
+        customerGroup: expect.objectContaining({
+          typeId: 'customer-group',
+        }),
+        channel: expect.objectContaining({
+          typeId: 'channel',
+        }),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        tiers: expect.arrayContaining([
+          expect.objectContaining({
+            minimumQuantity: expect.any(Number),
+            value: expect.objectContaining({
+              type: 'centPrecision',
+              currencyCode: expect.any(String),
+              centAmount: expect.any(Number),
+              fractionDigits: expect.any(Number),
+            }),
+          }),
+        ]),
+        discounted: null,
+        staged: null,
+        active: expect.any(Boolean),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TStandalonePrice, TStandalonePriceGraphql>(
+      'graphql',
+      StandalonePrice.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        createdAt: expect.any(String),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          anonymousId: expect.any(String),
+        }),
+        createdBy: expect.objectContaining({
+          anonymousId: expect.any(String),
+        }),
+        key: expect.any(String),
+        sku: expect.any(String),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+        country: expect.any(String),
+        customerGroup: expect.objectContaining({
+          id: expect.any(String),
+          key: expect.any(String),
+        }),
+        channel: expect.objectContaining({
+          id: expect.any(String),
+          key: expect.any(String),
+        }),
+        customerGroupRef: expect.objectContaining({
+          typeId: 'customer-group',
+          key: expect.any(String),
+        }),
+        channelRef: expect.objectContaining({
+          typeId: 'channel',
+          key: expect.any(String),
+        }),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        tiers: expect.arrayContaining([
+          expect.objectContaining({
+            minimumQuantity: expect.any(Number),
+            value: expect.objectContaining({
+              type: 'centPrecision',
+              currencyCode: expect.any(String),
+              centAmount: expect.any(Number),
+              fractionDigits: expect.any(Number),
+            }),
+          }),
+        ]),
+        discounted: null,
+        staged: null,
+        active: expect.any(Boolean),
+        __typename: 'StandalonePrice',
+      })
+    )
+  );
+});

--- a/models/standalone-price/src/builder.ts
+++ b/models/standalone-price/src/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type { TStandalonePrice, TCreateStandalonePriceBuilder } from './types';
+
+const Model: TCreateStandalonePriceBuilder = () =>
+  Builder<TStandalonePrice>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/standalone-price/src/generator.ts
+++ b/models/standalone-price/src/generator.ts
@@ -1,0 +1,40 @@
+import { Channel } from '@commercetools-test-data/channel';
+import {
+  ClientLogging,
+  PriceTier,
+  CentPrecisionMoney,
+} from '@commercetools-test-data/commons';
+import { Generator, fake, sequence } from '@commercetools-test-data/core';
+import { CustomerGroup } from '@commercetools-test-data/customer-group';
+import { createRelatedDates } from '@commercetools-test-data/utils';
+import { TStandalonePrice } from './types';
+
+// https://docs.commercetools.com/api/projects/standalone-prices#standaloneprice
+
+const [getCreatedAt, getLastModifiedAt, getExpiresAt] = createRelatedDates();
+
+const generator = Generator<TStandalonePrice>({
+  fields: {
+    id: fake((f) => f.string.alphanumeric(10)),
+    version: sequence(),
+    createdAt: fake(getCreatedAt),
+    lastModifiedAt: fake(getLastModifiedAt),
+    lastModifiedBy: fake(() => ClientLogging.random()),
+    createdBy: fake(() => ClientLogging.random()),
+    key: fake((f) => f.string.alphanumeric(10)),
+    sku: fake((f) => `${f.lorem.word()}-${f.string.alphanumeric(3)}`),
+    value: fake(() => CentPrecisionMoney.random()),
+    country: fake((f) => f.location.countryCode()),
+    customerGroup: fake(() => CustomerGroup.random()),
+    channel: fake(() => Channel.random()),
+    validFrom: fake(getCreatedAt),
+    validUntil: fake(getExpiresAt),
+    tiers: [fake(() => PriceTier.random())],
+    discounted: null,
+    staged: null,
+    active: fake((f) => f.datatype.boolean()),
+    expiresAt: fake(getExpiresAt),
+  },
+});
+
+export default generator;

--- a/models/standalone-price/src/index.ts
+++ b/models/standalone-price/src/index.ts
@@ -1,3 +1,6 @@
+export * as StandalonePriceDraft from './standalone-price-draft';
+export * as StandalonePrice from '.';
+
 export { default as random } from './builder';
 export { default as presets } from './presets';
 export * from './types';

--- a/models/standalone-price/src/index.ts
+++ b/models/standalone-price/src/index.ts
@@ -1,0 +1,3 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+export * from './types';

--- a/models/standalone-price/src/presets/index.ts
+++ b/models/standalone-price/src/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/standalone-price/src/standalone-price-draft/builder.spec.ts
+++ b/models/standalone-price/src/standalone-price-draft/builder.spec.ts
@@ -1,0 +1,128 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TStandalonePriceDraft, TStandalonePriceDraftGraphql } from '../types';
+import * as StandalonePriceDraft from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TStandalonePriceDraft, TStandalonePriceDraft>(
+      'default',
+      StandalonePriceDraft.random(),
+      expect.objectContaining({
+        key: expect.any(String),
+        sku: expect.any(String),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+        country: expect.any(String),
+        customerGroup: expect.objectContaining({
+          typeId: 'customer-group',
+        }),
+        channel: expect.objectContaining({
+          typeId: 'channel',
+        }),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        tiers: expect.arrayContaining([
+          expect.objectContaining({
+            minimumQuantity: expect.any(Number),
+            value: expect.objectContaining({
+              type: 'centPrecision',
+              currencyCode: expect.any(String),
+              centAmount: expect.any(Number),
+              fractionDigits: expect.any(Number),
+            }),
+          }),
+        ]),
+        discounted: null,
+        staged: null,
+        active: expect.any(Boolean),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TStandalonePriceDraft, TStandalonePriceDraft>(
+      'rest',
+      StandalonePriceDraft.random(),
+      expect.objectContaining({
+        key: expect.any(String),
+        sku: expect.any(String),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+        country: expect.any(String),
+        customerGroup: expect.objectContaining({
+          typeId: 'customer-group',
+        }),
+        channel: expect.objectContaining({
+          typeId: 'channel',
+        }),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        tiers: expect.arrayContaining([
+          expect.objectContaining({
+            minimumQuantity: expect.any(Number),
+            value: expect.objectContaining({
+              type: 'centPrecision',
+              currencyCode: expect.any(String),
+              centAmount: expect.any(Number),
+              fractionDigits: expect.any(Number),
+            }),
+          }),
+        ]),
+        discounted: null,
+        staged: null,
+        active: expect.any(Boolean),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TStandalonePriceDraft, TStandalonePriceDraftGraphql>(
+      'graphql',
+      StandalonePriceDraft.random(),
+      expect.objectContaining({
+        key: expect.any(String),
+        sku: expect.any(String),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+        country: expect.any(String),
+        customerGroup: expect.objectContaining({
+          typeId: 'customer-group',
+        }),
+        channel: expect.objectContaining({
+          typeId: 'channel',
+        }),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        tiers: expect.arrayContaining([
+          expect.objectContaining({
+            minimumQuantity: expect.any(Number),
+            value: expect.objectContaining({
+              type: 'centPrecision',
+              currencyCode: expect.any(String),
+              centAmount: expect.any(Number),
+              fractionDigits: expect.any(Number),
+            }),
+          }),
+        ]),
+        discounted: null,
+        staged: null,
+        active: expect.any(Boolean),
+        __typename: 'CreateStandalonePrice',
+      })
+    )
+  );
+});

--- a/models/standalone-price/src/standalone-price-draft/builder.spec.ts
+++ b/models/standalone-price/src/standalone-price-draft/builder.spec.ts
@@ -2,7 +2,7 @@
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TStandalonePriceDraft, TStandalonePriceDraftGraphql } from '../types';
-import * as StandalonePriceDraft from '.';
+import { StandalonePriceDraft } from '..';
 
 describe('builder', () => {
   it(

--- a/models/standalone-price/src/standalone-price-draft/builder.ts
+++ b/models/standalone-price/src/standalone-price-draft/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type {
+  TCreateStandalonePriceDraftBuilder,
+  TStandalonePriceDraft,
+} from '../types';
+
+const Model: TCreateStandalonePriceDraftBuilder = () =>
+  Builder<TStandalonePriceDraft>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/standalone-price/src/standalone-price-draft/generator.ts
+++ b/models/standalone-price/src/standalone-price-draft/generator.ts
@@ -1,0 +1,31 @@
+import {
+  PriceTierDraft,
+  KeyReference,
+  CentPrecisionMoneyDraft,
+} from '@commercetools-test-data/commons';
+import { fake, Generator } from '@commercetools-test-data/core';
+import { createRelatedDates } from '@commercetools-test-data/utils';
+import { TStandalonePriceDraft } from '../types';
+
+// https://docs.commercetools.com/api/projects/standalone-prices#standalonepricedraft
+
+const [getValidFrom, getValidUntil] = createRelatedDates();
+
+const generator = Generator<TStandalonePriceDraft>({
+  fields: {
+    key: fake((f) => f.string.alphanumeric(10)),
+    sku: fake((f) => `${f.lorem.word()}-${f.string.alphanumeric(3)}`),
+    value: fake(() => CentPrecisionMoneyDraft.random()),
+    country: fake((f) => f.location.countryCode()),
+    customerGroup: fake(() => KeyReference.presets.customerGroup()),
+    channel: fake(() => KeyReference.presets.channel()),
+    validFrom: fake(getValidFrom),
+    validUntil: fake(getValidUntil),
+    tiers: [fake(() => PriceTierDraft.random())],
+    discounted: null,
+    staged: null,
+    active: fake((f) => f.datatype.boolean()),
+  },
+});
+
+export default generator;

--- a/models/standalone-price/src/standalone-price-draft/index.ts
+++ b/models/standalone-price/src/standalone-price-draft/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/standalone-price/src/standalone-price-draft/presets/index.ts
+++ b/models/standalone-price/src/standalone-price-draft/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/standalone-price/src/standalone-price-draft/transformers.ts
+++ b/models/standalone-price/src/standalone-price-draft/transformers.ts
@@ -1,0 +1,24 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type {
+  TStandalonePriceDraft,
+  TStandalonePriceDraftGraphql,
+} from '../types';
+
+const transformers = {
+  default: Transformer<TStandalonePriceDraft, TStandalonePriceDraft>(
+    'default',
+    { buildFields: ['value', 'customerGroup', 'channel', 'tiers'] }
+  ),
+  rest: Transformer<TStandalonePriceDraft, TStandalonePriceDraft>('rest', {
+    buildFields: ['value', 'customerGroup', 'channel', 'tiers'],
+  }),
+  graphql: Transformer<TStandalonePriceDraft, TStandalonePriceDraftGraphql>(
+    'graphql',
+    {
+      buildFields: ['value', 'customerGroup', 'channel', 'tiers'],
+      addFields: () => ({ __typename: 'CreateStandalonePrice' }),
+    }
+  ),
+};
+
+export default transformers;

--- a/models/standalone-price/src/transformers.ts
+++ b/models/standalone-price/src/transformers.ts
@@ -1,0 +1,116 @@
+import {
+  Reference,
+  KeyReference,
+  TReference,
+  TReferenceGraphql,
+} from '@commercetools-test-data/commons';
+import { Transformer } from '@commercetools-test-data/core';
+import { type TCustomerGroup } from '@commercetools-test-data/customer-group';
+import type {
+  TStandalonePrice,
+  TStandalonePriceGraphql,
+  TStandalonePriceRest,
+} from './types';
+
+// Overloads
+function createCustomerGroupReference(
+  customerGroup: TCustomerGroup,
+  target: 'rest'
+): TReference<'customer-group'>;
+function createCustomerGroupReference(
+  customerGroup: TCustomerGroup,
+  target: 'graphql'
+): TReferenceGraphql<'customer-group'>;
+
+// Create a customer group reference depending on `id` or `key` field availability
+function createCustomerGroupReference(
+  customerGroup: TCustomerGroup,
+  target: 'graphql' | 'rest'
+) {
+  let referenceBuilder;
+
+  // `key` is optional in CustomerGroup, prioritize it over `id`
+  if (customerGroup.key) {
+    referenceBuilder = KeyReference.random()
+      .typeId('customer-group')
+      .key(customerGroup.key);
+  } else if (customerGroup.id) {
+    referenceBuilder = Reference.random()
+      .typeId('customer-group')
+      .id(customerGroup.id);
+  }
+
+  // Dynamically call buildRest or buildGraphql based on target
+  if (referenceBuilder) {
+    return target === 'rest'
+      ? referenceBuilder.buildRest<TReference<'customer-group'>>()
+      : referenceBuilder.buildGraphql<TReferenceGraphql<'customer-group'>>();
+  }
+}
+
+const transformers = {
+  default: Transformer<TStandalonePrice, TStandalonePrice>('default', {
+    buildFields: [
+      'lastModifiedBy',
+      'createdBy',
+      'value',
+      'customerGroup',
+      'channel',
+      'tiers',
+    ],
+  }),
+  rest: Transformer<TStandalonePrice, TStandalonePriceRest>('rest', {
+    buildFields: [
+      'lastModifiedBy',
+      'createdBy',
+      'value',
+      'customerGroup',
+      'channel',
+      'tiers',
+    ],
+    replaceFields: ({ fields }) => {
+      // Remove `expiresAt` from the fields
+      const { expiresAt, ...rest } = fields;
+
+      const channel = fields.channel
+        ? KeyReference.random()
+            .typeId('channel')
+            .key(fields.channel.key)
+            .buildRest<TReference<'channel'>>()
+        : undefined;
+
+      return {
+        ...rest,
+        customerGroup: fields.customerGroup
+          ? createCustomerGroupReference(fields.customerGroup, 'rest')
+          : undefined,
+        channel,
+      };
+    },
+  }),
+  graphql: Transformer<TStandalonePrice, TStandalonePriceGraphql>('graphql', {
+    buildFields: [
+      'lastModifiedBy',
+      'createdBy',
+      'value',
+      'customerGroup',
+      'channel',
+      'tiers',
+    ],
+    addFields: ({ fields }) => {
+      const customerGroupRef = fields.customerGroup
+        ? createCustomerGroupReference(fields.customerGroup, 'graphql')
+        : null;
+      const channelRef = fields.channel
+        ? KeyReference.random()
+            .typeId('channel')
+            .key(fields.channel.key)
+            .buildGraphql<TReferenceGraphql<'channel'>>()
+        : null;
+
+      return { __typename: 'StandalonePrice', customerGroupRef, channelRef };
+    },
+  }),
+};
+
+export default transformers;

--- a/models/standalone-price/src/types.ts
+++ b/models/standalone-price/src/types.ts
@@ -1,0 +1,39 @@
+import {
+  StandalonePrice,
+  StandalonePriceDraft,
+  CustomerGroup,
+  Channel,
+} from '@commercetools/platform-sdk';
+import { TReferenceGraphql } from '@commercetools-test-data/commons';
+import type { TBuilder } from '@commercetools-test-data/core';
+
+// Base representation
+export type TStandalonePrice = Omit<
+  StandalonePrice,
+  'customerGroup' | 'channel'
+> & {
+  customerGroup: CustomerGroup | null;
+  channel: Channel | null;
+  expiresAt: string | null;
+};
+
+// REST representation
+export type TStandalonePriceRest = StandalonePrice;
+export type TStandalonePriceDraft = StandalonePriceDraft;
+
+// Graphql representation
+export type TStandalonePriceGraphql = TStandalonePrice & {
+  customerGroupRef: TReferenceGraphql | null;
+  channelRef: TReferenceGraphql | null;
+  expiresAt: TStandalonePrice['expiresAt'];
+  __typename: 'StandalonePrice';
+};
+export type TStandalonePriceDraftGraphql = StandalonePriceDraft & {
+  __typename: 'CreateStandalonePrice';
+};
+
+export type TStandalonePriceBuilder = TBuilder<TStandalonePrice>;
+export type TStandalonePriceDraftBuilder = TBuilder<StandalonePriceDraft>;
+export type TCreateStandalonePriceBuilder = () => TStandalonePriceBuilder;
+export type TCreateStandalonePriceDraftBuilder =
+  () => TStandalonePriceDraftBuilder;

--- a/models/standalone-price/src/types.ts
+++ b/models/standalone-price/src/types.ts
@@ -25,7 +25,6 @@ export type TStandalonePriceDraft = StandalonePriceDraft;
 export type TStandalonePriceGraphql = TStandalonePrice & {
   customerGroupRef: TReferenceGraphql | null;
   channelRef: TReferenceGraphql | null;
-  expiresAt: TStandalonePrice['expiresAt'];
   __typename: 'StandalonePrice';
 };
 export type TStandalonePriceDraftGraphql = StandalonePriceDraft & {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -887,6 +887,36 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
 
+  models/standalone-price:
+    dependencies:
+      '@babel/runtime':
+        specifier: ^7.17.9
+        version: 7.23.4
+      '@babel/runtime-corejs3':
+        specifier: ^7.17.9
+        version: 7.23.4
+      '@commercetools-test-data/channel':
+        specifier: 6.11.0
+        version: link:../channel
+      '@commercetools-test-data/commons':
+        specifier: 6.11.0
+        version: link:../commons
+      '@commercetools-test-data/core':
+        specifier: 6.11.0
+        version: link:../../core
+      '@commercetools-test-data/customer-group':
+        specifier: 6.11.0
+        version: link:../customer-group
+      '@commercetools-test-data/utils':
+        specifier: 6.11.0
+        version: link:../../utils
+      '@commercetools/platform-sdk':
+        specifier: ^7.0.0
+        version: 7.0.0
+      '@faker-js/faker':
+        specifier: ^7.4.0
+        version: 7.6.0
+
   models/state:
     dependencies:
       '@babel/runtime':
@@ -3486,6 +3516,11 @@ packages:
   /@eslint/js@8.56.0:
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
+
+  /@faker-js/faker@7.6.0:
+    resolution: {integrity: sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
     dev: false
 
   /@faker-js/faker@8.0.0:

--- a/schemas/settings.json
+++ b/schemas/settings.json
@@ -730,8 +730,8 @@
           {
             "name": "MachineLearning",
             "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "The machine learning APIs are not available anymore."
           },
           {
             "name": "ProductType",
@@ -3704,6 +3704,144 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "CustomViewQueryInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "limit",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "offset",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sort",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomViewQueryWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CustomViewQueryWhereInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "defaultLabel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "locators",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "CustomViewType",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "CustomViewSize",
         "description": null,
@@ -3809,6 +3947,105 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CustomViewsPagedQueryResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "offset",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "results",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CustomView",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -10325,6 +10562,303 @@
       },
       {
         "kind": "OBJECT",
+        "name": "MyCustomView",
+        "description": null,
+        "fields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "defaultLabel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labelAllLocales",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "LocalizedField",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "locators",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "permissions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CustomViewPermission",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CustomViewStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CustomViewType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "typeSettings",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CustomViewTypeSettings",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "MyCustomViewsQueryInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "MyCustomViewsQueryWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "MyCustomViewsQueryWhereInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "CustomViewStatus",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "NavbarMenu",
         "description": null,
         "fields": [
@@ -12113,6 +12647,73 @@
       },
       {
         "kind": "OBJECT",
+        "name": "OrganizationExtensionForCustomView",
+        "description": null,
+        "fields": [
+          {
+            "name": "customView",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "RestrictedCustomViewForOrganization",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "PimSearchListView",
         "description": null,
         "fields": [
@@ -12127,6 +12728,30 @@
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expandedRows",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -12296,6 +12921,26 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "expandedRows",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "filters",
             "description": null,
@@ -13865,6 +14510,35 @@
             "deprecationReason": "Experimental feature - For internal usage only"
           },
           {
+            "name": "allCustomViews",
+            "description": null,
+            "args": [
+              {
+                "name": "params",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CustomViewQueryInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CustomViewsPagedQueryResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Experimental feature - For internal usage only"
+          },
+          {
             "name": "allCustomViewsInstallationsByLocator",
             "description": null,
             "args": [
@@ -14487,6 +15161,43 @@
             "deprecationReason": null
           },
           {
+            "name": "myCustomViews",
+            "description": null,
+            "args": [
+              {
+                "name": "params",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MyCustomViewsQueryInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MyCustomView",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "orderDetailView",
             "description": null,
             "args": [
@@ -14637,6 +15348,35 @@
             "type": {
               "kind": "OBJECT",
               "name": "OrganizationExtensionForCustomApplication",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationExtensionForCustomView",
+            "description": null,
+            "args": [
+              {
+                "name": "customViewId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "OrganizationExtensionForCustomView",
               "ofType": null
             },
             "isDeprecated": false,


### PR DESCRIPTION
## Summary

This PR creates the `StandalonePrice` model and associated draft for use with our B2B dataset support effort.

[Standalone prices REST documentation](https://docs.commercetools.com/api/projects/standalone-prices#standalonepricedraft)

**Graphql structure:**
Base model:
![image](https://github.com/commercetools/test-data/assets/15024562/7b8b3961-2ea7-4c55-aace-c8ac8ce68ede)
Draft model:
![image](https://github.com/commercetools/test-data/assets/15024562/04507a03-8d6f-453b-b555-7274f6d81a41)

