### PR TITLE
fix: export `HighPrecisionMoney` and `HighPrecisionMoneyDraft` models and its types

### DIFF
--- a/.changeset/tough-crews-search.md
+++ b/.changeset/tough-crews-search.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/commons': patch
+---
+
+Export `HighPrecisionMoney` and `HighPrecisionMoneyDraft` models and its types

--- a/models/commons/README.md
+++ b/models/commons/README.md
@@ -15,6 +15,7 @@ $ pnpm add -D @commercetools-test-data/commons
 - [Address](#address)<br>
 - [CentPrecisionMoney](#centprecisionmoney)<br>
 - [ClientLogging](#clientlogging)<br>
+- [HighPrecisionMoney](#highprecisionmoney)<br>
 - [KeyReference](#keyreference)<br>
 - [LocalizedString](#localizedstring)<br>
 - [Money](#money)<br>
@@ -60,6 +61,22 @@ import {
   type TClientLogging,
 } from '@commercetools-test-data/commons';
 const clientLogging = ClientLogging.random().build<TClientLogging>();
+```
+
+# HighPrecisionMoney
+
+```ts
+import {
+  HighPrecisionMoney,
+  HighPrecisionMoneyDraft,
+  type THighPrecisionMoney,
+  type THighPrecisionMoneyDraft,
+} from '@commercetools-test-data/commons';
+
+const highPrecisionMoney =
+  HighPrecisionMoney.random().build<THighPrecisionMoney>();
+const highPrecisionMoneyDraft =
+  HighPrecisionMoneyDraft.random().build<THighPrecisionMoneyDraft>();
 ```
 
 ## `KeyReference`

--- a/models/commons/src/high-precision-money/builder.spec.ts
+++ b/models/commons/src/high-precision-money/builder.spec.ts
@@ -1,8 +1,8 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import { THighPrecisionMoney, THighPrecisionMoneyGraphql } from './types';
-import * as HighPrecisionMoney from './index';
+import type { THighPrecisionMoney, THighPrecisionMoneyGraphql } from '../';
+import { HighPrecisionMoney } from '../';
 
 describe('builder', () => {
   it(

--- a/models/commons/src/index.ts
+++ b/models/commons/src/index.ts
@@ -2,6 +2,7 @@
 export * from './address/types';
 export * from './cent-precision-money/types';
 export * from './client-logging/types';
+export * from './high-precision-money/types';
 export * from './key-reference/types';
 export * from './localized-field/types';
 export * from './localized-string/types';
@@ -16,6 +17,8 @@ export * as AddressDraft from './address/address-draft';
 export * as CentPrecisionMoney from './cent-precision-money';
 export * as CentPrecisionMoneyDraft from './cent-precision-money/cent-precision-money-draft';
 export * as ClientLogging from './client-logging';
+export * as HighPrecisionMoney from './high-precision-money';
+export * as HighPrecisionMoneyDraft from './high-precision-money/high-precision-money-draft';
 export * as KeyReference from './key-reference';
 export * as KeyReferenceDraft from './key-reference/key-reference-draft';
 export * as LocalizedField from './localized-field';


### PR DESCRIPTION
This PR is a follow-up/fix of https://github.com/commercetools/test-data/pull/552
`HighPrecisionMoney` related models and types were not exported 😅