### PR TITLE
chore: publish last version of cart-discount package

### DIFF
--- a/.changeset/poor-clouds-accept.md
+++ b/.changeset/poor-clouds-accept.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart-discount': minor
+---
+
+mach typenames with typenames on mc


### PR DESCRIPTION
this is the bump after the canary realize https://github.com/commercetools/test-data/pull/567 

