### PR TITLE
FCT 598: Omit `__typename` field when building graphql draft models

### DIFF
--- a/.changeset/unlucky-phones-repair.md
+++ b/.changeset/unlucky-phones-repair.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/core': minor
+---
+
+"fix(graphql drafts): omit \_\_typename field from built graphql draft models when isGraphqlDraft option is passed to transformer"

--- a/core/src/builder.spec.ts
+++ b/core/src/builder.spec.ts
@@ -506,6 +506,49 @@ describe('building', () => {
               ],
             });
           });
+          it('should omit __typename field when building nested builders and isGraphqlDraft is true', () => {
+            const teamTransformers = {
+              graphql: Transformer<TestTeam, TestTeam>('graphql', {
+                buildFields: ['users'],
+                isGraphqlDraft: true,
+              }),
+            };
+            const userTransformers = {
+              graphql: Transformer<
+                TestExpandedUserReference,
+                TestExpandedUserReferenceGraphql
+              >('graphql', {
+                addFields: () => ({
+                  __typename: 'User',
+                }),
+                isGraphqlDraft: true,
+              }),
+            };
+            const userBuilder1 = Builder<TestExpandedUserReference>({
+              transformers: userTransformers,
+            }).name('My name');
+            const userBuilder2 = Builder<TestExpandedUserReference>({
+              transformers: userTransformers,
+            }).name('My other name');
+            const built = Builder<TestTeam>({
+              transformers: teamTransformers,
+            })
+              .id('my-id')
+              .users<TestExpandedUserReference>([userBuilder1, userBuilder2])
+              .buildGraphql<TestTeam>();
+
+            expect(built).toEqual({
+              id: 'my-id',
+              users: [
+                {
+                  name: 'My name',
+                },
+                {
+                  name: 'My other name',
+                },
+              ],
+            });
+          });
         });
       });
     });

--- a/core/src/helpers.ts
+++ b/core/src/helpers.ts
@@ -28,6 +28,33 @@ const upperFirst = (value: string): string =>
 const lowerFirst = (value: string): string =>
   value.charAt(0).toLowerCase() + value.slice(1);
 
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+function deleteKeyFromObject(inputObject: any, keyToDelete: string) {
+  for (let [currentObjectKey, currentObjectValue] of Object.entries(
+    inputObject
+  )) {
+    if (currentObjectKey === keyToDelete) {
+      delete inputObject[keyToDelete];
+    } else if (Array.isArray(currentObjectValue)) {
+      deleteKeyFromObjectInArray(currentObjectValue, keyToDelete);
+    } else if (isObject(currentObjectValue)) {
+      deleteKeyFromObject(currentObjectValue, keyToDelete);
+    }
+  }
+}
+
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+function deleteKeyFromObjectInArray(inputArray: any[], keyToDelete: string) {
+  for (let currentIndex = 0; currentIndex < inputArray.length; currentIndex++) {
+    let currentElement = inputArray[currentIndex];
+    if (Array.isArray(currentElement)) {
+      deleteKeyFromObjectInArray(currentElement, keyToDelete);
+    } else if (isObject(currentElement)) {
+      deleteKeyFromObject(currentElement, keyToDelete);
+    }
+  }
+}
+
 const omitOne = <T, K extends keyof T>(entity: T, prop: K): Omit<T, K> => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { [prop]: deleted, ...newState } = entity;
@@ -175,6 +202,7 @@ export {
   isBuilderFunction,
   upperFirst,
   lowerFirst,
+  deleteKeyFromObject,
   omitMany,
   pickMany,
   convertBuiltNameToTransformName,

--- a/core/src/transformer.ts
+++ b/core/src/transformer.ts
@@ -1,4 +1,4 @@
-import { buildField, buildFields } from './helpers';
+import { buildField, buildFields, deleteKeyFromObject } from './helpers';
 import type {
   TTransformer,
   TTransformerOptions,
@@ -36,6 +36,11 @@ function Transformer<Model, TransformedModel>(
           };
         }
       });
+
+      if (transformOptions?.isGraphqlDraft) {
+        /**recursively delete '__typename' field from all built fields in graphql draft */
+        deleteKeyFromObject(transformedFields, '__typename');
+      }
     }
 
     // The default transformer only allows building nested fields to not

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -50,6 +50,11 @@ export type TTransformerOptions<Model, TransformedModel> = {
   removeFields?: (keyof Model)[];
   replaceFields?: (args: { fields: Model }) => TransformedModel;
   buildFields?: (keyof Model)[];
+  /** When transforming fields for GraphQL draft models,
+   * this flag removes all "__typename" fields from transformed models
+   * so that the draft can be used with the API
+   */
+  isGraphqlDraft?: Boolean;
 };
 
 export interface TTransformer<Model> {


### PR DESCRIPTION
When transforming fields for graphql draft models, built fields will add a `__typename` field, which is not a valid field to send in a draft and makes API's very sad and send us a 400.

This PR implements an `isGraphqlDraft` option that can be passed to the `Transformer` function.  When this option is passed, all `__typename` fields are removed from the transformed model so that the model can be used directly as a draft.

For a more in depth walkthrough and explanation of this code, see [this previous PR](https://github.com/commercetools/test-data/pull/444).