### PR TITLE
feat: add stores package  cart discount model

### DIFF
--- a/.changeset/tender-flies-change.md
+++ b/.changeset/tender-flies-change.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart-discount': patch
+---
+
+add stores package to cart discount model and test that cart discount build stores when a store builder is given

--- a/models/cart-discount/package.json
+++ b/models/cart-discount/package.json
@@ -8,14 +8,23 @@
     "url": "https://github.com/commercetools/test-data.git",
     "directory": "models/cart-discount"
   },
-  "keywords": ["javascript", "typescript", "test-data"],
+  "keywords": [
+    "javascript",
+    "typescript",
+    "test-data"
+  ],
   "license": "MIT",
   "publishConfig": {
     "access": "public"
   },
   "main": "dist/commercetools-test-data-cart-discount.cjs.js",
   "module": "dist/commercetools-test-data-cart-discount.esm.js",
-  "files": ["dist", "package.json", "LICENSE", "README.md"],
+  "files": [
+    "dist",
+    "package.json",
+    "LICENSE",
+    "README.md"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
@@ -23,6 +32,7 @@
     "@commercetools-test-data/commons": "8.2.2",
     "@commercetools-test-data/core": "8.2.2",
     "@commercetools-test-data/customer-group": "8.2.2",
+    "@commercetools-test-data/store": "8.2.2",
     "@commercetools-test-data/product-type": "8.2.2",
     "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",

--- a/models/cart-discount/src/cart-discount/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount/builder.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { Store } from '@commercetools-test-data/store';
 import type { TCartDiscount, TCartDiscountGraphql } from './types';
 import * as CartDiscount from './index';
 
@@ -24,7 +25,7 @@ describe('builder', () => {
         }),
         target: null,
         cartPredicate: '1=1',
-        stores: null,
+        stores: [],
         sortOrder: expect.any(String),
         isActive: expect.any(Boolean),
         validFrom: expect.any(String),
@@ -63,7 +64,7 @@ describe('builder', () => {
           type: expect.any(String),
         }),
         cartPredicate: '1=1',
-        stores: null,
+        stores: [],
         sortOrder: expect.any(String),
         isActive: expect.any(Boolean),
         validFrom: expect.any(String),
@@ -107,7 +108,57 @@ describe('builder', () => {
         ]),
         value: expect.any(Object),
         cartPredicate: '1=1',
-        stores: null,
+        stores: [],
+        sortOrder: expect.any(String),
+        isActive: expect.any(Boolean),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        requiresDiscountCode: expect.any(Boolean),
+        references: expect.arrayContaining([]),
+        stackingMode: expect.any(String),
+        createdAt: expect.any(String),
+        createdBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+          userRef: expect.objectContaining({ typeId: 'user' }),
+          __typename: 'Initiator',
+        }),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+          userRef: expect.objectContaining({ typeId: 'user' }),
+          __typename: 'Initiator',
+        }),
+        __typename: 'CartDiscount',
+      })
+    )
+  );
+});
+describe('with Store builder', () => {
+  it(
+    ...createBuilderSpec<TCartDiscount, TCartDiscountGraphql>(
+      'graphql',
+      CartDiscount.random().stores([Store.random()]),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        key: expect.any(String),
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        descriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        value: expect.any(Object),
+        cartPredicate: '1=1',
+        stores: expect.any(Array),
         sortOrder: expect.any(String),
         isActive: expect.any(Boolean),
         validFrom: expect.any(String),

--- a/models/cart-discount/src/cart-discount/generator.ts
+++ b/models/cart-discount/src/cart-discount/generator.ts
@@ -33,7 +33,7 @@ const generator = Generator<TCartDiscount>({
       ])
     ),
     cartPredicate: '1=1',
-    stores: null,
+    stores: [],
     target: null,
     // Faker `min` and `max` bounds are inclusive, we need between 0 and 1
     sortOrder: fake((f) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       '@commercetools-test-data/product-type':
         specifier: 8.2.2
         version: link:../product-type
+      '@commercetools-test-data/store':
+        specifier: 8.2.2
+        version: link:../store
       '@commercetools-test-data/utils':
         specifier: 8.2.2
         version: link:../../utils


### PR DESCRIPTION
Cart discount is having types issues when  he store package is not installed, we install the store package and test that model build the model without yelling errors.
```Type 'TBuilder<Store>' is not assignable to type 'TBuilder<{ readonly id: string | TBuilderMapStateFunction<Store> | TBuilder<unknown>; readonly version: number | TBuilderMapStateFunction<Store> | TBuilder<...>; ... 14 more ...; buildRest: TFieldBuilderArgs<...> | undefined; }>'.
  Type 'TBuilder<Store>' is not assignable to type '{ readonly id: TFieldUpdater<{ readonly id: string | TBuilderMapStateFunction<Store> | TBuilder<unknown>; readonly version: number | TBuilderMapStateFunction<Store> | TBuilder<...>; ... 14 more ...; buildRest: TFieldBuilderArgs<...> | undefined; }, string | ... 1 more ... | TBuilder<...>>; ... 15 more ...; buildRest...'.
    Types of property 'id' are incompatible.
      Type 'TFieldUpdater<Store, string>' is not assignable to type 'TFieldUpdater<{ readonly id: string | TBuilderMapStateFunction<Store> | TBuilder<unknown>; readonly version: number | TBuilderMapStateFunction<Store> | TBuilder<...>; ... 14 more ...; buildRest: TFieldBuilderArgs<...> | undefined; }, string | ... 1 more ... | TBuilder<...>>'.
        Types of parameters 'fnOrValue' and 'fnOrValue' are incompatible.
          Type 'string | TBuilder<...> | TBuilder<Model>[] | TBuilderMapStateFunction<...> | TBuilder<...> | TBuilderMapStateFunction<...>' is not assignable to type 'string | TBuilderMapStateFunction<Store> | TBuilder<unknown> | TBuilder<unknown>[]'.
            Type 'TBuilderMapStateFunction<{ readonly id: string | TBuilderMapStateFunction<Store> | TBuilder<unknown>; readonly version: number | TBuilderMapStateFunction<Store> | TBuilder<...>; ... 14 more ...; buildRest: TFieldBuilderArgs<...> | undefined; }>' is not assignable to type 'string | TBuilderMapStateFunction<Store> | TBuilder<unknown> | TBuilder<unknown>[]'.
              Type 'TBuilderMapStateFunction<{ readonly id: string | TBuilderMapStateFunction<Store> | TBuilder<unknown>; readonly version: number | TBuilderMapStateFunction<Store> | TBuilder<...>; ... 14 more ...; buildRest: TFieldBuilderArgs<...> | undefined; }>' is not assignable to type 'TBuilderMapStateFunction<Store>'.
                Types of parameters 'state' and 'state' are incompatible.
                  Type 'Partial<Store>' is not assignable to type 'Partial<{ readonly id: string | TBuilderMapStateFunction<Store> | TBuilder<unknown>; readonly version: number | TBuilderMapStateFunction<Store> | TBuilder<...>; ... 14 more ...; buildRest: TFieldBuilderArgs<...> | undefined; }>'.
                    Types of property 'languages' are incompatible.
                      Type 'string[] | undefined' is not assignable to type 'TBuilderMapStateFunction<Store> | TBuilder<unknown> | undefined'.
                        Type 'string[]' is not assignable to type 'TBuilderMapStateFunction<Store> | TBuilder<unknown> | undefined'.ts(2322)
(alias) random(): Store.TStoreBuilder
export random


<img width="1512" alt="Screenshot 2024-05-16 at 07 29 18" src="https://github.com/commercetools/test-data/assets/64659499/d97d8c59-6fe0-4e5c-8cc9-760f59929e9b">
