### PR TITLE
Tf/fix shipping rate draft b2c preset tests

### DIFF
--- a/.changeset/dull-mangos-carry.md
+++ b/.changeset/dull-mangos-carry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/shipping-method': patch
+---
+
+Update tests to prefer inline snapshots over object matching.

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/eur-10000.spec.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/eur-10000.spec.ts
@@ -8,19 +8,31 @@ describe('with eur10000 preset', () => {
   it('should return a eur10000 preset', () => {
     const eur10000Preset = eur10000().build<TShippingRateDraft>();
 
-    expect(eur10000Preset).toMatchObject({
-      price: { centAmount: 10000, currencyCode: 'EUR' },
-      tiers: [],
-    });
+    expect(eur10000Preset).toMatchInlineSnapshot(`
+      {
+        "freeAbove": undefined,
+        "price": {
+          "centAmount": 10000,
+          "currencyCode": "EUR",
+        },
+        "tiers": [],
+      }
+    `);
   });
 
   it('should return a eur10000 preset when built for graphql', () => {
     const eur10000PresetGraphql =
       eur10000().buildGraphql<TShippingRateDraftGraphql>();
 
-    expect(eur10000PresetGraphql).toMatchObject({
-      price: { centAmount: 10000, currencyCode: 'EUR' },
-      tiers: [],
-    });
+    expect(eur10000PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "freeAbove": undefined,
+        "price": {
+          "centAmount": 10000,
+          "currencyCode": "EUR",
+        },
+        "tiers": [],
+      }
+    `);
   });
 });

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/eur-50000.spec.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/eur-50000.spec.ts
@@ -8,19 +8,31 @@ describe('with eur50000 preset', () => {
   it('should return a eur50000 preset', () => {
     const eur50000Preset = eur50000().build<TShippingRateDraft>();
 
-    expect(eur50000Preset).toMatchObject({
-      price: { centAmount: 50000, currencyCode: 'EUR' },
-      tiers: [],
-    });
+    expect(eur50000Preset).toMatchInlineSnapshot(`
+      {
+        "freeAbove": undefined,
+        "price": {
+          "centAmount": 50000,
+          "currencyCode": "EUR",
+        },
+        "tiers": [],
+      }
+    `);
   });
 
   it('should return a eur50000 preset when built for graphql', () => {
     const eur50000PresetGraphql =
       eur50000().buildGraphql<TShippingRateDraftGraphql>();
 
-    expect(eur50000PresetGraphql).toMatchObject({
-      price: { centAmount: 50000, currencyCode: 'EUR' },
-      tiers: [],
-    });
+    expect(eur50000PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "freeAbove": undefined,
+        "price": {
+          "centAmount": 50000,
+          "currencyCode": "EUR",
+        },
+        "tiers": [],
+      }
+    `);
   });
 });

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/gbp-10000.spec.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/gbp-10000.spec.ts
@@ -8,19 +8,31 @@ describe('with gbp10000 preset', () => {
   it('should return a gbp10000 preset', () => {
     const gbp10000Preset = gbp10000().build<TShippingRateDraft>();
 
-    expect(gbp10000Preset).toMatchObject({
-      price: { centAmount: 10000, currencyCode: 'GBP' },
-      tiers: [],
-    });
+    expect(gbp10000Preset).toMatchInlineSnapshot(`
+      {
+        "freeAbove": undefined,
+        "price": {
+          "centAmount": 10000,
+          "currencyCode": "GBP",
+        },
+        "tiers": [],
+      }
+    `);
   });
 
   it('should return a gbp10000 preset when built for graphql', () => {
     const gbp10000PresetGraphql =
       gbp10000().buildGraphql<TShippingRateDraftGraphql>();
 
-    expect(gbp10000PresetGraphql).toMatchObject({
-      price: { centAmount: 10000, currencyCode: 'GBP' },
-      tiers: [],
-    });
+    expect(gbp10000PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "freeAbove": undefined,
+        "price": {
+          "centAmount": 10000,
+          "currencyCode": "GBP",
+        },
+        "tiers": [],
+      }
+    `);
   });
 });

--- a/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/gbp-50000.spec.ts
+++ b/models/shipping-method/src/shipping-rate/shipping-rate-draft/presets/sample-data-goodstore/gbp-50000.spec.ts
@@ -8,19 +8,31 @@ describe('with gbp50000 preset', () => {
   it('should return a gbp50000 preset', () => {
     const gbp50000Preset = gbp50000().build<TShippingRateDraft>();
 
-    expect(gbp50000Preset).toMatchObject({
-      price: { centAmount: 50000, currencyCode: 'GBP' },
-      tiers: [],
-    });
+    expect(gbp50000Preset).toMatchInlineSnapshot(`
+      {
+        "freeAbove": undefined,
+        "price": {
+          "centAmount": 50000,
+          "currencyCode": "GBP",
+        },
+        "tiers": [],
+      }
+    `);
   });
 
   it('should return a gbp50000 preset when built for graphql', () => {
     const gbp50000PresetGraphql =
       gbp50000().buildGraphql<TShippingRateDraftGraphql>();
 
-    expect(gbp50000PresetGraphql).toMatchObject({
-      price: { centAmount: 50000, currencyCode: 'GBP' },
-      tiers: [],
-    });
+    expect(gbp50000PresetGraphql).toMatchInlineSnapshot(`
+      {
+        "freeAbove": undefined,
+        "price": {
+          "centAmount": 50000,
+          "currencyCode": "GBP",
+        },
+        "tiers": [],
+      }
+    `);
   });
 });


### PR DESCRIPTION
This PR cleans up a small inconsistency in preset tests for `ShippingRateDraft` that would cause a future dev to passively shake their fist at the sky - in general it makes sense to use `toMatchInlineSnapshot` instead of `toMatchObject` for preset tests.