### PR TITLE
Downgrades pnpm to v8 after v9 seems to cause publishing issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ typings/
 
 # Optional npm cache directory
 .npm
-.npmrc
 
 # Optional eslint cache
 .eslintcache

--- a/package.json
+++ b/package.json
@@ -60,5 +60,5 @@
     "tsc-files": "^1.1.3",
     "typescript": "5.4.4"
   },
-  "packageManager": "pnpm@9.0.6"
+  "packageManager": "pnpm@8.15.6"
 }


### PR DESCRIPTION
The `link-workspace-package=true` doesn't seem to work. Let's try to isolate the issue on the pnpm version.