### PR TITLE
FCT-783: Add Product Selections to Stores

### DIFF
--- a/.changeset/honest-bikes-think.md
+++ b/.changeset/honest-bikes-think.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/commons': minor
+'@commercetools-test-data/store': minor
+---
+
+generate productSelectionSettingsDraft presets for both b2b product-selections, reference appropriate PSSD's in b2b storeDraft presets, create productSelection keyReference preset

--- a/models/commons/src/key-reference/key-reference-draft/presets/index.ts
+++ b/models/commons/src/key-reference/key-reference-draft/presets/index.ts
@@ -5,6 +5,7 @@ import category from './category-reference';
 import channel from './channel-reference';
 import customerGroup from './customer-group-reference';
 import customer from './customer-reference';
+import productSelection from './product-selection-reference';
 import productType from './product-type-reference';
 import quote from './quote-reference';
 import quoteRequest from './quote-request-reference';
@@ -22,6 +23,7 @@ const presets = {
   channel,
   customer,
   customerGroup,
+  productSelection,
   productType,
   quote,
   quoteRequest,

--- a/models/commons/src/key-reference/key-reference-draft/presets/product-selection-reference.spec.ts
+++ b/models/commons/src/key-reference/key-reference-draft/presets/product-selection-reference.spec.ts
@@ -1,0 +1,10 @@
+import type { TKeyReferenceDraft } from '../../types';
+import productSelectionReference from './product-selection-reference';
+
+it('should build product type reference', () => {
+  const built = productSelectionReference().build<TKeyReferenceDraft>();
+  expect(built).toEqual({
+    key: expect.any(String),
+    typeId: 'product-selection',
+  });
+});

--- a/models/commons/src/key-reference/key-reference-draft/presets/product-selection-reference.ts
+++ b/models/commons/src/key-reference/key-reference-draft/presets/product-selection-reference.ts
@@ -1,0 +1,7 @@
+import type { TKeyReferenceDraftBuilder } from '../../types';
+import KeyReferenceDraft from '../builder';
+
+const productSelection = (): TKeyReferenceDraftBuilder =>
+  KeyReferenceDraft().typeId('product-selection');
+
+export default productSelection;

--- a/models/store/src/product-selection-setting/product-selection-setting-draft/presets/index.ts
+++ b/models/store/src/product-selection-setting/product-selection-setting-draft/presets/index.ts
@@ -1,3 +1,7 @@
-const presets = {};
+import sampleDataB2B from './sample-data-b2b';
+
+const presets = {
+  sampleDataB2B,
+};
 
 export default presets;

--- a/models/store/src/product-selection-setting/product-selection-setting-draft/presets/sample-data-b2b/default-product-selection.spec.ts
+++ b/models/store/src/product-selection-setting/product-selection-setting-draft/presets/sample-data-b2b/default-product-selection.spec.ts
@@ -1,0 +1,33 @@
+import type { TProductSelectionSettingDraft } from '../../../types';
+import defaultProductSelection from './default-product-selection';
+
+describe('with defaultProductSelection present', () => {
+  it('should return a defaultProductSelection preset', () => {
+    const defaultProductSelectionPreset =
+      defaultProductSelection().build<TProductSelectionSettingDraft>();
+
+    expect(defaultProductSelectionPreset).toMatchInlineSnapshot(`
+      {
+        "active": true,
+        "productSelection": {
+          "key": "default-product-selection",
+          "typeId": "product-selection",
+        },
+      }
+    `);
+  });
+  it('should return a defaultProductSelection preset when built for graphql', () => {
+    const defaultProductSelectionPresetGraphql =
+      defaultProductSelection().buildGraphql<TProductSelectionSettingDraft>();
+
+    expect(defaultProductSelectionPresetGraphql).toMatchInlineSnapshot(`
+      {
+        "active": true,
+        "productSelection": {
+          "key": "default-product-selection",
+          "typeId": "product-selection",
+        },
+      }
+    `);
+  });
+});

--- a/models/store/src/product-selection-setting/product-selection-setting-draft/presets/sample-data-b2b/default-product-selection.ts
+++ b/models/store/src/product-selection-setting/product-selection-setting-draft/presets/sample-data-b2b/default-product-selection.ts
@@ -1,0 +1,23 @@
+import { KeyReferenceDraft } from '@commercetools-test-data/commons';
+import {
+  ProductSelectionDraft,
+  type TProductSelectionDraft,
+} from '@commercetools-test-data/product-selection';
+import type { TProductSelectionSettingDraftBuilder } from '../../../types';
+import ProductSelectionSettingDraft from '../../builder';
+
+const defaultProductSelection = ProductSelectionDraft.presets.sampleDataB2B
+  .defaultProductSelection()
+  .build<TProductSelectionDraft>();
+
+const defaultProductSelectionSetting =
+  (): TProductSelectionSettingDraftBuilder =>
+    ProductSelectionSettingDraft()
+      .productSelection(
+        KeyReferenceDraft.presets
+          .productSelection()
+          .key(defaultProductSelection.key!)
+      )
+      .active(true);
+
+export default defaultProductSelectionSetting;

--- a/models/store/src/product-selection-setting/product-selection-setting-draft/presets/sample-data-b2b/index.ts
+++ b/models/store/src/product-selection-setting/product-selection-setting-draft/presets/sample-data-b2b/index.ts
@@ -1,0 +1,9 @@
+import defaultProductSelection from './default-product-selection';
+import usMediumCustomersCatalogProductSelection from './us-medium-customers-catalog-product-selection';
+
+const presets = {
+  defaultProductSelection,
+  usMediumCustomersCatalogProductSelection,
+};
+
+export default presets;

--- a/models/store/src/product-selection-setting/product-selection-setting-draft/presets/sample-data-b2b/us-medium-customers-catalog-product-selection.spec.ts
+++ b/models/store/src/product-selection-setting/product-selection-setting-draft/presets/sample-data-b2b/us-medium-customers-catalog-product-selection.spec.ts
@@ -1,0 +1,35 @@
+import type { TProductSelectionSettingDraft } from '../../../types';
+import usMediumCustomersCatalogProductSelection from './us-medium-customers-catalog-product-selection';
+
+describe('with usMediumCustomersCatalogProductSelection present', () => {
+  it('should return a usMediumCustomersCatalogProductSelection preset', () => {
+    const usMediumCustomersCatalogProductSelectionPreset =
+      usMediumCustomersCatalogProductSelection().build<TProductSelectionSettingDraft>();
+
+    expect(usMediumCustomersCatalogProductSelectionPreset)
+      .toMatchInlineSnapshot(`
+      {
+        "active": true,
+        "productSelection": {
+          "key": "us-medium-customers-catalog",
+          "typeId": "product-selection",
+        },
+      }
+    `);
+  });
+  it('should return a usMediumCustomersCatalogProductSelection preset when built for graphql', () => {
+    const usMediumCustomersCatalogProductSelectionPresetGraphql =
+      usMediumCustomersCatalogProductSelection().buildGraphql<TProductSelectionSettingDraft>();
+
+    expect(usMediumCustomersCatalogProductSelectionPresetGraphql)
+      .toMatchInlineSnapshot(`
+      {
+        "active": true,
+        "productSelection": {
+          "key": "us-medium-customers-catalog",
+          "typeId": "product-selection",
+        },
+      }
+    `);
+  });
+});

--- a/models/store/src/product-selection-setting/product-selection-setting-draft/presets/sample-data-b2b/us-medium-customers-catalog-product-selection.ts
+++ b/models/store/src/product-selection-setting/product-selection-setting-draft/presets/sample-data-b2b/us-medium-customers-catalog-product-selection.ts
@@ -1,0 +1,23 @@
+import { KeyReferenceDraft } from '@commercetools-test-data/commons';
+import {
+  ProductSelectionDraft,
+  type TProductSelectionDraft,
+} from '@commercetools-test-data/product-selection';
+import type { TProductSelectionSettingDraftBuilder } from '../../../types';
+import ProductSelectionSettingDraft from '../../builder';
+
+const usMediumCustomersCatalog = ProductSelectionDraft.presets.sampleDataB2B
+  .usMediumCustomersCatalog()
+  .build<TProductSelectionDraft>();
+
+const usMediumCustomersCatalogProductSelectionSetting =
+  (): TProductSelectionSettingDraftBuilder =>
+    ProductSelectionSettingDraft()
+      .productSelection(
+        KeyReferenceDraft.presets
+          .productSelection()
+          .key(usMediumCustomersCatalog.key!)
+      )
+      .active(true);
+
+export default usMediumCustomersCatalogProductSelectionSetting;

--- a/models/store/src/store/store-draft/presets/sample-data-b2b/de-fr-uk.spec.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-b2b/de-fr-uk.spec.ts
@@ -31,7 +31,15 @@ describe(`with deFrUk preset`, () => {
           "nl-NL": "Duitsland, Frankrijk en Verenigd Koninkrijk",
           "pt-PT": "Alemanha, França e Reino Unido",
         },
-        "productSelections": undefined,
+        "productSelections": [
+          {
+            "active": true,
+            "productSelection": {
+              "key": "default-product-selection",
+              "typeId": "product-selection",
+            },
+          },
+        ],
         "supplyChannels": [
           {
             "key": "eu-warehouse",
@@ -98,7 +106,15 @@ describe(`with deFrUk preset`, () => {
             "value": "Germany, France and United Kingdom",
           },
         ],
-        "productSelections": undefined,
+        "productSelections": [
+          {
+            "active": true,
+            "productSelection": {
+              "key": "default-product-selection",
+              "typeId": "product-selection",
+            },
+          },
+        ],
         "supplyChannels": [
           {
             "key": "eu-warehouse",

--- a/models/store/src/store/store-draft/presets/sample-data-b2b/de-fr-uk.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-b2b/de-fr-uk.ts
@@ -6,6 +6,10 @@ import {
   KeyReferenceDraft,
   LocalizedStringDraft,
 } from '@commercetools-test-data/commons';
+import {
+  ProductSelectionSettingDraft,
+  type TProductSelectionSettingDraft,
+} from '../../../../product-selection-setting/index';
 import type { TStoreDraftBuilder } from '../../../types';
 import * as StoreDraft from '../../index';
 
@@ -15,6 +19,11 @@ const deFrUkChannel = ChannelDraft.presets.sampleDataB2B
 const euWarehouseChannel = ChannelDraft.presets.sampleDataB2B
   .euWarehouse()
   .build<TChannelDraft>();
+
+const defaultProductSelectionSetting =
+  ProductSelectionSettingDraft.presets.sampleDataB2B
+    .defaultProductSelection()
+    .build<TProductSelectionSettingDraft>();
 
 const deFrUk = (): TStoreDraftBuilder =>
   StoreDraft.presets
@@ -39,6 +48,7 @@ const deFrUk = (): TStoreDraftBuilder =>
     ])
     .supplyChannels([
       KeyReferenceDraft.presets.channel().key(euWarehouseChannel.key),
-    ]);
+    ])
+    .productSelections([defaultProductSelectionSetting]);
 
 export default deFrUk;

--- a/models/store/src/store/store-draft/presets/sample-data-b2b/default-store.spec.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-b2b/default-store.spec.ts
@@ -31,7 +31,15 @@ describe(`with defaultStore preset`, () => {
           "nl-NL": "Standaard",
           "pt-PT": "Padrão",
         },
-        "productSelections": undefined,
+        "productSelections": [
+          {
+            "active": true,
+            "productSelection": {
+              "key": "default-product-selection",
+              "typeId": "product-selection",
+            },
+          },
+        ],
         "supplyChannels": [
           {
             "key": "default-warehouse",
@@ -99,7 +107,15 @@ describe(`with defaultStore preset`, () => {
             "value": "Default",
           },
         ],
-        "productSelections": undefined,
+        "productSelections": [
+          {
+            "active": true,
+            "productSelection": {
+              "key": "default-product-selection",
+              "typeId": "product-selection",
+            },
+          },
+        ],
         "supplyChannels": [
           {
             "key": "default-warehouse",

--- a/models/store/src/store/store-draft/presets/sample-data-b2b/default-store.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-b2b/default-store.ts
@@ -2,8 +2,17 @@ import {
   KeyReferenceDraft,
   LocalizedStringDraft,
 } from '@commercetools-test-data/commons';
+import {
+  ProductSelectionSettingDraft,
+  type TProductSelectionSettingDraft,
+} from '../../../../product-selection-setting/index';
 import type { TStoreDraftBuilder } from '../../../types';
 import * as StoreDraft from '../../index';
+
+const defaultProductSelectionSetting =
+  ProductSelectionSettingDraft.presets.sampleDataB2B
+    .defaultProductSelection()
+    .build<TProductSelectionSettingDraft>();
 
 const defaultStore = (): TStoreDraftBuilder =>
   StoreDraft.presets
@@ -28,6 +37,7 @@ const defaultStore = (): TStoreDraftBuilder =>
     ])
     .supplyChannels([
       KeyReferenceDraft.presets.channel().key('default-warehouse'),
-    ]);
+    ])
+    .productSelections([defaultProductSelectionSetting]);
 
 export default defaultStore;

--- a/models/store/src/store/store-draft/presets/sample-data-b2b/spain.spec.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-b2b/spain.spec.ts
@@ -31,7 +31,15 @@ describe(`with spain preset`, () => {
           "nl-NL": "Spanje",
           "pt-PT": "Espanha",
         },
-        "productSelections": undefined,
+        "productSelections": [
+          {
+            "active": true,
+            "productSelection": {
+              "key": "default-product-selection",
+              "typeId": "product-selection",
+            },
+          },
+        ],
         "supplyChannels": [
           {
             "key": "eu-warehouse",
@@ -98,7 +106,15 @@ describe(`with spain preset`, () => {
             "value": "Spain",
           },
         ],
-        "productSelections": undefined,
+        "productSelections": [
+          {
+            "active": true,
+            "productSelection": {
+              "key": "default-product-selection",
+              "typeId": "product-selection",
+            },
+          },
+        ],
         "supplyChannels": [
           {
             "key": "eu-warehouse",

--- a/models/store/src/store/store-draft/presets/sample-data-b2b/spain.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-b2b/spain.ts
@@ -2,8 +2,17 @@ import {
   KeyReferenceDraft,
   LocalizedStringDraft,
 } from '@commercetools-test-data/commons';
+import {
+  ProductSelectionSettingDraft,
+  type TProductSelectionSettingDraft,
+} from '../../../../product-selection-setting/index';
 import type { TStoreDraftBuilder } from '../../../types';
 import * as StoreDraft from '../../index';
+
+const defaultProductSelectionSetting =
+  ProductSelectionSettingDraft.presets.sampleDataB2B
+    .defaultProductSelection()
+    .build<TProductSelectionSettingDraft>();
 
 const spain = (): TStoreDraftBuilder =>
   StoreDraft.presets
@@ -24,6 +33,7 @@ const spain = (): TStoreDraftBuilder =>
         ['en-US']('Spain')
     )
     .distributionChannels([KeyReferenceDraft.presets.channel().key('spain')])
-    .supplyChannels([KeyReferenceDraft.presets.channel().key('eu-warehouse')]);
+    .supplyChannels([KeyReferenceDraft.presets.channel().key('eu-warehouse')])
+    .productSelections([defaultProductSelectionSetting]);
 
 export default spain;

--- a/models/store/src/store/store-draft/presets/sample-data-b2b/us-large-customers.spec.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-b2b/us-large-customers.spec.ts
@@ -31,7 +31,15 @@ describe(`with usLargeCustomers preset`, () => {
           "nl-NL": "Grote Klanten in de VS",
           "pt-PT": "Grandes Clientes dos EUA",
         },
-        "productSelections": undefined,
+        "productSelections": [
+          {
+            "active": true,
+            "productSelection": {
+              "key": "default-product-selection",
+              "typeId": "product-selection",
+            },
+          },
+        ],
         "supplyChannels": [
           {
             "key": "us-warehouse",
@@ -99,7 +107,15 @@ describe(`with usLargeCustomers preset`, () => {
             "value": "US Large Customers",
           },
         ],
-        "productSelections": undefined,
+        "productSelections": [
+          {
+            "active": true,
+            "productSelection": {
+              "key": "default-product-selection",
+              "typeId": "product-selection",
+            },
+          },
+        ],
         "supplyChannels": [
           {
             "key": "us-warehouse",

--- a/models/store/src/store/store-draft/presets/sample-data-b2b/us-large-customers.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-b2b/us-large-customers.ts
@@ -2,8 +2,17 @@ import {
   KeyReferenceDraft,
   LocalizedStringDraft,
 } from '@commercetools-test-data/commons';
+import {
+  ProductSelectionSettingDraft,
+  type TProductSelectionSettingDraft,
+} from '../../../../product-selection-setting/index';
 import type { TStoreDraftBuilder } from '../../../types';
 import * as StoreDraft from '../../index';
+
+const defaultProductSelectionSetting =
+  ProductSelectionSettingDraft.presets.sampleDataB2B
+    .defaultProductSelection()
+    .build<TProductSelectionSettingDraft>();
 
 const usLargeCustomers = (): TStoreDraftBuilder =>
   StoreDraft.presets
@@ -26,6 +35,7 @@ const usLargeCustomers = (): TStoreDraftBuilder =>
     .distributionChannels([
       KeyReferenceDraft.presets.channel().key('us-large-customers'),
     ])
-    .supplyChannels([KeyReferenceDraft.presets.channel().key('us-warehouse')]);
+    .supplyChannels([KeyReferenceDraft.presets.channel().key('us-warehouse')])
+    .productSelections([defaultProductSelectionSetting]);
 
 export default usLargeCustomers;

--- a/models/store/src/store/store-draft/presets/sample-data-b2b/us-medium-customers.spec.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-b2b/us-medium-customers.spec.ts
@@ -31,7 +31,15 @@ describe(`with usMediumCustomers preset`, () => {
           "nl-NL": "Middelgrote Klanten in de VS",
           "pt-PT": "Clientes Médios dos EUA",
         },
-        "productSelections": undefined,
+        "productSelections": [
+          {
+            "active": true,
+            "productSelection": {
+              "key": "us-medium-customers-catalog",
+              "typeId": "product-selection",
+            },
+          },
+        ],
         "supplyChannels": [
           {
             "key": "us-warehouse",
@@ -99,7 +107,15 @@ describe(`with usMediumCustomers preset`, () => {
             "value": "US Medium Customers",
           },
         ],
-        "productSelections": undefined,
+        "productSelections": [
+          {
+            "active": true,
+            "productSelection": {
+              "key": "us-medium-customers-catalog",
+              "typeId": "product-selection",
+            },
+          },
+        ],
         "supplyChannels": [
           {
             "key": "us-warehouse",

--- a/models/store/src/store/store-draft/presets/sample-data-b2b/us-medium-customers.ts
+++ b/models/store/src/store/store-draft/presets/sample-data-b2b/us-medium-customers.ts
@@ -2,8 +2,17 @@ import {
   KeyReferenceDraft,
   LocalizedStringDraft,
 } from '@commercetools-test-data/commons';
+import {
+  ProductSelectionSettingDraft,
+  type TProductSelectionSettingDraft,
+} from '../../../../product-selection-setting/index';
 import type { TStoreDraftBuilder } from '../../../types';
 import * as StoreDraft from '../../index';
+
+const usMediumCustomersCatalogProductSelection =
+  ProductSelectionSettingDraft.presets.sampleDataB2B
+    .usMediumCustomersCatalogProductSelection()
+    .build<TProductSelectionSettingDraft>();
 
 const usMediumCustomers = (): TStoreDraftBuilder =>
   StoreDraft.presets
@@ -26,6 +35,7 @@ const usMediumCustomers = (): TStoreDraftBuilder =>
     .distributionChannels([
       KeyReferenceDraft.presets.channel().key('us-medium-customers'),
     ])
-    .supplyChannels([KeyReferenceDraft.presets.channel().key('us-warehouse')]);
+    .supplyChannels([KeyReferenceDraft.presets.channel().key('us-warehouse')])
+    .productSelections([usMediumCustomersCatalogProductSelection]);
 
 export default usMediumCustomers;


### PR DESCRIPTION
- generates `productSelectionSettingsDraft` presets for both b2b product-selections
- references appropriate `PSSD`'s in b2b `storeDraft` presets
- creates `productSelection` keyReference preset
- adds and updates appropriate tests