### PR TITLE
add missing productRef field grapql

### DIFF
--- a/.changeset/brave-lizards-doubt.md
+++ b/.changeset/brave-lizards-doubt.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart-discount': patch
+---
+
+add missing productRef into the grapQl response

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/builder.spec.ts
@@ -69,7 +69,7 @@ describe('builder', () => {
       CartDiscountValueGiftLineItem.random(),
       expect.objectContaining({
         type: 'giftLineItem',
-        product: expect.objectContaining({
+        productRef: expect.objectContaining({
           id: expect.any(String),
           typeId: 'product',
         }),

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
@@ -24,6 +24,10 @@ const transformers = {
   >('graphql', {
     buildFields: ['product'],
     addFields: ({ fields }) => {
+      const productRef = Reference.random()
+        .id(fields.product.id)
+        .typeId('product')
+        .buildGraphql<TReference<'product'>>();
       const supplyChannelRef = fields.supplyChannel
         ? Reference.random()
             .id(fields.supplyChannel.id)
@@ -39,12 +43,13 @@ const transformers = {
         : null;
 
       return {
+        productRef,
         supplyChannelRef,
         distributionChannelRef,
         __typename: 'GiftLineItemValue',
       };
     },
-    removeFields: ['distributionChannel', 'supplyChannel'],
+    removeFields: ['distributionChannel', 'supplyChannel', 'product'],
   }),
 };
 

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/transformers.ts
@@ -22,7 +22,6 @@ const transformers = {
     TCartDiscountValueGiftLineItem,
     TCartDiscountValueGiftLineItemGraphql
   >('graphql', {
-    buildFields: ['product'],
     addFields: ({ fields }) => {
       const productRef = Reference.random()
         .id(fields.product.id)

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
@@ -11,7 +11,7 @@ export type TCartDiscountValueGiftLineItemDraft =
 
 export type TCartDiscountValueGiftLineItemGraphql = Omit<
   CartDiscountValueGiftLineItem,
-  'supplyChannel' | 'distributionChannel'
+  'supplyChannel' | 'distributionChannel' | 'product'
 > & {
   productRef: TReference;
   distributionChannelRef: TReference | null;

--- a/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
+++ b/models/cart-discount/src/cart-discount-value-gift-line-item/types.ts
@@ -13,6 +13,7 @@ export type TCartDiscountValueGiftLineItemGraphql = Omit<
   CartDiscountValueGiftLineItem,
   'supplyChannel' | 'distributionChannel'
 > & {
+  productRef: TReference;
   distributionChannelRef: TReference | null;
   supplyChannelRef: TReference | null;
   __typename: 'GiftLineItemValue';


### PR DESCRIPTION
missing field productRef. was also needed for the GraphQl response.

the bump is needed but it will not be deployed till we merge this prhttps://github.com/commercetools/test-data/pull/583
we merge to main and we get our canary.

 
![329538918-b88cccf6-6afc-4a61-a62c-f805f683138c](https://github.com/commercetools/test-data/assets/64659499/2b73b4f0-623f-4ad4-886b-a338f0a53447)
