### PR TITLE
chore: rename ref in graphql

### DIFF
--- a/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
@@ -74,15 +74,7 @@ describe('builder', () => {
           typeId: 'product',
         }),
         variantId: expect.any(Number),
-        supplyChannel: expect.objectContaining({
-          id: expect.any(String),
-          typeId: 'channel',
-        }),
         supplyChannelRef: expect.objectContaining({
-          id: expect.any(String),
-          typeId: 'channel',
-        }),
-        distributionChannel: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
@@ -22,11 +22,11 @@ describe('builder', () => {
           typeId: 'product',
         }),
         variantId: expect.any(Number),
-        supplyChannelRef: expect.objectContaining({
+        supplyChannel: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),
-        distributionChannelRef: expect.objectContaining({
+        distributionChannel: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),
@@ -48,11 +48,11 @@ describe('builder', () => {
           typeId: 'product',
         }),
         variantId: expect.any(Number),
-        supplyChannelRef: expect.objectContaining({
+        supplyChannel: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),
-        distributionChannelRef: expect.objectContaining({
+        distributionChannel: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),
@@ -74,7 +74,15 @@ describe('builder', () => {
           typeId: 'product',
         }),
         variantId: expect.any(Number),
+        supplyChannel: expect.objectContaining({
+          id: expect.any(String),
+          typeId: 'channel',
+        }),
         supplyChannelRef: expect.objectContaining({
+          id: expect.any(String),
+          typeId: 'channel',
+        }),
+        distributionChannel: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
@@ -22,11 +22,11 @@ describe('builder', () => {
           typeId: 'product',
         }),
         variantId: expect.any(Number),
-        supplyChannel: expect.objectContaining({
+        supplyChannelRef: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),
-        distributionChannel: expect.objectContaining({
+        distributionChannelRef: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),
@@ -48,11 +48,11 @@ describe('builder', () => {
           typeId: 'product',
         }),
         variantId: expect.any(Number),
-        supplyChannel: expect.objectContaining({
+        supplyChannelRef: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),
-        distributionChannel: expect.objectContaining({
+        distributionChannelRef: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),
@@ -74,11 +74,11 @@ describe('builder', () => {
           typeId: 'product',
         }),
         variantId: expect.any(Number),
-        supplyChannel: expect.objectContaining({
+        supplyChannelRef: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),
-        distributionChannel: expect.objectContaining({
+        distributionChannelRef: expect.objectContaining({
           id: expect.any(String),
           typeId: 'channel',
         }),

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
@@ -59,6 +59,7 @@ describe('builder', () => {
       })
     )
   );
+
   it(
     ...createBuilderSpec<
       TCartDiscountValueGiftLineItem,

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
@@ -59,7 +59,6 @@ describe('builder', () => {
       })
     )
   );
-
   it(
     ...createBuilderSpec<
       TCartDiscountValueGiftLineItem,

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/generator.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/generator.ts
@@ -9,8 +9,8 @@ const generator = Generator<TCartDiscountValueGiftLineItem>({
     type: 'giftLineItem',
     product: fake(() => Reference.random().typeId('product')),
     variantId: fake((f) => f.number.int()),
-    supplyChannelRef: fake(() => Reference.random().typeId('channel')),
-    distributionChannelRef: fake(() => Reference.random().typeId('channel')),
+    supplyChannel: fake(() => Reference.random().typeId('channel')),
+    distributionChannel: fake(() => Reference.random().typeId('channel')),
   },
 });
 

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/generator.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/generator.ts
@@ -9,8 +9,8 @@ const generator = Generator<TCartDiscountValueGiftLineItem>({
     type: 'giftLineItem',
     product: fake(() => Reference.random().typeId('product')),
     variantId: fake((f) => f.number.int()),
-    supplyChannel: fake(() => Reference.random().typeId('channel')),
-    distributionChannel: fake(() => Reference.random().typeId('channel')),
+    supplyChannelRef: fake(() => Reference.random().typeId('channel')),
+    distributionChannelRef: fake(() => Reference.random().typeId('channel')),
   },
 });
 

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
@@ -1,4 +1,4 @@
-import { Reference, TReferenceGraphql } from '@commercetools-test-data/commons';
+import { Reference, TReference } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type {
   TCartDiscountValueGiftLineItem,
@@ -27,12 +27,12 @@ const transformers = {
       const supplyChannelRef = fields.supplyChannel
         ? Reference.random()
             .typeId('channel')
-            .buildGraphql<TReferenceGraphql<'channel'>>()
+            .buildGraphql<TReference<'channel'>>()
         : null;
       const distributionChannelRef = fields.distributionChannel
         ? Reference.random()
             .typeId('channel')
-            .buildGraphql<TReferenceGraphql<'channel'>>()
+            .buildGraphql<TReference<'channel'>>()
         : null;
       return {
         supplyChannelRef,

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
@@ -9,20 +9,23 @@ const transformers = {
     TCartDiscountValueGiftLineItem,
     TCartDiscountValueGiftLineItem
   >('default', {
-    buildFields: ['product', 'supplyChannelRef', 'distributionChannelRef'],
+    buildFields: ['product', 'supplyChannel', 'distributionChannel'],
   }),
   rest: Transformer<
     TCartDiscountValueGiftLineItem,
     TCartDiscountValueGiftLineItem
   >('rest', {
-    buildFields: ['product', 'supplyChannelRef', 'distributionChannelRef'],
+    buildFields: ['product', 'supplyChannel', 'distributionChannel'],
   }),
   graphql: Transformer<
     TCartDiscountValueGiftLineItem,
     TCartDiscountValueGiftLineItemGraphql
   >('graphql', {
-    buildFields: ['product', 'supplyChannelRef', 'distributionChannelRef'],
-    addFields: () => ({
+    buildFields: ['product'],
+    addFields: ({ fields }) => ({
+      ...fields,
+      distributionChannelRef: fields.distributionChannel,
+      supplyChannelRef: fields.supplyChannel,
       __typename: 'GiftLineItemValue',
     }),
   }),

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
@@ -26,12 +26,14 @@ const transformers = {
     addFields: ({ fields }) => {
       const supplyChannelRef = fields.supplyChannel
         ? Reference.random()
+            .id(fields.supplyChannel.id)
             .typeId('channel')
             .buildGraphql<TReference<'channel'>>()
         : null;
 
       const distributionChannelRef = fields.distributionChannel
         ? Reference.random()
+            .id(fields.distributionChannel.id)
             .typeId('channel')
             .buildGraphql<TReference<'channel'>>()
         : null;
@@ -42,6 +44,7 @@ const transformers = {
         __typename: 'GiftLineItemValue',
       };
     },
+    removeFields: ['distributionChannel', 'supplyChannel'],
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
@@ -21,7 +21,7 @@ const transformers = {
     TCartDiscountValueGiftLineItem,
     TCartDiscountValueGiftLineItemGraphql
   >('graphql', {
-    buildFields: ['product'],
+    buildFields: ['product', 'supplyChannel', 'distributionChannel'],
     addFields: ({ fields }) => ({
       ...fields,
       distributionChannelRef: fields.distributionChannel,

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
@@ -22,7 +22,7 @@ const transformers = {
     TCartDiscountValueGiftLineItem,
     TCartDiscountValueGiftLineItemGraphql
   >('graphql', {
-    buildFields: ['product', 'supplyChannel', 'distributionChannel'],
+    buildFields: ['product'],
     addFields: ({ fields }) => {
       const supplyChannelRef = fields.supplyChannel
         ? Reference.random()

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
@@ -29,11 +29,13 @@ const transformers = {
             .typeId('channel')
             .buildGraphql<TReference<'channel'>>()
         : null;
+
       const distributionChannelRef = fields.distributionChannel
         ? Reference.random()
             .typeId('channel')
             .buildGraphql<TReference<'channel'>>()
         : null;
+
       return {
         supplyChannelRef,
         distributionChannelRef,

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
@@ -1,3 +1,4 @@
+import { Reference, TReferenceGraphql } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type {
   TCartDiscountValueGiftLineItem,
@@ -22,12 +23,23 @@ const transformers = {
     TCartDiscountValueGiftLineItemGraphql
   >('graphql', {
     buildFields: ['product', 'supplyChannel', 'distributionChannel'],
-    addFields: ({ fields }) => ({
-      ...fields,
-      distributionChannelRef: fields.distributionChannel,
-      supplyChannelRef: fields.supplyChannel,
-      __typename: 'GiftLineItemValue',
-    }),
+    addFields: ({ fields }) => {
+      const supplyChannelRef = fields.supplyChannel
+        ? Reference.random()
+            .typeId('channel')
+            .buildGraphql<TReferenceGraphql<'channel'>>()
+        : null;
+      const distributionChannelRef = fields.distributionChannel
+        ? Reference.random()
+            .typeId('channel')
+            .buildGraphql<TReferenceGraphql<'channel'>>()
+        : null;
+      return {
+        supplyChannelRef,
+        distributionChannelRef,
+        __typename: 'GiftLineItemValue',
+      };
+    },
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
@@ -9,19 +9,19 @@ const transformers = {
     TCartDiscountValueGiftLineItem,
     TCartDiscountValueGiftLineItem
   >('default', {
-    buildFields: ['product', 'supplyChannel', 'distributionChannel'],
+    buildFields: ['product', 'supplyChannelRef', 'distributionChannelRef'],
   }),
   rest: Transformer<
     TCartDiscountValueGiftLineItem,
     TCartDiscountValueGiftLineItem
   >('rest', {
-    buildFields: ['product', 'supplyChannel', 'distributionChannel'],
+    buildFields: ['product', 'supplyChannelRef', 'distributionChannelRef'],
   }),
   graphql: Transformer<
     TCartDiscountValueGiftLineItem,
     TCartDiscountValueGiftLineItemGraphql
   >('graphql', {
-    buildFields: ['product', 'supplyChannel', 'distributionChannel'],
+    buildFields: ['product', 'supplyChannelRef', 'distributionChannelRef'],
     addFields: () => ({
       __typename: 'GiftLineItemValue',
     }),

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
@@ -2,7 +2,7 @@ import {
   CartDiscountValueGiftLineItem,
   CartDiscountValueGiftLineItemDraft,
 } from '@commercetools/platform-sdk';
-import { TReferenceGraphql } from '@commercetools-test-data/commons';
+import { TReference } from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TCartDiscountValueGiftLineItem = CartDiscountValueGiftLineItem;
@@ -11,13 +11,12 @@ export type TCartDiscountValueGiftLineItemDraft =
 
 export type TCartDiscountValueGiftLineItemGraphql =
   TCartDiscountValueGiftLineItem & {
+    distributionChannelRef: TReference | null;
+    supplyChannelRef: TReference | null;
     __typename: 'GiftLineItemValue';
   };
 export type TCartDiscountValueGiftLineItemDraftGraphql = {
-  giftLineItem: Omit<TCartDiscountValueGiftLineItemDraft, 'type'> & {
-    distributionChannelRef: TReferenceGraphql | null;
-    supplyChannelRef: TReferenceGraphql | null;
-  };
+  giftLineItem: Omit<TCartDiscountValueGiftLineItemDraft, 'type'>;
 };
 
 export type TCartDiscountValueGiftLineItemBuilder =

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
@@ -1,8 +1,8 @@
 import {
   CartDiscountValueGiftLineItem,
   CartDiscountValueGiftLineItemDraft,
-  ChannelReference,
 } from '@commercetools/platform-sdk';
+import { TReferenceGraphql } from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TCartDiscountValueGiftLineItem = CartDiscountValueGiftLineItem;
@@ -15,8 +15,8 @@ export type TCartDiscountValueGiftLineItemGraphql =
   };
 export type TCartDiscountValueGiftLineItemDraftGraphql = {
   giftLineItem: Omit<TCartDiscountValueGiftLineItemDraft, 'type'> & {
-    distributionChannelRef: ChannelReference;
-    supplyChannelRef: ChannelReference;
+    distributionChannelRef: TReferenceGraphql | null;
+    supplyChannelRef: TReferenceGraphql | null;
   };
 };
 

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
@@ -5,13 +5,7 @@ import {
 } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
 
-export type TCartDiscountValueGiftLineItem = Omit<
-  CartDiscountValueGiftLineItem,
-  'supplyChannel' | 'distributionChannel'
-> & {
-  distributionChannelRef: ChannelReference;
-  supplyChannelRef: ChannelReference;
-};
+export type TCartDiscountValueGiftLineItem = CartDiscountValueGiftLineItem;
 export type TCartDiscountValueGiftLineItemDraft =
   CartDiscountValueGiftLineItemDraft;
 
@@ -20,7 +14,10 @@ export type TCartDiscountValueGiftLineItemGraphql =
     __typename: 'GiftLineItemValue';
   };
 export type TCartDiscountValueGiftLineItemDraftGraphql = {
-  giftLineItem: Omit<TCartDiscountValueGiftLineItemDraft, 'type'>;
+  giftLineItem: Omit<TCartDiscountValueGiftLineItemDraft, 'type'> & {
+    distributionChannelRef: ChannelReference;
+    supplyChannelRef: ChannelReference;
+  };
 };
 
 export type TCartDiscountValueGiftLineItemBuilder =

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
@@ -9,12 +9,14 @@ export type TCartDiscountValueGiftLineItem = CartDiscountValueGiftLineItem;
 export type TCartDiscountValueGiftLineItemDraft =
   CartDiscountValueGiftLineItemDraft;
 
-export type TCartDiscountValueGiftLineItemGraphql =
-  TCartDiscountValueGiftLineItem & {
-    distributionChannelRef: TReference | null;
-    supplyChannelRef: TReference | null;
-    __typename: 'GiftLineItemValue';
-  };
+export type TCartDiscountValueGiftLineItemGraphql = Omit<
+  CartDiscountValueGiftLineItem,
+  'supplyChannel' | 'distributionChannel'
+> & {
+  distributionChannelRef: TReference | null;
+  supplyChannelRef: TReference | null;
+  __typename: 'GiftLineItemValue';
+};
 export type TCartDiscountValueGiftLineItemDraftGraphql = {
   giftLineItem: Omit<TCartDiscountValueGiftLineItemDraft, 'type'>;
 };

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
@@ -1,10 +1,17 @@
 import {
   CartDiscountValueGiftLineItem,
   CartDiscountValueGiftLineItemDraft,
+  ChannelReference,
 } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
 
-export type TCartDiscountValueGiftLineItem = CartDiscountValueGiftLineItem;
+export type TCartDiscountValueGiftLineItem = Omit<
+  CartDiscountValueGiftLineItem,
+  'supplyChannel' | 'distributionChannel'
+> & {
+  distributionChannelRef: ChannelReference;
+  supplyChannelRef: ChannelReference;
+};
 export type TCartDiscountValueGiftLineItemDraft =
   CartDiscountValueGiftLineItemDraft;
 


### PR DESCRIPTION
This pr Changes and now we add the missing references to the references


this pr will solve the issue the card discount value when giftline item is selected, I will go with a canary Realize becuase we are modify some hard code data on data examples
```      

 Missing field 'distributionChannelRef' while writing result {
      "type": "giftLineItem",
      "product": {
        "id": "07dff654-196d-4ba0-aae6-3508dfaf7d80",
        "typeId": "product",
        "__typename": "Reference"
      },
      "variantId": 341916377939968,
      "supplyChannel": {
        "id": "ba4652d3-5aef-448c-903c-c8abe4bb48cf",
        "typeId": "channel",
        "__typename": "Reference"
      },
      "distributionChannel": {
        "id": "bd072d11-791a-4d67-a34a-40786c72b9df",
        "typeId": "channel",
        "__typename": "Reference"
      },
      "__typename": "GiftLineItemValue"
    }```

this bug what found during https://app.circleci.com/pipelines/github/commercetools/merchant-center-frontend/85029/workflows/7e3521d2-06f8-46e6-bf4b-d2f3fabdf2af/jobs/1888955

when the value on a card discount is created there are 3 options and the tests fails https://github.com/commercetools/test-data/blob/main/models/cart-discount/src/cart-discount/generator.ts#L27

when CartDiscountValueGiftLineItem.random(), is randomly selected