### PR TITLE
chore: return required value type model from cart discount

### DIFF
--- a/.changeset/metal-experts-reflect.md
+++ b/.changeset/metal-experts-reflect.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart-discount': patch
+---
+
+return a full price on value instead a draft price to mach the values expected

--- a/models/cart-discount/src/cart-discount/generator.ts
+++ b/models/cart-discount/src/cart-discount/generator.ts
@@ -26,10 +26,10 @@ const generator = Generator<TCartDiscount>({
     description: fake(() => LocalizedString.random()),
     value: fake((f) =>
       f.helpers.arrayElement([
-        CartDiscountValueAbsolute.CartDiscountValueAbsoluteDraft.random(),
-        CartDiscountValueFixed.CartDiscountValueFixedDraft.random(),
-        CartDiscountValueGiftLineItem.CartDiscountValueGiftLineItemDraft.random(),
-        CartDiscountValueRelative.CartDiscountValueRelativeDraft.random(),
+        CartDiscountValueAbsolute.random(),
+        CartDiscountValueFixed.random(),
+        CartDiscountValueGiftLineItem.random(),
+        CartDiscountValueRelative.random(),
       ])
     ),
     cartPredicate: '1=1',


### PR DESCRIPTION
when we return the values from the card cart discount we need a complete price value not a draft, that does not mach with what the api return https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscountvalue draft miss the type property.(draft are not a preset they are a different type)

we are the only team using the card discount which is the reason for omitting the canary realize.