### PR TITLE
chore: remove pangolin from models catch-all ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /codegen* @commercetools/shield-team-fe
 
 # Models
-/models @commercetools/merchant-center-tech-leadership @commercetools/pangolin-team-fe
+/models @commercetools/merchant-center-tech-leadership
 
 /models/associate-role @commercetools/customers-team-fe
 /models/business-unit @commercetools/customers-team-fe


### PR DESCRIPTION
The Pangolin team isn't responsible for shared tooling and can't reliably devote time to this. However, if the goal is to properly assign ownership to the right team when changes are made, it seems like that should be directed by tech leadership with more granular code ownership assignments. Ideally, any time a new model is added or an existing, unowned model is updated, `CODEOWNERS` should be updated to reflect the correct team at that time, and we can't really make that call.