### PR TITLE
Revert "Version Packages"

### DIFF
--- a/.changeset/brave-lizards-doubt.md
+++ b/.changeset/brave-lizards-doubt.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart-discount': patch
+---
+
+add missing productRef into the grapQl response

--- a/.changeset/cuddly-socks-compete.md
+++ b/.changeset/cuddly-socks-compete.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart-discount': patch
+---
+
+add disctributionChannelRef and supplyChanelRef to discunt value gift line item test data in the fraphQl response

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,7 +1,5 @@
 # @commercetools-test-data/core
 
-## 8.2.3
-
 ## 8.2.2
 
 ## 8.2.1

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/core",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "This package provides the core functions to define the data models",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {

--- a/graphql-types/CHANGELOG.md
+++ b/graphql-types/CHANGELOG.md
@@ -1,7 +1,5 @@
 # @commercetools-test-data/graphql-types
 
-## 8.2.3
-
 ## 8.2.2
 
 ## 8.2.1

--- a/graphql-types/package.json
+++ b/graphql-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/graphql-types",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Generated GraphQL types based on the GraphQL API schemas",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {

--- a/models/associate-role/CHANGELOG.md
+++ b/models/associate-role/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/associate-role
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/associate-role/package.json
+++ b/models/associate-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/associate-role",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API AssociateRole",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/business-unit/CHANGELOG.md
+++ b/models/business-unit/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @commercetools-test-data/business-unit
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/associate-role@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/customer@8.2.3
-  - @commercetools-test-data/store@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/business-unit/package.json
+++ b/models/business-unit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/business-unit",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data models for commercetools API Business Unit",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,12 +19,12 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/associate-role": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/customer": "8.2.3",
-    "@commercetools-test-data/store": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/associate-role": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/customer": "8.2.2",
+    "@commercetools-test-data/store": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/cart-discount/CHANGELOG.md
+++ b/models/cart-discount/CHANGELOG.md
@@ -1,21 +1,5 @@
 # @commercetools-test-data/cart-discount
 
-## 8.2.3
-
-### Patch Changes
-
-- [#585](https://github.com/commercetools/test-data/pull/585) [`94327e8`](https://github.com/commercetools/test-data/commit/94327e8969fab3b92007f0f09651cfaa6a984e9a) Thanks [@ARRIOLALEO](https://github.com/ARRIOLALEO)! - add missing productRef into the grapQl response
-
-- [#582](https://github.com/commercetools/test-data/pull/582) [`b1cb62c`](https://github.com/commercetools/test-data/commit/b1cb62c6a33e923b433c1e6bc8dc4069a498f771) Thanks [@ARRIOLALEO](https://github.com/ARRIOLALEO)! - add disctributionChannelRef and supplyChanelRef to discunt value gift line item test data in the fraphQl response
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/category@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/customer-group@8.2.3
-  - @commercetools-test-data/product-type@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/cart-discount/package.json
+++ b/models/cart-discount/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/cart-discount",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data models for commercetools API CartDiscount",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,12 +19,12 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/category": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/customer-group": "8.2.3",
-    "@commercetools-test-data/product-type": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/category": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/customer-group": "8.2.2",
+    "@commercetools-test-data/product-type": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/cart/CHANGELOG.md
+++ b/models/cart/CHANGELOG.md
@@ -1,22 +1,5 @@
 # @commercetools-test-data/cart
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/discount-code@8.2.3
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/business-unit@8.2.3
-  - @commercetools-test-data/channel@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/customer@8.2.3
-  - @commercetools-test-data/product@8.2.3
-  - @commercetools-test-data/shipping-method@8.2.3
-  - @commercetools-test-data/store@8.2.3
-  - @commercetools-test-data/tax-category@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/cart/package.json
+++ b/models/cart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/cart",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Cart",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,17 +19,17 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/business-unit": "8.2.3",
-    "@commercetools-test-data/channel": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/customer": "8.2.3",
-    "@commercetools-test-data/discount-code": "8.2.3",
-    "@commercetools-test-data/product": "8.2.3",
-    "@commercetools-test-data/shipping-method": "8.2.3",
-    "@commercetools-test-data/store": "8.2.3",
-    "@commercetools-test-data/tax-category": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/business-unit": "8.2.2",
+    "@commercetools-test-data/channel": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/customer": "8.2.2",
+    "@commercetools-test-data/discount-code": "8.2.2",
+    "@commercetools-test-data/product": "8.2.2",
+    "@commercetools-test-data/shipping-method": "8.2.2",
+    "@commercetools-test-data/store": "8.2.2",
+    "@commercetools-test-data/tax-category": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/category/CHANGELOG.md
+++ b/models/category/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/category
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/category/package.json
+++ b/models/category/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/category",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Category",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/channel/CHANGELOG.md
+++ b/models/channel/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/channel
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/channel/package.json
+++ b/models/channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/channel",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Channel",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/commons/CHANGELOG.md
+++ b/models/commons/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @commercetools-test-data/commons
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/commons/package.json
+++ b/models/commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/commons",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools platform common types",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,8 +19,8 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0",
     "@types/lodash": "^4.17.0",

--- a/models/custom-application/CHANGELOG.md
+++ b/models/custom-application/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @commercetools-test-data/custom-application
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/graphql-types@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/custom-application/package.json
+++ b/models/custom-application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/custom-application",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for internal Merchant Center API Custom Application",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -21,10 +21,10 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-frontend/application-config": "^22.10.0",
     "@commercetools-frontend/constants": "^22.10.0",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/graphql-types": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/graphql-types": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0",
     "@types/lodash": "^4.14.182",

--- a/models/custom-object/CHANGELOG.md
+++ b/models/custom-object/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/custom-object
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/custom-object/package.json
+++ b/models/custom-object/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/custom-object",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API CustomObject",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/custom-view/CHANGELOG.md
+++ b/models/custom-view/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @commercetools-test-data/custom-view
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/graphql-types@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/custom-view/package.json
+++ b/models/custom-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/custom-view",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for internal Merchan Center API Custom View",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -21,10 +21,10 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-frontend/application-config": "^22.10.0",
     "@commercetools-frontend/constants": "^22.10.0",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/graphql-types": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/graphql-types": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0",
     "@types/lodash": "^4.17.0",

--- a/models/customer-group/CHANGELOG.md
+++ b/models/customer-group/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/customer-group
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/customer-group/package.json
+++ b/models/customer-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/customer-group",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Customer Group",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/customer/CHANGELOG.md
+++ b/models/customer/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @commercetools-test-data/customer
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/customer-group@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/customer/package.json
+++ b/models/customer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/customer",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Customer",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,10 +19,10 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/customer-group": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/customer-group": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/discount-code/CHANGELOG.md
+++ b/models/discount-code/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @commercetools-test-data/discount-code
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies [[`94327e8`](https://github.com/commercetools/test-data/commit/94327e8969fab3b92007f0f09651cfaa6a984e9a), [`b1cb62c`](https://github.com/commercetools/test-data/commit/b1cb62c6a33e923b433c1e6bc8dc4069a498f771)]:
-  - @commercetools-test-data/cart-discount@8.2.3
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/discount-code/package.json
+++ b/models/discount-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/discount-code",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API DiscountCode",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,10 +19,10 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/cart-discount": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/cart-discount": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/inventory-entry/CHANGELOG.md
+++ b/models/inventory-entry/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @commercetools-test-data/inventory-entry
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/channel@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/product@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/inventory-entry/package.json
+++ b/models/inventory-entry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/inventory-entry",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API InventoryEntry",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,11 +19,11 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/channel": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/product": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/channel": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/product": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/order/CHANGELOG.md
+++ b/models/order/CHANGELOG.md
@@ -1,18 +1,5 @@
 # @commercetools-test-data/order
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies [[`94327e8`](https://github.com/commercetools/test-data/commit/94327e8969fab3b92007f0f09651cfaa6a984e9a), [`b1cb62c`](https://github.com/commercetools/test-data/commit/b1cb62c6a33e923b433c1e6bc8dc4069a498f771)]:
-  - @commercetools-test-data/cart-discount@8.2.3
-  - @commercetools-test-data/cart@8.2.3
-  - @commercetools-test-data/quote@8.2.3
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/customer-group@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/order/package.json
+++ b/models/order/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/order",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Order",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,13 +19,13 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/cart": "8.2.3",
-    "@commercetools-test-data/cart-discount": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/customer-group": "8.2.3",
-    "@commercetools-test-data/quote": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/cart": "8.2.2",
+    "@commercetools-test-data/cart-discount": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/customer-group": "8.2.2",
+    "@commercetools-test-data/quote": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/organization/CHANGELOG.md
+++ b/models/organization/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @commercetools-test-data/organization
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/graphql-types@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/user@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/organization/package.json
+++ b/models/organization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/organization",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Organization",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,11 +19,11 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/graphql-types": "8.2.3",
-    "@commercetools-test-data/user": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/graphql-types": "8.2.2",
+    "@commercetools-test-data/user": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0"
   }
 }

--- a/models/payment/CHANGELOG.md
+++ b/models/payment/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @commercetools-test-data/payment
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/order@8.2.3
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/customer@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/payment/package.json
+++ b/models/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/payment",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data models for commercetools Payment representations",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,11 +19,11 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/customer": "8.2.3",
-    "@commercetools-test-data/order": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/customer": "8.2.2",
+    "@commercetools-test-data/order": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/product-discount/CHANGELOG.md
+++ b/models/product-discount/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @commercetools-test-data/product-discount
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/category@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/product-type@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/product-discount/package.json
+++ b/models/product-discount/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/product-discount",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API ProductDiscount",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,11 +19,11 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/category": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/product-type": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/category": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/product-type": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/product-selection/CHANGELOG.md
+++ b/models/product-selection/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/product-selection
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/product-selection/package.json
+++ b/models/product-selection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/product-selection",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API ProductSelection",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/product-type/CHANGELOG.md
+++ b/models/product-type/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/product-type
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/product-type/package.json
+++ b/models/product-type/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/product-type",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API ProductType",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/product/CHANGELOG.md
+++ b/models/product/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @commercetools-test-data/product
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/category@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/product-type@8.2.3
-  - @commercetools-test-data/tax-category@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/product/package.json
+++ b/models/product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/product",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data models for commercetools API Product",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -20,13 +20,13 @@
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/attribute-definition": "5.11.2",
-    "@commercetools-test-data/category": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/product-type": "8.2.3",
+    "@commercetools-test-data/category": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/product-type": "8.2.2",
     "@commercetools-test-data/product-variant": "5.11.2",
-    "@commercetools-test-data/tax-category": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/tax-category": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/project/CHANGELOG.md
+++ b/models/project/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @commercetools-test-data/project
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/project/package.json
+++ b/models/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/project",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Project",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,8 +19,8 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0"
   }
 }

--- a/models/quote-request/CHANGELOG.md
+++ b/models/quote-request/CHANGELOG.md
@@ -1,19 +1,5 @@
 # @commercetools-test-data/quote-request
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/cart@8.2.3
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/business-unit@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/customer@8.2.3
-  - @commercetools-test-data/customer-group@8.2.3
-  - @commercetools-test-data/store@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/quote-request/package.json
+++ b/models/quote-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/quote-request",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API QuoteRequest",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,14 +19,14 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/business-unit": "8.2.3",
-    "@commercetools-test-data/cart": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/customer": "8.2.3",
-    "@commercetools-test-data/customer-group": "8.2.3",
-    "@commercetools-test-data/store": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/business-unit": "8.2.2",
+    "@commercetools-test-data/cart": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/customer": "8.2.2",
+    "@commercetools-test-data/customer-group": "8.2.2",
+    "@commercetools-test-data/store": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/quote/CHANGELOG.md
+++ b/models/quote/CHANGELOG.md
@@ -1,21 +1,5 @@
 # @commercetools-test-data/quote
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/cart@8.2.3
-  - @commercetools-test-data/quote-request@8.2.3
-  - @commercetools-test-data/staged-quote@8.2.3
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/business-unit@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/customer@8.2.3
-  - @commercetools-test-data/customer-group@8.2.3
-  - @commercetools-test-data/store@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/quote/package.json
+++ b/models/quote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/quote",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Quote",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,16 +19,16 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/business-unit": "8.2.3",
-    "@commercetools-test-data/cart": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/customer": "8.2.3",
-    "@commercetools-test-data/customer-group": "8.2.3",
-    "@commercetools-test-data/quote-request": "8.2.3",
-    "@commercetools-test-data/staged-quote": "^8.2.3",
-    "@commercetools-test-data/store": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/business-unit": "8.2.2",
+    "@commercetools-test-data/cart": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/customer": "8.2.2",
+    "@commercetools-test-data/customer-group": "8.2.2",
+    "@commercetools-test-data/quote-request": "8.2.2",
+    "@commercetools-test-data/staged-quote": "^8.2.2",
+    "@commercetools-test-data/store": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/review/CHANGELOG.md
+++ b/models/review/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/review
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/review/package.json
+++ b/models/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/review",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Review",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/shipping-method/CHANGELOG.md
+++ b/models/shipping-method/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @commercetools-test-data/shipping-method
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/tax-category@8.2.3
-  - @commercetools-test-data/zone@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/shipping-method/package.json
+++ b/models/shipping-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/shipping-method",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data models for commercetools Shipping Method representations",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,11 +19,11 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/tax-category": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
-    "@commercetools-test-data/zone": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/tax-category": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
+    "@commercetools-test-data/zone": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/shopping-list/CHANGELOG.md
+++ b/models/shopping-list/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/shopping-list
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/shopping-list/package.json
+++ b/models/shopping-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/shopping-list",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Shopping List",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/staged-quote/CHANGELOG.md
+++ b/models/staged-quote/CHANGELOG.md
@@ -1,20 +1,5 @@
 # @commercetools-test-data/staged-quote
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/cart@8.2.3
-  - @commercetools-test-data/quote-request@8.2.3
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/business-unit@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/customer@8.2.3
-  - @commercetools-test-data/customer-group@8.2.3
-  - @commercetools-test-data/store@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/staged-quote/package.json
+++ b/models/staged-quote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/staged-quote",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API StagedQuote",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,15 +19,15 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/business-unit": "8.2.3",
-    "@commercetools-test-data/cart": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/customer": "8.2.3",
-    "@commercetools-test-data/customer-group": "8.2.3",
-    "@commercetools-test-data/quote-request": "8.2.3",
-    "@commercetools-test-data/store": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/business-unit": "8.2.2",
+    "@commercetools-test-data/cart": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/customer": "8.2.2",
+    "@commercetools-test-data/customer-group": "8.2.2",
+    "@commercetools-test-data/quote-request": "8.2.2",
+    "@commercetools-test-data/store": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/standalone-price/CHANGELOG.md
+++ b/models/standalone-price/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @commercetools-test-data/standalone-price
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/channel@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/customer-group@8.2.3
-  - @commercetools-test-data/product@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/standalone-price/package.json
+++ b/models/standalone-price/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/standalone-price",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API StandalonePrice",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,12 +19,12 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/channel": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/customer-group": "8.2.3",
-    "@commercetools-test-data/product": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/channel": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/customer-group": "8.2.2",
+    "@commercetools-test-data/product": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/state/CHANGELOG.md
+++ b/models/state/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/state
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/state/package.json
+++ b/models/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/state",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API State",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/store/CHANGELOG.md
+++ b/models/store/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @commercetools-test-data/store
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/channel@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/product-selection@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/store/package.json
+++ b/models/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/store",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data models for commercetools Store representations",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,11 +19,11 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/channel": "8.2.3",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/product-selection": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/channel": "8.2.2",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/product-selection": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/tax-category/CHANGELOG.md
+++ b/models/tax-category/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/tax-category
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/tax-category/package.json
+++ b/models/tax-category/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/tax-category",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data models for commercetools Tax Category representations",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/type/CHANGELOG.md
+++ b/models/type/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/type
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/type/package.json
+++ b/models/type/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/type",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Type",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/user/CHANGELOG.md
+++ b/models/user/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @commercetools-test-data/user
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/graphql-types@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/project@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/user/package.json
+++ b/models/user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/user",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API User",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,11 +19,11 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/graphql-types": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/graphql-types": "8.2.2",
     "@commercetools-test-data/project": "workspace:^",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/zone/CHANGELOG.md
+++ b/models/zone/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @commercetools-test-data/zone
 
-## 8.2.3
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @commercetools-test-data/core@8.2.3
-  - @commercetools-test-data/commons@8.2.3
-  - @commercetools-test-data/utils@8.2.3
-
 ## 8.2.2
 
 ### Patch Changes

--- a/models/zone/package.json
+++ b/models/zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/zone",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools API Zones",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "8.2.3",
-    "@commercetools-test-data/core": "8.2.3",
-    "@commercetools-test-data/utils": "8.2.3",
+    "@commercetools-test-data/commons": "8.2.2",
+    "@commercetools-test-data/core": "8.2.2",
+    "@commercetools-test-data/utils": "8.2.2",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,13 +140,13 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -164,22 +164,22 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/associate-role':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../associate-role
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/customer':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer
       '@commercetools-test-data/store':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../store
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -197,37 +197,37 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/business-unit':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../business-unit
       '@commercetools-test-data/channel':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../channel
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/customer':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer
       '@commercetools-test-data/discount-code':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../discount-code
       '@commercetools-test-data/product':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../product
       '@commercetools-test-data/shipping-method':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../shipping-method
       '@commercetools-test-data/store':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../store
       '@commercetools-test-data/tax-category':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../tax-category
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -245,22 +245,22 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/category':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../category
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/customer-group':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer-group
       '@commercetools-test-data/product-type':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../product-type
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -278,13 +278,13 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -302,13 +302,13 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -326,10 +326,10 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -359,16 +359,16 @@ importers:
         specifier: ^22.10.0
         version: 22.10.0
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/graphql-types':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../graphql-types
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -392,13 +392,13 @@ importers:
         specifier: ^7.17.9
         version: 7.23.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -422,16 +422,16 @@ importers:
         specifier: ^22.10.0
         version: 22.10.0
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/graphql-types':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../graphql-types
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -455,16 +455,16 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/customer-group':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer-group
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -482,13 +482,13 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -506,16 +506,16 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/cart-discount':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../cart-discount
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -533,19 +533,19 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/channel':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../channel
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/product':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../product
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -563,25 +563,25 @@ importers:
         specifier: ^7.17.9
         version: 7.21.0
       '@commercetools-test-data/cart':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../cart
       '@commercetools-test-data/cart-discount':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../cart-discount
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/customer-group':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer-group
       '@commercetools-test-data/quote':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../quote
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -599,19 +599,19 @@ importers:
         specifier: ^7.17.9
         version: 7.23.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/graphql-types':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../graphql-types
       '@commercetools-test-data/user':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../user
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -626,19 +626,19 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/customer':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer
       '@commercetools-test-data/order':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../order
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -659,25 +659,25 @@ importers:
         specifier: 5.11.2
         version: 5.11.2
       '@commercetools-test-data/category':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../category
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/product-type':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../product-type
       '@commercetools-test-data/product-variant':
         specifier: 5.11.2
         version: 5.11.2
       '@commercetools-test-data/tax-category':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../tax-category
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -695,19 +695,19 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/category':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../category
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/product-type':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../product-type
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -725,13 +725,13 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -749,13 +749,13 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -773,10 +773,10 @@ importers:
         specifier: ^7.17.9
         version: 7.23.4
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -791,34 +791,34 @@ importers:
         specifier: ^7.17.9
         version: 7.23.4
       '@commercetools-test-data/business-unit':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../business-unit
       '@commercetools-test-data/cart':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../cart
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/customer':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer
       '@commercetools-test-data/customer-group':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer-group
       '@commercetools-test-data/quote-request':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../quote-request
       '@commercetools-test-data/staged-quote':
-        specifier: ^8.2.3
+        specifier: ^8.2.2
         version: link:../staged-quote
       '@commercetools-test-data/store':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../store
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -836,28 +836,28 @@ importers:
         specifier: ^7.17.9
         version: 7.23.1
       '@commercetools-test-data/business-unit':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../business-unit
       '@commercetools-test-data/cart':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../cart
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/customer':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer
       '@commercetools-test-data/customer-group':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer-group
       '@commercetools-test-data/store':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../store
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -875,13 +875,13 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -899,19 +899,19 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/tax-category':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../tax-category
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools-test-data/zone':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../zone
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -929,13 +929,13 @@ importers:
         specifier: ^7.17.9
         version: 7.23.1
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -953,31 +953,31 @@ importers:
         specifier: ^7.17.9
         version: 7.23.1
       '@commercetools-test-data/business-unit':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../business-unit
       '@commercetools-test-data/cart':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../cart
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/customer':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer
       '@commercetools-test-data/customer-group':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer-group
       '@commercetools-test-data/quote-request':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../quote-request
       '@commercetools-test-data/store':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../store
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -995,22 +995,22 @@ importers:
         specifier: ^7.17.9
         version: 7.23.4
       '@commercetools-test-data/channel':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../channel
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/customer-group':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../customer-group
       '@commercetools-test-data/product':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../product
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -1028,13 +1028,13 @@ importers:
         specifier: ^7.17.9
         version: 7.23.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -1052,19 +1052,19 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/channel':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../channel
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/product-selection':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../product-selection
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -1082,13 +1082,13 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -1106,13 +1106,13 @@ importers:
         specifier: ^7.17.9
         version: 7.23.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -1130,19 +1130,19 @@ importers:
         specifier: ^7.17.9
         version: 7.23.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/graphql-types':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../graphql-types
       '@commercetools-test-data/project':
         specifier: workspace:^
         version: link:../project
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
@@ -1160,13 +1160,13 @@ importers:
         specifier: ^7.17.9
         version: 7.19.4
       '@commercetools-test-data/commons':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 8.2.3
+        specifier: 8.2.2
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -1,7 +1,5 @@
 # @commercetools-test-data/utils
 
-## 8.2.3
-
 ## 8.2.2
 
 ## 8.2.1

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/utils",
-  "version": "8.2.3",
+  "version": "8.2.2",
   "description": "Data model for commercetools platform common types",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {


### PR DESCRIPTION
Reverts commercetools/test-data#583

last deployment contains an error related with the cart discount types need to revert to prevent usage, it was myself the person who deployed. the version packages