### PR TITLE
PANGOLIN-3789: updated `code` property on discount-code-draft to fix duplicate value

### DIFF
--- a/.changeset/empty-dragons-lie.md
+++ b/.changeset/empty-dragons-lie.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/discount-code': patch
+---
+
+update discount-code-draft generator

--- a/models/discount-code/src/discount-code-draft/generator.ts
+++ b/models/discount-code/src/discount-code-draft/generator.ts
@@ -12,7 +12,7 @@ const generator = Generator<TDiscountCodeDraft>({
   fields: {
     name: fake(() => LocalizedStringDraft.random()),
     description: fake(() => LocalizedStringDraft.random()),
-    code: fake((f) => f.lorem.word()),
+    code: fake((f) => f.lorem.words({ min: 1, max: 3 })),
     cartDiscounts: [],
     cartPredicate: '1=1',
     isActive: fake((f) => f.datatype.boolean()),

--- a/models/discount-code/src/discount-code-draft/generator.ts
+++ b/models/discount-code/src/discount-code-draft/generator.ts
@@ -12,7 +12,7 @@ const generator = Generator<TDiscountCodeDraft>({
   fields: {
     name: fake(() => LocalizedStringDraft.random()),
     description: fake(() => LocalizedStringDraft.random()),
-    code: fake((f) => f.lorem.words({ min: 1, max: 3 })),
+    code: fake((f) => f.string.alphanumeric({ length: 20 })),
     cartDiscounts: [],
     cartPredicate: '1=1',
     isActive: fake((f) => f.datatype.boolean()),


### PR DESCRIPTION
The `code` property on `discount-code-draft` is causing flaky tests. This PR adds randomness to the `code` property with an alphanumeric value so we can lessen the chance of duplicate value errors.

Example: 
```
Error in function getDiscountCodeCreateData --- Error: 
BadRequest: A duplicate value '"addo"' exists for field 'code'.
```

Reference: https://app.circleci.com/pipelines/github/commercetools/audit-log/26918/workflows/caacfa3c-1f72-4ffd-82e7-3b3b839560fc/jobs/272586/tests