### PR TITLE
chore(test-data): Fix `StandalonePriceDraft` GraphQL shape

### DIFF
--- a/.changeset/silent-days-fail.md
+++ b/.changeset/silent-days-fail.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/standalone-price': patch
+---
+
+Fix StandalonePriceDraft GraphQL shape

--- a/models/standalone-price/src/standalone-price-draft/builder.spec.ts
+++ b/models/standalone-price/src/standalone-price-draft/builder.spec.ts
@@ -13,10 +13,8 @@ describe('builder', () => {
         key: expect.any(String),
         sku: expect.any(String),
         value: expect.objectContaining({
-          type: 'centPrecision',
           currencyCode: expect.any(String),
           centAmount: expect.any(Number),
-          fractionDigits: expect.any(Number),
         }),
         country: expect.any(String),
         customerGroup: expect.objectContaining({
@@ -53,10 +51,8 @@ describe('builder', () => {
         key: expect.any(String),
         sku: expect.any(String),
         value: expect.objectContaining({
-          type: 'centPrecision',
           currencyCode: expect.any(String),
           centAmount: expect.any(Number),
-          fractionDigits: expect.any(Number),
         }),
         country: expect.any(String),
         customerGroup: expect.objectContaining({
@@ -93,10 +89,10 @@ describe('builder', () => {
         key: expect.any(String),
         sku: expect.any(String),
         value: expect.objectContaining({
-          type: 'centPrecision',
-          currencyCode: expect.any(String),
-          centAmount: expect.any(Number),
-          fractionDigits: expect.any(Number),
+          centPrecision: expect.objectContaining({
+            currencyCode: expect.any(String),
+            centAmount: expect.any(Number),
+          }),
         }),
         country: expect.any(String),
         customerGroup: expect.objectContaining({

--- a/models/standalone-price/src/standalone-price-draft/generator.ts
+++ b/models/standalone-price/src/standalone-price-draft/generator.ts
@@ -1,7 +1,7 @@
 import {
   PriceTierDraft,
   KeyReferenceDraft,
-  CentPrecisionMoneyDraft,
+  MoneyDraft,
 } from '@commercetools-test-data/commons';
 import { fake, Generator } from '@commercetools-test-data/core';
 import { createRelatedDates } from '@commercetools-test-data/utils';
@@ -15,7 +15,7 @@ const generator = Generator<TStandalonePriceDraft>({
   fields: {
     key: fake((f) => f.string.alphanumeric(10)),
     sku: fake((f) => `${f.lorem.word()}-${f.string.alphanumeric(3)}`),
-    value: fake(() => CentPrecisionMoneyDraft.random()),
+    value: fake(() => MoneyDraft.random()),
     country: fake((f) => f.location.countryCode()),
     customerGroup: fake(() => KeyReferenceDraft.presets.customerGroup()),
     channel: fake(() => KeyReferenceDraft.presets.channel()),

--- a/models/standalone-price/src/standalone-price-draft/transformers.ts
+++ b/models/standalone-price/src/standalone-price-draft/transformers.ts
@@ -1,3 +1,4 @@
+import { TMoneyDraftGraphql } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type {
   TStandalonePriceDraft,
@@ -16,6 +17,12 @@ const transformers = {
     'graphql',
     {
       buildFields: ['value', 'customerGroup', 'channel', 'tiers'],
+      replaceFields: ({ fields }) => ({
+        ...fields,
+        value: {
+          centPrecision: fields.value as TMoneyDraftGraphql,
+        },
+      }),
     }
   ),
 };

--- a/models/standalone-price/src/types.ts
+++ b/models/standalone-price/src/types.ts
@@ -4,7 +4,10 @@ import {
   CustomerGroup,
   Channel,
 } from '@commercetools/platform-sdk';
-import { TReferenceGraphql } from '@commercetools-test-data/commons';
+import {
+  TMoneyGraphql,
+  TReferenceGraphql,
+} from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 // Base representation
@@ -27,7 +30,15 @@ export type TStandalonePriceGraphql = TStandalonePrice & {
   channelRef: TReferenceGraphql | null;
   __typename: 'StandalonePrice';
 };
-export type TStandalonePriceDraftGraphql = StandalonePriceDraft;
+
+export type TStandalonePriceDraftGraphql = Omit<
+  TStandalonePriceDraft,
+  'value'
+> & {
+  value: {
+    centPrecision: TMoneyGraphql;
+  };
+};
 
 export type TStandalonePriceBuilder = TBuilder<TStandalonePrice>;
 export type TStandalonePriceDraftBuilder = TBuilder<StandalonePriceDraft>;


### PR DESCRIPTION
## Summary

The standalone price draft model (`CreateStandalonePrice` in GraphQL land) has a particular shape for its `value` input:
<img width="391" alt="image" src="https://github.com/commercetools/test-data/assets/15024562/d234e421-6556-42a9-aac7-86baca118683">

Just making that fix here, and using `MoneyDraft` rather than `CentPrecisionMoneyDraft`.