### PR TITLE
feat(order): add orderFromQuoteDraft model

### DIFF
--- a/.changeset/slimy-rocks-refuse.md
+++ b/.changeset/slimy-rocks-refuse.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/order': minor
+---
+
+Adds the `OrderFromQuoteDraft` model.

--- a/models/order/README.md
+++ b/models/order/README.md
@@ -16,11 +16,15 @@ $ pnpm add -D @commercetools-test-data/order
 import {
   Order,
   OrderFromCartDraft,
+  OrderFromQuoteDraft,
   type TOrder,
   type TOrderFromCartDraft,
+  type TOrderFromQuoteDraft,
 } from '@commercetools-test-data/order';
 
 const order = Order.random().build<TOrder>();
 const orderFromCartDraft =
   OrderFromCartDraft.random().build<TOrderFromCartDraft>();
+const orderFromQuoteDraft =
+  OrderFromQuoteDraft.random().build<TOrderFromQuoteDraft>();
 ```

--- a/models/order/src/order-from-quote-draft/builder.spec.ts
+++ b/models/order/src/order-from-quote-draft/builder.spec.ts
@@ -1,0 +1,75 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import type {
+  TOrderFromQuoteDraft,
+  TOrderFromQuoteDraftGraphql,
+} from '../types';
+import * as OrderFromQuoteDraftDraft from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TOrderFromQuoteDraft, TOrderFromQuoteDraft>(
+      'default',
+      OrderFromQuoteDraftDraft.random(),
+      expect.objectContaining({
+        version: expect.any(Number),
+        quote: expect.objectContaining({
+          typeId: 'quote',
+        }),
+        quoteStateToAccepted: false,
+        orderNumber: expect.any(String),
+        paymentState: expect.any(String),
+        shipmentState: expect.any(String),
+        orderState: expect.any(String),
+        state: expect.objectContaining({
+          typeId: 'state',
+        }),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TOrderFromQuoteDraft, TOrderFromQuoteDraft>(
+      'rest',
+      OrderFromQuoteDraftDraft.random(),
+      expect.objectContaining({
+        version: expect.any(Number),
+        quote: expect.objectContaining({
+          typeId: 'quote',
+        }),
+        quoteStateToAccepted: false,
+        orderNumber: expect.any(String),
+        paymentState: expect.any(String),
+        shipmentState: expect.any(String),
+        orderState: expect.any(String),
+        state: expect.objectContaining({
+          typeId: 'state',
+        }),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TOrderFromQuoteDraft, TOrderFromQuoteDraftGraphql>(
+      'graphql',
+      OrderFromQuoteDraftDraft.random(),
+      expect.objectContaining({
+        version: expect.any(Number),
+        quote: expect.objectContaining({
+          typeId: 'quote',
+          __typename: 'Reference',
+        }),
+        quoteStateToAccepted: false,
+        orderNumber: expect.any(String),
+        paymentState: expect.any(String),
+        shipmentState: expect.any(String),
+        orderState: expect.any(String),
+        state: expect.objectContaining({
+          typeId: 'state',
+          __typename: 'Reference',
+        }),
+      })
+    )
+  );
+});

--- a/models/order/src/order-from-quote-draft/builder.spec.ts
+++ b/models/order/src/order-from-quote-draft/builder.spec.ts
@@ -58,7 +58,6 @@ describe('builder', () => {
         version: expect.any(Number),
         quote: expect.objectContaining({
           typeId: 'quote',
-          __typename: 'Reference',
         }),
         quoteStateToAccepted: expect.any(Boolean),
         orderNumber: expect.any(String),
@@ -67,7 +66,6 @@ describe('builder', () => {
         orderState: expect.any(String),
         state: expect.objectContaining({
           typeId: 'state',
-          __typename: 'Reference',
         }),
       })
     )

--- a/models/order/src/order-from-quote-draft/builder.spec.ts
+++ b/models/order/src/order-from-quote-draft/builder.spec.ts
@@ -17,7 +17,7 @@ describe('builder', () => {
         quote: expect.objectContaining({
           typeId: 'quote',
         }),
-        quoteStateToAccepted: false,
+        quoteStateToAccepted: expect.any(Boolean),
         orderNumber: expect.any(String),
         paymentState: expect.any(String),
         shipmentState: expect.any(String),
@@ -38,7 +38,7 @@ describe('builder', () => {
         quote: expect.objectContaining({
           typeId: 'quote',
         }),
-        quoteStateToAccepted: false,
+        quoteStateToAccepted: expect.any(Boolean),
         orderNumber: expect.any(String),
         paymentState: expect.any(String),
         shipmentState: expect.any(String),
@@ -60,7 +60,7 @@ describe('builder', () => {
           typeId: 'quote',
           __typename: 'Reference',
         }),
-        quoteStateToAccepted: false,
+        quoteStateToAccepted: expect.any(Boolean),
         orderNumber: expect.any(String),
         paymentState: expect.any(String),
         shipmentState: expect.any(String),

--- a/models/order/src/order-from-quote-draft/builder.ts
+++ b/models/order/src/order-from-quote-draft/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import type {
+  TOrderFromQuoteDraft,
+  TCreateOrderFromQuoteDraftBuilder,
+} from '../types';
+import generator from './generator';
+import transformers from './transformers';
+
+const Model: TCreateOrderFromQuoteDraftBuilder = () =>
+  Builder<TOrderFromQuoteDraft>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/order/src/order-from-quote-draft/generator.ts
+++ b/models/order/src/order-from-quote-draft/generator.ts
@@ -1,0 +1,26 @@
+import { Reference } from '@commercetools-test-data/commons';
+import {
+  fake,
+  Generator,
+  oneOf,
+  sequence,
+} from '@commercetools-test-data/core';
+import { orderState, paymentState, shipmentState } from '../constants';
+import { TOrderFromQuoteDraft } from '../types';
+
+// https://docs.commercetools.com/api/projects/orders#orderfromquotedraft
+
+const generator = Generator<TOrderFromQuoteDraft>({
+  fields: {
+    version: sequence(),
+    quote: fake(() => Reference.random().typeId('quote')),
+    quoteStateToAccepted: fake(() => false),
+    orderNumber: fake((f) => String(f.number.int({ min: 100000 }))),
+    paymentState: oneOf(...Object.values(paymentState)),
+    shipmentState: oneOf(...Object.values(shipmentState)),
+    orderState: oneOf(...Object.values(orderState)),
+    state: fake(() => Reference.random().typeId('state')),
+  },
+});
+
+export default generator;

--- a/models/order/src/order-from-quote-draft/generator.ts
+++ b/models/order/src/order-from-quote-draft/generator.ts
@@ -14,7 +14,7 @@ const generator = Generator<TOrderFromQuoteDraft>({
   fields: {
     version: sequence(),
     quote: fake(() => Reference.random().typeId('quote')),
-    quoteStateToAccepted: fake(() => false),
+    quoteStateToAccepted: fake((f) => f.datatype.boolean()),
     orderNumber: fake((f) => String(f.number.int({ min: 100000 }))),
     paymentState: oneOf(...Object.values(paymentState)),
     shipmentState: oneOf(...Object.values(shipmentState)),

--- a/models/order/src/order-from-quote-draft/generator.ts
+++ b/models/order/src/order-from-quote-draft/generator.ts
@@ -1,4 +1,4 @@
-import { Reference } from '@commercetools-test-data/commons';
+import { ReferenceDraft } from '@commercetools-test-data/commons';
 import {
   fake,
   Generator,
@@ -13,13 +13,13 @@ import { TOrderFromQuoteDraft } from '../types';
 const generator = Generator<TOrderFromQuoteDraft>({
   fields: {
     version: sequence(),
-    quote: fake(() => Reference.random().typeId('quote')),
+    quote: fake(() => ReferenceDraft.random().typeId('quote')),
     quoteStateToAccepted: fake((f) => f.datatype.boolean()),
     orderNumber: fake((f) => String(f.number.int({ min: 100000 }))),
     paymentState: oneOf(...Object.values(paymentState)),
     shipmentState: oneOf(...Object.values(shipmentState)),
     orderState: oneOf(...Object.values(orderState)),
-    state: fake(() => Reference.random().typeId('state')),
+    state: fake(() => ReferenceDraft.random().typeId('state')),
   },
 });
 

--- a/models/order/src/order-from-quote-draft/index.ts
+++ b/models/order/src/order-from-quote-draft/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/order/src/order-from-quote-draft/presets/empty.spec.ts
+++ b/models/order/src/order-from-quote-draft/presets/empty.spec.ts
@@ -1,0 +1,18 @@
+import type { TOrderFromQuoteDraft } from '../../types';
+import empty from './empty';
+
+it(`should set the specified fields to undefined`, () => {
+  const emptyOrderFromCartDraft = empty().build<TOrderFromQuoteDraft>();
+  expect(emptyOrderFromCartDraft).toEqual({
+    quote: expect.objectContaining({
+      typeId: 'quote',
+    }),
+    version: expect.any(Number),
+    quoteStateToAccepted: undefined,
+    orderNumber: undefined,
+    paymentState: undefined,
+    shipmentState: undefined,
+    orderState: undefined,
+    state: undefined,
+  });
+});

--- a/models/order/src/order-from-quote-draft/presets/empty.ts
+++ b/models/order/src/order-from-quote-draft/presets/empty.ts
@@ -1,0 +1,13 @@
+import type { TOrderFromQuoteDraftBuilder } from '../../types';
+import OrderFromQuoteDraft from '../builder';
+
+const empty = (): TOrderFromQuoteDraftBuilder =>
+  OrderFromQuoteDraft()
+    .quoteStateToAccepted(undefined)
+    .orderNumber(undefined)
+    .paymentState(undefined)
+    .shipmentState(undefined)
+    .orderState(undefined)
+    .state(undefined);
+
+export default empty;

--- a/models/order/src/order-from-quote-draft/presets/index.ts
+++ b/models/order/src/order-from-quote-draft/presets/index.ts
@@ -1,0 +1,5 @@
+import empty from './empty';
+
+const presets = { empty };
+
+export default presets;

--- a/models/order/src/order-from-quote-draft/transformers.ts
+++ b/models/order/src/order-from-quote-draft/transformers.ts
@@ -1,0 +1,22 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type {
+  TOrderFromQuoteDraft,
+  TOrderFromQuoteDraftGraphql,
+} from '../types';
+
+const transformers = {
+  default: Transformer<TOrderFromQuoteDraft, TOrderFromQuoteDraft>('default', {
+    buildFields: ['quote', 'state'],
+  }),
+  rest: Transformer<TOrderFromQuoteDraft, TOrderFromQuoteDraft>('rest', {
+    buildFields: ['quote', 'state'],
+  }),
+  graphql: Transformer<TOrderFromQuoteDraft, TOrderFromQuoteDraftGraphql>(
+    'graphql',
+    {
+      buildFields: ['quote', 'state'],
+    }
+  ),
+};
+
+export default transformers;

--- a/models/order/src/types.ts
+++ b/models/order/src/types.ts
@@ -5,6 +5,7 @@ import {
   CustomerGroup,
   Order,
   OrderFromCartDraft,
+  OrderFromQuoteDraft,
   Quote,
   State,
   Store,
@@ -45,10 +46,16 @@ export type TOrderGraphql = TOrder & {
 };
 
 export type TOrderFromCartDraft = OrderFromCartDraft;
+export type TOrderFromQuoteDraft = OrderFromQuoteDraft;
 
 export type TOrderFromCartDraftGraphql = TOrderFromCartDraft;
+export type TOrderFromQuoteDraftGraphql = TOrderFromQuoteDraft;
 
 export type TOrderBuilder = TBuilder<TOrder>;
 export type TOrderFromCartDraftBuilder = TBuilder<TOrderFromCartDraft>;
+export type TOrderFromQuoteDraftBuilder = TBuilder<TOrderFromQuoteDraft>;
+
 export type TCreateOrderBuilder = () => TOrderBuilder;
 export type TCreateOrderFromCartDraftBuilder = () => TOrderFromCartDraftBuilder;
+export type TCreateOrderFromQuoteDraftBuilder =
+  () => TOrderFromQuoteDraftBuilder;


### PR DESCRIPTION
Adds the `OrderFromQuoteDraft` [model](https://docs.commercetools.com/api/projects/orders#orderfromquotedraft) to the Orders package.