### PR TITLE
refactor: improve DX when using LocalizedString

### DIFF
--- a/.changeset/large-laws-listen.md
+++ b/.changeset/large-laws-listen.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/commons': patch
+---
+
+Improve DX of LocalizedString

--- a/models/commons/src/localized-string/types.ts
+++ b/models/commons/src/localized-string/types.ts
@@ -2,7 +2,7 @@ import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TLocalizedString = {
   [locale: string]: string | undefined;
-};
+} & Partial<Record<'de' | 'en' | 'fr', string>>;
 export type TLocalizedStringGraphql = {
   __typename: 'LocalizedString';
   locale: string;


### PR DESCRIPTION
When using `LocalizedString` (or `LocalizedStringDraft`) TS complains when trying to set a value for a locale.
With the following code and the current implementation of `LocalizedString` we get this error `Cannot invoke an object which is possibly 'undefined'.`
```
LocalizedString.random().en("test")
```
We can somehow mute the compiler by using the non-null assertion operator (`!`) and TS would not complain again
```
LocalizedString.random().en!("test")
```
The issue is the current type doesn't guarantee that the 'en' locale really exists on the object.

As a suggestion to improve the DX when using `LocalizedString`, this PR modifies the types from

```
export type TLocalizedString = {
  [locale: string]: string | undefined;
};
```
to
```
export type TLocalizedString = {
  [locale: string]: string | undefined;
} & Partial<Record<'de' | 'en' | 'fr', string>>;
```
The reason is the builder is already providing random values for `de`, `en`, `fr` locales and the consumers of the package could use `LocalizedString.random().en("test")` with ease.

Objections are welcomed. I might be missing some other issues.