### PR TITLE
fix(product selection draft type)

### DIFF
--- a/.changeset/spotty-socks-fetch.md
+++ b/.changeset/spotty-socks-fetch.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product-selection': patch
+---
+
+Update TProductSelectionDraftGraphql type to use TLocalizedStringGraphql as type for name field

--- a/models/product-selection/src/types.ts
+++ b/models/product-selection/src/types.ts
@@ -2,6 +2,7 @@ import type {
   ProductSelection,
   ProductSelectionDraft,
 } from '@commercetools/platform-sdk';
+import { TLocalizedStringGraphql } from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 //ProductSelectionDraft
@@ -9,7 +10,12 @@ export type TProductSelectionDraft = ProductSelectionDraft;
 export type TProductSelectionDraftBuilder = TBuilder<TProductSelectionDraft>;
 export type TCreateProductSelectionDraftBuilder =
   () => TProductSelectionDraftBuilder;
-export type TProductSelectionDraftGraphql = TProductSelectionDraft;
+export type TProductSelectionDraftGraphql = Omit<
+  TProductSelectionDraft,
+  'name'
+> & {
+  name: TLocalizedStringGraphql;
+};
 
 //ProductSelection
 export type TProductSelection = ProductSelection;


### PR DESCRIPTION
update `TProductSelectionDraftGraphql` to use `TLocalizedStringGraphql` as type for `name` field