### PR TITLE
PRC-3436: Add `HighPrecisionMoney` and `HighPrecisionMoneyDraft` models

### DIFF
--- a/.changeset/yellow-mirrors-heal.md
+++ b/.changeset/yellow-mirrors-heal.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/commons': minor
+---
+
+Add `HighPrecisionMoney` and `HighPrecisionMoneyDraft` models

--- a/models/commons/src/high-precision-money/builder.spec.ts
+++ b/models/commons/src/high-precision-money/builder.spec.ts
@@ -1,0 +1,50 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { THighPrecisionMoney, THighPrecisionMoneyGraphql } from './types';
+import * as HighPrecisionMoney from './index';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<THighPrecisionMoney, THighPrecisionMoney>(
+      'default',
+      HighPrecisionMoney.random(),
+      expect.objectContaining({
+        type: 'highPrecision',
+        centAmount: expect.any(Number),
+        currencyCode: expect.any(String),
+        fractionDigits: expect.any(Number),
+        preciseAmount: expect.any(Number),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<THighPrecisionMoney, THighPrecisionMoney>(
+      'rest',
+      HighPrecisionMoney.random(),
+      expect.objectContaining({
+        type: 'highPrecision',
+        centAmount: expect.any(Number),
+        currencyCode: expect.any(String),
+        fractionDigits: expect.any(Number),
+        preciseAmount: expect.any(Number),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<THighPrecisionMoney, THighPrecisionMoneyGraphql>(
+      'graphql',
+      HighPrecisionMoney.random(),
+      expect.objectContaining({
+        type: 'highPrecision',
+        centAmount: expect.any(Number),
+        currencyCode: expect.any(String),
+        fractionDigits: expect.any(Number),
+        preciseAmount: expect.any(Number),
+        __typename: 'HighPrecisionMoney',
+      })
+    )
+  );
+});

--- a/models/commons/src/high-precision-money/builder.ts
+++ b/models/commons/src/high-precision-money/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type {
+  THighPrecisionMoney,
+  TCreateHighPrecisionMoneyBuilder,
+} from './types';
+
+const Model: TCreateHighPrecisionMoneyBuilder = () =>
+  Builder<THighPrecisionMoney>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/commons/src/high-precision-money/generator.ts
+++ b/models/commons/src/high-precision-money/generator.ts
@@ -1,0 +1,16 @@
+import { fake, Generator, oneOf } from '@commercetools-test-data/core';
+import { THighPrecisionMoney } from './types';
+
+// https://docs.commercetools.com/api/types#highprecisionmoney
+
+const generator = Generator<THighPrecisionMoney>({
+  fields: {
+    type: 'highPrecision',
+    centAmount: fake((f) => f.number.int({ min: 1, max: 999999 })),
+    currencyCode: oneOf('EUR', 'USD'),
+    fractionDigits: fake((f) => f.number.int({ min: 3, max: 10 })),
+    preciseAmount: fake((f) => f.number.int({ min: 1, max: 9999999999 })),
+  },
+});
+
+export default generator;

--- a/models/commons/src/high-precision-money/generator.ts
+++ b/models/commons/src/high-precision-money/generator.ts
@@ -3,13 +3,22 @@ import { THighPrecisionMoney } from './types';
 
 // https://docs.commercetools.com/api/types#highprecisionmoney
 
+const CENT_PRECISION_FRACTION_DIGITS = 2;
+
 const generator = Generator<THighPrecisionMoney>({
   fields: {
     type: 'highPrecision',
-    centAmount: fake((f) => f.number.int({ min: 1, max: 999999 })),
+    centAmount: 1,
     currencyCode: oneOf('EUR', 'USD'),
     fractionDigits: fake((f) => f.number.int({ min: 3, max: 10 })),
     preciseAmount: fake((f) => f.number.int({ min: 1, max: 9999999999 })),
+  },
+  postBuild: (highPrecision: THighPrecisionMoney) => {
+    const centAmount = Math.round(
+      highPrecision.preciseAmount /
+        10 ** (highPrecision.fractionDigits - CENT_PRECISION_FRACTION_DIGITS)
+    );
+    return { ...highPrecision, centAmount };
   },
 });
 

--- a/models/commons/src/high-precision-money/high-precision-money-draft/builder.spec.ts
+++ b/models/commons/src/high-precision-money/high-precision-money-draft/builder.spec.ts
@@ -14,7 +14,6 @@ describe('builder', () => {
       HighPrecisionMoneyDraft.random(),
       expect.objectContaining({
         type: 'highPrecision',
-        centAmount: expect.any(Number),
         currencyCode: expect.any(String),
         fractionDigits: expect.any(Number),
         preciseAmount: expect.any(Number),
@@ -28,7 +27,6 @@ describe('builder', () => {
       HighPrecisionMoneyDraft.random(),
       expect.objectContaining({
         type: 'highPrecision',
-        centAmount: expect.any(Number),
         currencyCode: expect.any(String),
         fractionDigits: expect.any(Number),
         preciseAmount: expect.any(Number),
@@ -45,7 +43,6 @@ describe('builder', () => {
       HighPrecisionMoneyDraft.random(),
       expect.objectContaining({
         type: 'highPrecision',
-        centAmount: expect.any(Number),
         currencyCode: expect.any(String),
         fractionDigits: expect.any(Number),
         preciseAmount: expect.any(Number),

--- a/models/commons/src/high-precision-money/high-precision-money-draft/builder.spec.ts
+++ b/models/commons/src/high-precision-money/high-precision-money-draft/builder.spec.ts
@@ -1,0 +1,55 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import {
+  THighPrecisionMoneyDraft,
+  THighPrecisionMoneyDraftGraphql,
+} from '../types';
+import * as HighPrecisionMoneyDraft from './index';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<THighPrecisionMoneyDraft, THighPrecisionMoneyDraft>(
+      'default',
+      HighPrecisionMoneyDraft.random(),
+      expect.objectContaining({
+        type: 'highPrecision',
+        centAmount: expect.any(Number),
+        currencyCode: expect.any(String),
+        fractionDigits: expect.any(Number),
+        preciseAmount: expect.any(Number),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<THighPrecisionMoneyDraft, THighPrecisionMoneyDraft>(
+      'rest',
+      HighPrecisionMoneyDraft.random(),
+      expect.objectContaining({
+        type: 'highPrecision',
+        centAmount: expect.any(Number),
+        currencyCode: expect.any(String),
+        fractionDigits: expect.any(Number),
+        preciseAmount: expect.any(Number),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<
+      THighPrecisionMoneyDraft,
+      THighPrecisionMoneyDraftGraphql
+    >(
+      'graphql',
+      HighPrecisionMoneyDraft.random(),
+      expect.objectContaining({
+        type: 'highPrecision',
+        centAmount: expect.any(Number),
+        currencyCode: expect.any(String),
+        fractionDigits: expect.any(Number),
+        preciseAmount: expect.any(Number),
+      })
+    )
+  );
+});

--- a/models/commons/src/high-precision-money/high-precision-money-draft/builder.ts
+++ b/models/commons/src/high-precision-money/high-precision-money-draft/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import type {
+  TCreateHighPrecisionMoneyDraftBuilder,
+  THighPrecisionMoneyDraft,
+} from '../types';
+import generator from './generator';
+import transformers from './transformers';
+
+const Model: TCreateHighPrecisionMoneyDraftBuilder = () =>
+  Builder<THighPrecisionMoneyDraft>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/commons/src/high-precision-money/high-precision-money-draft/generator.ts
+++ b/models/commons/src/high-precision-money/high-precision-money-draft/generator.ts
@@ -1,0 +1,16 @@
+import { fake, Generator, oneOf } from '@commercetools-test-data/core';
+import { THighPrecisionMoneyDraft } from '../types';
+
+// https://docs.commercetools.com/api/types#highprecisionmoneydraft
+
+const generator = Generator<THighPrecisionMoneyDraft>({
+  fields: {
+    type: 'highPrecision',
+    centAmount: fake((f) => f.number.int({ min: 1, max: 999999 })),
+    currencyCode: oneOf('EUR', 'USD'),
+    fractionDigits: fake((f) => f.number.int({ min: 3, max: 10 })),
+    preciseAmount: fake((f) => f.number.int({ min: 1, max: 9999999999 })),
+  },
+});
+
+export default generator;

--- a/models/commons/src/high-precision-money/high-precision-money-draft/generator.ts
+++ b/models/commons/src/high-precision-money/high-precision-money-draft/generator.ts
@@ -6,7 +6,6 @@ import { THighPrecisionMoneyDraft } from '../types';
 const generator = Generator<THighPrecisionMoneyDraft>({
   fields: {
     type: 'highPrecision',
-    centAmount: fake((f) => f.number.int({ min: 1, max: 999999 })),
     currencyCode: oneOf('EUR', 'USD'),
     fractionDigits: fake((f) => f.number.int({ min: 3, max: 10 })),
     preciseAmount: fake((f) => f.number.int({ min: 1, max: 9999999999 })),

--- a/models/commons/src/high-precision-money/high-precision-money-draft/index.ts
+++ b/models/commons/src/high-precision-money/high-precision-money-draft/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/commons/src/high-precision-money/high-precision-money-draft/presets/index.ts
+++ b/models/commons/src/high-precision-money/high-precision-money-draft/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/commons/src/high-precision-money/high-precision-money-draft/transformers.ts
+++ b/models/commons/src/high-precision-money/high-precision-money-draft/transformers.ts
@@ -1,0 +1,24 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type {
+  THighPrecisionMoneyDraft,
+  THighPrecisionMoneyDraftGraphql,
+} from '../types';
+
+const transformers = {
+  default: Transformer<THighPrecisionMoneyDraft, THighPrecisionMoneyDraft>(
+    'default',
+    { buildFields: [] }
+  ),
+  rest: Transformer<THighPrecisionMoneyDraft, THighPrecisionMoneyDraft>(
+    'rest',
+    { buildFields: [] }
+  ),
+  graphql: Transformer<
+    THighPrecisionMoneyDraft,
+    THighPrecisionMoneyDraftGraphql
+  >('graphql', {
+    buildFields: [],
+  }),
+};
+
+export default transformers;

--- a/models/commons/src/high-precision-money/index.ts
+++ b/models/commons/src/high-precision-money/index.ts
@@ -1,0 +1,5 @@
+export * as HighPrecisionMoneyDraft from './high-precision-money-draft';
+
+export { default as random } from './builder';
+export { default as presets } from './presets';
+export * from './types';

--- a/models/commons/src/high-precision-money/presets/index.ts
+++ b/models/commons/src/high-precision-money/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/commons/src/high-precision-money/transformers.ts
+++ b/models/commons/src/high-precision-money/transformers.ts
@@ -1,0 +1,22 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type { THighPrecisionMoney, THighPrecisionMoneyGraphql } from './types';
+
+const transformers = {
+  default: Transformer<THighPrecisionMoney, THighPrecisionMoney>('default', {
+    buildFields: [],
+  }),
+  rest: Transformer<THighPrecisionMoney, THighPrecisionMoney>('rest', {
+    buildFields: [],
+  }),
+  graphql: Transformer<THighPrecisionMoney, THighPrecisionMoneyGraphql>(
+    'graphql',
+    {
+      buildFields: [],
+      addFields: () => ({
+        __typename: 'HighPrecisionMoney',
+      }),
+    }
+  ),
+};
+
+export default transformers;

--- a/models/commons/src/high-precision-money/types.ts
+++ b/models/commons/src/high-precision-money/types.ts
@@ -1,0 +1,21 @@
+import {
+  HighPrecisionMoney,
+  HighPrecisionMoneyDraft,
+} from '@commercetools/platform-sdk';
+import type { TBuilder } from '@commercetools-test-data/core';
+
+export type THighPrecisionMoney = HighPrecisionMoney;
+export type THighPrecisionMoneyDraft = HighPrecisionMoneyDraft;
+
+export type THighPrecisionMoneyGraphql = THighPrecisionMoney & {
+  __typename: 'HighPrecisionMoney';
+};
+export type THighPrecisionMoneyDraftGraphql = THighPrecisionMoneyDraft;
+
+export type THighPrecisionMoneyBuilder = TBuilder<THighPrecisionMoney>;
+export type THighPrecisionMoneyDraftBuilder =
+  TBuilder<THighPrecisionMoneyDraft>;
+
+export type TCreateHighPrecisionMoneyBuilder = () => THighPrecisionMoneyBuilder;
+export type TCreateHighPrecisionMoneyDraftBuilder =
+  () => THighPrecisionMoneyDraftBuilder;


### PR DESCRIPTION
In Priceless, we want to test Standalone Prices with high precision values. With that goal, and assuming that high precision money could be used elsewhere, this PR introduces `HighPrecisionMoney` and `HighPrecisionMoneyDraft` models to `@commercetools-test-data/commons`.