### PR TITLE
[Breaking]: FCT-726 update exports for Reference and ReferenceDraft presets to simplify call syntax

### DIFF
--- a/.changeset/chilled-dryers-relax.md
+++ b/.changeset/chilled-dryers-relax.md
@@ -1,0 +1,16 @@
+---
+'@commercetools-test-data/inventory-entry': major
+'@commercetools-test-data/business-unit': major
+'@commercetools-test-data/quote-request': major
+'@commercetools-test-data/staged-quote': major
+'@commercetools-test-data/commons': major
+'@commercetools-test-data/payment': major
+'@commercetools-test-data/quote': major
+---
+
+This breaking change updates the export method for Reference and ReferenceDraft presets to simplify the call syntax. Models that use these presets in their generators or transformers are also updated.
+
+Updating this package will require changes in your codebase. To migrate:
+
+- Replace any instance of `Reference.presets.<preset-name>.<preset-name>()` with `Reference.presets.<preset-name>()`
+- Replace any instance of `ReferenceDraft.presets.<preset-name>.<preset-name>()` with `ReferenceDraft.presets.<preset-name>()`

--- a/models/business-unit/src/associate-role-assignment/associate-role-assignment-draft/generator.ts
+++ b/models/business-unit/src/associate-role-assignment/associate-role-assignment-draft/generator.ts
@@ -7,9 +7,7 @@ import { TAssociateRoleAssignmentDraft } from '../types';
 
 const generator = Generator<TAssociateRoleAssignmentDraft>({
   fields: {
-    associateRole: fake(() =>
-      ReferenceDraft.presets.associateRoleReference.associateRoleReference()
-    ),
+    associateRole: fake(() => ReferenceDraft.presets.associateRoleReference()),
     inheritance: oneOf(...Object.values(associateRoleInheritanceMode)),
   },
 });

--- a/models/business-unit/src/associate/associate-draft/generator.ts
+++ b/models/business-unit/src/associate/associate-draft/generator.ts
@@ -10,9 +10,7 @@ const generator = Generator<TAssociateDraft>({
     associateRoleAssignments: fake(() => [
       AssociateRoleAssignmentDraft.random(),
     ]),
-    customer: fake(() =>
-      ReferenceDraft.presets.customerReference.customerReference()
-    ),
+    customer: fake(() => ReferenceDraft.presets.customerReference()),
   },
 });
 

--- a/models/business-unit/src/associate/generator.ts
+++ b/models/business-unit/src/associate/generator.ts
@@ -8,9 +8,7 @@ import { TAssociateDefault } from './types';
 const generator = Generator<TAssociateDefault>({
   fields: {
     associateRoleAssignments: fake(() => [AssociateRoleAssignment.random()]),
-    customer: fake(() =>
-      Reference.presets.customerReference.customerReference()
-    ),
+    customer: fake(() => Reference.presets.customerReference()),
   },
 });
 

--- a/models/business-unit/src/associate/transformers.ts
+++ b/models/business-unit/src/associate/transformers.ts
@@ -17,11 +17,10 @@ const transformers = {
   rest: Transformer<TAssociateDefault, TAssociateRest>('rest', {
     buildFields: ['associateRoleAssignments', 'customer'],
     replaceFields: ({ fields }) => {
-      const customer: TReference<'customer'> =
-        Reference.presets.customerReference
-          .customerReference()
-          .id(fields.customer.id)
-          .build();
+      const customer: TReference<'customer'> = Reference.presets
+        .customerReference()
+        .id(fields.customer.id)
+        .build();
       return {
         ...fields,
         customer,
@@ -31,7 +30,7 @@ const transformers = {
   graphql: Transformer<TAssociateDefault, TAssociateGraphql>('graphql', {
     buildFields: ['associateRoleAssignments', 'customer'],
     replaceFields: ({ fields }) => {
-      const customerRef: TReferenceGraphql = Reference.presets.customerReference
+      const customerRef: TReferenceGraphql = Reference.presets
         .customerReference()
         .id(fields.customer.id)
         .buildGraphql();

--- a/models/commons/src/reference/presets/associate-role/index.ts
+++ b/models/commons/src/reference/presets/associate-role/index.ts
@@ -1,5 +1,1 @@
-import associateRoleReference from './associate-role-reference';
-
-const presets = { associateRoleReference };
-
-export default presets;
+export { default } from './associate-role-reference';

--- a/models/commons/src/reference/presets/attribute-group/index.ts
+++ b/models/commons/src/reference/presets/attribute-group/index.ts
@@ -1,5 +1,1 @@
-import attributeGroupReference from './attribute-group-reference';
-
-const presets = { attributeGroupReference };
-
-export default presets;
+export { default } from './attribute-group-reference';

--- a/models/commons/src/reference/presets/business-unit/index.ts
+++ b/models/commons/src/reference/presets/business-unit/index.ts
@@ -1,5 +1,1 @@
-import businessUnitReference from './business-unit-reference';
-
-const presets = { businessUnitReference };
-
-export default presets;
+export { default } from './business-unit-reference';

--- a/models/commons/src/reference/presets/cart-discount/index.ts
+++ b/models/commons/src/reference/presets/cart-discount/index.ts
@@ -1,5 +1,1 @@
-import cartDiscountReference from './cart-discount-reference';
-
-const presets = { cartDiscountReference };
-
-export default presets;
+export { default } from './cart-discount-reference';

--- a/models/commons/src/reference/presets/cart/index.ts
+++ b/models/commons/src/reference/presets/cart/index.ts
@@ -1,5 +1,1 @@
-import cartReference from './cart-reference';
-
-const presets = { cartReference };
-
-export default presets;
+export { default } from './cart-reference';

--- a/models/commons/src/reference/presets/category/index.ts
+++ b/models/commons/src/reference/presets/category/index.ts
@@ -1,5 +1,1 @@
-import categoryReference from './category-reference';
-
-const presets = { categoryReference };
-
-export default presets;
+export { default } from './category-reference';

--- a/models/commons/src/reference/presets/channel/index.ts
+++ b/models/commons/src/reference/presets/channel/index.ts
@@ -1,5 +1,1 @@
-import channelReference from './channel-reference';
-
-const presets = { channelReference };
-
-export default presets;
+export { default } from './channel-reference';

--- a/models/commons/src/reference/presets/customer-group/index.ts
+++ b/models/commons/src/reference/presets/customer-group/index.ts
@@ -1,5 +1,1 @@
-import customerGroupReference from './customer-group-reference';
-
-const presets = { customerGroupReference };
-
-export default presets;
+export { default } from './customer-group-reference';

--- a/models/commons/src/reference/presets/customer/index.ts
+++ b/models/commons/src/reference/presets/customer/index.ts
@@ -1,5 +1,1 @@
-import customerReference from './customer-reference';
-
-const presets = { customerReference };
-
-export default presets;
+export { default } from './customer-reference';

--- a/models/commons/src/reference/presets/direct-discount/index.ts
+++ b/models/commons/src/reference/presets/direct-discount/index.ts
@@ -1,5 +1,1 @@
-import directDiscountReference from './direct-discount-reference';
-
-const presets = { directDiscountReference };
-
-export default presets;
+export { default } from './direct-discount-reference';

--- a/models/commons/src/reference/presets/discount-code/index.ts
+++ b/models/commons/src/reference/presets/discount-code/index.ts
@@ -1,5 +1,1 @@
-import discountCodeReference from './discount-code-reference';
-
-const presets = { discountCodeReference };
-
-export default presets;
+export { default } from './discount-code-reference';

--- a/models/commons/src/reference/presets/extension/index.ts
+++ b/models/commons/src/reference/presets/extension/index.ts
@@ -1,5 +1,1 @@
-import extensionReference from './extension-reference';
-
-const presets = { extensionReference };
-
-export default presets;
+export { default } from './extension-reference';

--- a/models/commons/src/reference/presets/inventory-entry/index.ts
+++ b/models/commons/src/reference/presets/inventory-entry/index.ts
@@ -1,5 +1,1 @@
-import inventoryEntryReference from './inventory-entry-reference';
-
-const presets = { inventoryEntryReference };
-
-export default presets;
+export { default } from './inventory-entry-reference';

--- a/models/commons/src/reference/presets/key-value-document/index.ts
+++ b/models/commons/src/reference/presets/key-value-document/index.ts
@@ -1,5 +1,1 @@
-import keyValueDocumentReference from './key-value-document-reference';
-
-const presets = { keyValueDocumentReference };
-
-export default presets;
+export { default } from './key-value-document-reference';

--- a/models/commons/src/reference/presets/order-edit/index.ts
+++ b/models/commons/src/reference/presets/order-edit/index.ts
@@ -1,5 +1,1 @@
-import orderEditReference from './order-edit-reference';
-
-const presets = { orderEditReference };
-
-export default presets;
+export { default } from './order-edit-reference';

--- a/models/commons/src/reference/presets/order/index.ts
+++ b/models/commons/src/reference/presets/order/index.ts
@@ -1,5 +1,1 @@
-import orderReference from './order-reference';
-
-const presets = { orderReference };
-
-export default presets;
+export { default } from './order-reference';

--- a/models/commons/src/reference/presets/payment/index.ts
+++ b/models/commons/src/reference/presets/payment/index.ts
@@ -1,5 +1,1 @@
-import paymentReference from './payment-reference';
-
-const presets = { paymentReference };
-
-export default presets;
+export { default } from './payment-reference';

--- a/models/commons/src/reference/presets/product-discount/index.ts
+++ b/models/commons/src/reference/presets/product-discount/index.ts
@@ -1,5 +1,1 @@
-import productDiscountReference from './product-discount-reference';
-
-const presets = { productDiscountReference };
-
-export default presets;
+export { default } from './product-discount-reference';

--- a/models/commons/src/reference/presets/product-price/index.ts
+++ b/models/commons/src/reference/presets/product-price/index.ts
@@ -1,5 +1,1 @@
-import productPriceReference from './product-price-reference';
-
-const presets = { productPriceReference };
-
-export default presets;
+export { default } from './product-price-reference';

--- a/models/commons/src/reference/presets/product-selection/index.ts
+++ b/models/commons/src/reference/presets/product-selection/index.ts
@@ -1,5 +1,1 @@
-import productSelectionReference from './product-selection-reference';
-
-const presets = { productSelectionReference };
-
-export default presets;
+export { default } from './product-selection-reference';

--- a/models/commons/src/reference/presets/product-type/index.ts
+++ b/models/commons/src/reference/presets/product-type/index.ts
@@ -1,5 +1,1 @@
-import productTypeReference from './product-type-reference';
-
-const presets = { productTypeReference };
-
-export default presets;
+export { default } from './product-type-reference';

--- a/models/commons/src/reference/presets/product/index.ts
+++ b/models/commons/src/reference/presets/product/index.ts
@@ -1,5 +1,1 @@
-import productReference from './product-reference';
-
-const presets = { productReference };
-
-export default presets;
+export { default } from './product-reference';

--- a/models/commons/src/reference/presets/quote-request/index.ts
+++ b/models/commons/src/reference/presets/quote-request/index.ts
@@ -1,5 +1,1 @@
-import quoteRequestReference from './quote-request-reference';
-
-const presets = { quoteRequestReference };
-
-export default presets;
+export { default } from './quote-request-reference';

--- a/models/commons/src/reference/presets/quote/index.ts
+++ b/models/commons/src/reference/presets/quote/index.ts
@@ -1,5 +1,1 @@
-import quoteReference from './quote-reference';
-
-const presets = { quoteReference };
-
-export default presets;
+export { default } from './quote-reference';

--- a/models/commons/src/reference/presets/review/index.ts
+++ b/models/commons/src/reference/presets/review/index.ts
@@ -1,5 +1,1 @@
-import reviewReference from './review-reference';
-
-const presets = { reviewReference };
-
-export default presets;
+export { default } from './review-reference';

--- a/models/commons/src/reference/presets/shipping-method/index.ts
+++ b/models/commons/src/reference/presets/shipping-method/index.ts
@@ -1,5 +1,1 @@
-import shippingMethodReference from './shipping-method-reference';
-
-const presets = { shippingMethodReference };
-
-export default presets;
+export { default } from './shipping-method-reference';

--- a/models/commons/src/reference/presets/shopping-list/index.ts
+++ b/models/commons/src/reference/presets/shopping-list/index.ts
@@ -1,5 +1,1 @@
-import shoppingListReference from './shopping-list-reference';
-
-const presets = { shoppingListReference };
-
-export default presets;
+export { default } from './shopping-list-reference';

--- a/models/commons/src/reference/presets/staged-quote/index.ts
+++ b/models/commons/src/reference/presets/staged-quote/index.ts
@@ -1,5 +1,1 @@
-import stagedQuoteReference from './staged-quote-reference';
-
-const presets = { stagedQuoteReference };
-
-export default presets;
+export { default } from './staged-quote-reference';

--- a/models/commons/src/reference/presets/standalone-price/index.ts
+++ b/models/commons/src/reference/presets/standalone-price/index.ts
@@ -1,5 +1,1 @@
-import standalonePriceReference from './standalone-price-reference';
-
-const presets = { standalonePriceReference };
-
-export default presets;
+export { default } from './standalone-price-reference';

--- a/models/commons/src/reference/presets/state/index.ts
+++ b/models/commons/src/reference/presets/state/index.ts
@@ -1,5 +1,1 @@
-import stateReference from './state-reference';
-
-const presets = { stateReference };
-
-export default presets;
+export { default } from './state-reference';

--- a/models/commons/src/reference/presets/store/index.ts
+++ b/models/commons/src/reference/presets/store/index.ts
@@ -1,5 +1,1 @@
-import storeReference from './store-reference';
-
-const presets = { storeReference };
-
-export default presets;
+export { default } from './store-reference';

--- a/models/commons/src/reference/presets/subscription/index.ts
+++ b/models/commons/src/reference/presets/subscription/index.ts
@@ -1,5 +1,1 @@
-import subscriptionReference from './subscription-reference';
-
-const presets = { subscriptionReference };
-
-export default presets;
+export { default } from './subscription-reference';

--- a/models/commons/src/reference/presets/tax-category/index.ts
+++ b/models/commons/src/reference/presets/tax-category/index.ts
@@ -1,5 +1,1 @@
-import taxCategoryReference from './tax-category-reference';
-
-const presets = { taxCategoryReference };
-
-export default presets;
+export { default } from './tax-category-reference';

--- a/models/commons/src/reference/presets/type/index.ts
+++ b/models/commons/src/reference/presets/type/index.ts
@@ -1,5 +1,1 @@
-import typeReference from './type-reference';
-
-const presets = { typeReference };
-
-export default presets;
+export { default } from './type-reference';

--- a/models/commons/src/reference/presets/zone/index.ts
+++ b/models/commons/src/reference/presets/zone/index.ts
@@ -1,5 +1,1 @@
-import zoneReference from './zone-reference';
-
-const presets = { zoneReference };
-
-export default presets;
+export { default } from './zone-reference';

--- a/models/commons/src/reference/reference-draft/presets/associate-role/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/associate-role/index.ts
@@ -1,5 +1,5 @@
-import associateRoleReference from './associate-role-reference';
+// import associateRoleReference from './associate-role-reference';
 
-const presets = { associateRoleReference };
+// const presets = { associateRoleReference };
 
-export default presets;
+export { default } from './associate-role-reference';

--- a/models/commons/src/reference/reference-draft/presets/associate-role/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/associate-role/index.ts
@@ -1,5 +1,1 @@
-// import associateRoleReference from './associate-role-reference';
-
-// const presets = { associateRoleReference };
-
 export { default } from './associate-role-reference';

--- a/models/commons/src/reference/reference-draft/presets/attribute-group/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/attribute-group/index.ts
@@ -1,5 +1,1 @@
-// import attributeGroupReference from './attribute-group-reference';
-
-// const presets = { attributeGroupReference };
-
 export { default } from './attribute-group-reference';

--- a/models/commons/src/reference/reference-draft/presets/attribute-group/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/attribute-group/index.ts
@@ -1,5 +1,5 @@
-import attributeGroupReference from './attribute-group-reference';
+// import attributeGroupReference from './attribute-group-reference';
 
-const presets = { attributeGroupReference };
+// const presets = { attributeGroupReference };
 
-export default presets;
+export { default } from './attribute-group-reference';

--- a/models/commons/src/reference/reference-draft/presets/business-unit/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/business-unit/index.ts
@@ -1,5 +1,1 @@
-import businessUnitReference from './business-unit-reference';
-
-const presets = { businessUnitReference };
-
-export default presets;
+export { default } from './business-unit-reference';

--- a/models/commons/src/reference/reference-draft/presets/cart-discount/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/cart-discount/index.ts
@@ -1,5 +1,1 @@
-import cartDiscountReference from './cart-discount-reference';
-
-const presets = { cartDiscountReference };
-
-export default presets;
+export { default } from './cart-discount-reference';

--- a/models/commons/src/reference/reference-draft/presets/cart/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/cart/index.ts
@@ -1,5 +1,1 @@
-import cartReference from './cart-reference';
-
-const presets = { cartReference };
-
-export default presets;
+export { default } from './cart-reference';

--- a/models/commons/src/reference/reference-draft/presets/category/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/category/index.ts
@@ -1,5 +1,1 @@
-import categoryReference from './category-reference';
-
-const presets = { categoryReference };
-
-export default presets;
+export { default } from './category-reference';

--- a/models/commons/src/reference/reference-draft/presets/channel/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/channel/index.ts
@@ -1,5 +1,1 @@
-import channelReference from './channel-reference';
-
-const presets = { channelReference };
-
-export default presets;
+export { default } from './channel-reference';

--- a/models/commons/src/reference/reference-draft/presets/customer-group/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/customer-group/index.ts
@@ -1,5 +1,1 @@
-import customerGroupReference from './customer-group-reference';
-
-const presets = { customerGroupReference };
-
-export default presets;
+export { default } from './customer-group-reference';

--- a/models/commons/src/reference/reference-draft/presets/customer/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/customer/index.ts
@@ -1,5 +1,1 @@
-import customerReference from './customer-reference';
-
-const presets = { customerReference };
-
-export default presets;
+export { default } from './customer-reference';

--- a/models/commons/src/reference/reference-draft/presets/direct-discount/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/direct-discount/index.ts
@@ -1,5 +1,1 @@
-import directDiscountReference from './direct-discount-reference';
-
-const presets = { directDiscountReference };
-
-export default presets;
+export { default } from './direct-discount-reference';

--- a/models/commons/src/reference/reference-draft/presets/discount-code/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/discount-code/index.ts
@@ -1,5 +1,1 @@
-import discountCodeReference from './discount-code-reference';
-
-const presets = { discountCodeReference };
-
-export default presets;
+export { default } from './discount-code-reference';

--- a/models/commons/src/reference/reference-draft/presets/extension/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/extension/index.ts
@@ -1,5 +1,1 @@
-import extensionReference from './extension-reference';
-
-const presets = { extensionReference };
-
-export default presets;
+export { default } from './extension-reference';

--- a/models/commons/src/reference/reference-draft/presets/inventory-entry/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/inventory-entry/index.ts
@@ -1,5 +1,1 @@
-import inventoryEntryReference from './inventory-entry-reference';
-
-const presets = { inventoryEntryReference };
-
-export default presets;
+export { default } from './inventory-entry-reference';

--- a/models/commons/src/reference/reference-draft/presets/key-value-document/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/key-value-document/index.ts
@@ -1,5 +1,1 @@
-import keyValueDocumentReference from './key-value-document-reference';
-
-const presets = { keyValueDocumentReference };
-
-export default presets;
+export { default } from './key-value-document-reference';

--- a/models/commons/src/reference/reference-draft/presets/order-edit/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/order-edit/index.ts
@@ -1,5 +1,1 @@
-import orderEditReference from './order-edit-reference';
-
-const presets = { orderEditReference };
-
-export default presets;
+export { default } from './order-edit-reference';

--- a/models/commons/src/reference/reference-draft/presets/order/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/order/index.ts
@@ -1,5 +1,1 @@
-import orderReference from './order-reference';
-
-const presets = { orderReference };
-
-export default presets;
+export { default } from './order-reference';

--- a/models/commons/src/reference/reference-draft/presets/payment/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/payment/index.ts
@@ -1,5 +1,1 @@
-import paymentReference from './payment-reference';
-
-const presets = { paymentReference };
-
-export default presets;
+export { default } from './payment-reference';

--- a/models/commons/src/reference/reference-draft/presets/product-discount/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/product-discount/index.ts
@@ -1,5 +1,1 @@
-import productDiscountReference from './product-discount-reference';
-
-const presets = { productDiscountReference };
-
-export default presets;
+export { default } from './product-discount-reference';

--- a/models/commons/src/reference/reference-draft/presets/product-price/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/product-price/index.ts
@@ -1,5 +1,1 @@
-import productPriceReference from './product-price-reference';
-
-const presets = { productPriceReference };
-
-export default presets;
+export { default } from './product-price-reference';

--- a/models/commons/src/reference/reference-draft/presets/product-selection/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/product-selection/index.ts
@@ -1,5 +1,1 @@
-import productSelectionReference from './product-selection-reference';
-
-const presets = { productSelectionReference };
-
-export default presets;
+export { default } from './product-selection-reference';

--- a/models/commons/src/reference/reference-draft/presets/product-type/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/product-type/index.ts
@@ -1,5 +1,1 @@
-import productTypeReference from './product-type-reference';
-
-const presets = { productTypeReference };
-
-export default presets;
+export { default } from './product-type-reference';

--- a/models/commons/src/reference/reference-draft/presets/product/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/product/index.ts
@@ -1,5 +1,1 @@
-import productReference from './product-reference';
-
-const presets = { productReference };
-
-export default presets;
+export { default } from './product-reference';

--- a/models/commons/src/reference/reference-draft/presets/quote-request/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/quote-request/index.ts
@@ -1,5 +1,1 @@
-import quoteRequestReference from './quote-request-reference';
-
-const presets = { quoteRequestReference };
-
-export default presets;
+export { default } from './quote-request-reference';

--- a/models/commons/src/reference/reference-draft/presets/quote/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/quote/index.ts
@@ -1,5 +1,1 @@
-import quoteReference from './quote-reference';
-
-const presets = { quoteReference };
-
-export default presets;
+export { default } from './quote-reference';

--- a/models/commons/src/reference/reference-draft/presets/review/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/review/index.ts
@@ -1,5 +1,1 @@
-import reviewReference from './review-reference';
-
-const presets = { reviewReference };
-
-export default presets;
+export { default } from './review-reference';

--- a/models/commons/src/reference/reference-draft/presets/shipping-method/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/shipping-method/index.ts
@@ -1,5 +1,1 @@
-import shippingMethodReference from './shipping-method-reference';
-
-const presets = { shippingMethodReference };
-
-export default presets;
+export { default } from './shipping-method-reference';

--- a/models/commons/src/reference/reference-draft/presets/shopping-list/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/shopping-list/index.ts
@@ -1,5 +1,1 @@
-import shoppingListReference from './shopping-list-reference';
-
-const presets = { shoppingListReference };
-
-export default presets;
+export { default } from './shopping-list-reference';

--- a/models/commons/src/reference/reference-draft/presets/staged-quote/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/staged-quote/index.ts
@@ -1,5 +1,1 @@
-import stagedQuoteReference from './staged-quote-reference';
-
-const presets = { stagedQuoteReference };
-
-export default presets;
+export { default } from './staged-quote-reference';

--- a/models/commons/src/reference/reference-draft/presets/standalone-price/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/standalone-price/index.ts
@@ -1,5 +1,1 @@
-import standalonePriceReference from './standalone-price-reference';
-
-const presets = { standalonePriceReference };
-
-export default presets;
+export { default } from './standalone-price-reference';

--- a/models/commons/src/reference/reference-draft/presets/state/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/state/index.ts
@@ -1,5 +1,1 @@
-import stateReference from './state-reference';
-
-const presets = { stateReference };
-
-export default presets;
+export { default } from './state-reference';

--- a/models/commons/src/reference/reference-draft/presets/store/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/store/index.ts
@@ -1,5 +1,1 @@
-import storeReference from './store-reference';
-
-const presets = { storeReference };
-
-export default presets;
+export { default } from './store-reference';

--- a/models/commons/src/reference/reference-draft/presets/subscription/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/subscription/index.ts
@@ -1,5 +1,1 @@
-import subscriptionReference from './subscription-reference';
-
-const presets = { subscriptionReference };
-
-export default presets;
+export { default } from './subscription-reference';

--- a/models/commons/src/reference/reference-draft/presets/tax-category/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/tax-category/index.ts
@@ -1,5 +1,1 @@
-import taxCategoryReference from './tax-category-reference';
-
-const presets = { taxCategoryReference };
-
-export default presets;
+export { default } from './tax-category-reference';

--- a/models/commons/src/reference/reference-draft/presets/type/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/type/index.ts
@@ -1,5 +1,1 @@
-import typeReference from './type-reference';
-
-const presets = { typeReference };
-
-export default presets;
+export { default } from './type-reference';

--- a/models/commons/src/reference/reference-draft/presets/zone/index.ts
+++ b/models/commons/src/reference/reference-draft/presets/zone/index.ts
@@ -1,5 +1,1 @@
-import zoneReference from './zone-reference';
-
-const presets = { zoneReference };
-
-export default presets;
+export { default } from './zone-reference';

--- a/models/inventory-entry/src/transformers.ts
+++ b/models/inventory-entry/src/transformers.ts
@@ -17,7 +17,7 @@ const transformers = {
   rest: Transformer<TInventoryEntry, TInventoryEntryRest>('rest', {
     buildFields: ['supplyChannel'],
     replaceFields: ({ fields }) => {
-      const supplyChannel = Reference.presets.channelReference
+      const supplyChannel = Reference.presets
         .channelReference()
         .id(fields.supplyChannel.id)
         .build<TReference<'channel'>>();
@@ -30,7 +30,7 @@ const transformers = {
   graphql: Transformer<TInventoryEntry, TInventoryEntryGraphql>('graphql', {
     buildFields: ['supplyChannel'],
     replaceFields: ({ fields }) => {
-      const supplyChannelRef = Reference.presets.channelReference
+      const supplyChannelRef = Reference.presets
         .channelReference()
         .id(fields.supplyChannel.id)
         .buildGraphql<TReferenceGraphql<'channel'>>();

--- a/models/payment/src/payment/transformers.ts
+++ b/models/payment/src/payment/transformers.ts
@@ -32,7 +32,7 @@ const transformers = {
       'custom',
     ],
     replaceFields: ({ fields }) => {
-      const customer = Reference.presets.customerReference
+      const customer = Reference.presets
         .customerReference()
         .id(fields.customer.id)
         .build<TReference<'customer'>>();
@@ -52,7 +52,7 @@ const transformers = {
       'custom',
     ],
     replaceFields: ({ fields }) => {
-      const customerRef: TReferenceGraphql = Reference.presets.customerReference
+      const customerRef: TReferenceGraphql = Reference.presets
         .customerReference()
         .id(fields.customer.id)
         .buildGraphql();

--- a/models/quote-request/src/transformers.ts
+++ b/models/quote-request/src/transformers.ts
@@ -54,12 +54,12 @@ const transformers = {
       'lastModifiedBy',
     ],
     replaceFields: ({ fields }) => {
-      const customer = Reference.presets.customerReference
+      const customer = Reference.presets
         .customerReference()
         .id(fields.customer.id)
         .build<TReference<'customer'>>();
 
-      const customerGroup = Reference.presets.customerGroupReference
+      const customerGroup = Reference.presets
         .customerGroupReference()
         .id(fields.customerGroup?.id)
         .build<TReference<'customer-group'>>();
@@ -69,7 +69,7 @@ const transformers = {
         .key(fields.store?.key)
         .buildRest<StoreKeyReference>();
 
-      const state = Reference.presets.stateReference
+      const state = Reference.presets
         .stateReference()
         .id(fields.state?.id)
         .build<TReference<'state'>>();
@@ -107,32 +107,31 @@ const transformers = {
       'lastModifiedBy',
     ],
     addFields: ({ fields }) => {
-      const customerRef: TReferenceGraphql = Reference.presets.customerReference
+      const customerRef: TReferenceGraphql = Reference.presets
         .customerReference()
         .id(fields.customer.id)
         .typeId('customer')
         .buildGraphql();
 
-      const customerGroupRef: TReferenceGraphql =
-        Reference.presets.customerGroupReference
-          .customerGroupReference()
-          .id(fields.customerGroup?.id)
-          .typeId('customer-group')
-          .buildGraphql();
+      const customerGroupRef: TReferenceGraphql = Reference.presets
+        .customerGroupReference()
+        .id(fields.customerGroup?.id)
+        .typeId('customer-group')
+        .buildGraphql();
 
       const storeRef: TKeyReferenceGraphql = KeyReference.presets
         .store()
         .key(fields.store?.key)
         .buildGraphql();
 
-      const stateRef: TReferenceGraphql = Reference.presets.stateReference
+      const stateRef: TReferenceGraphql = Reference.presets
         .stateReference()
         .id(fields.state?.id)
         .typeId('state')
         .buildGraphql();
 
       const cartRef: TReferenceGraphql | null = fields.cart
-        ? Reference.presets.cartReference
+        ? Reference.presets
             .cartReference()
             .id(fields.cart.id)
             .typeId('cart')

--- a/models/quote/src/transformers.ts
+++ b/models/quote/src/transformers.ts
@@ -56,22 +56,22 @@ const transformers = {
       'lastModifiedBy',
     ],
     replaceFields: ({ fields }) => {
-      const quoteRequest = Reference.presets.quoteRequestReference
+      const quoteRequest = Reference.presets
         .quoteRequestReference()
         .id(fields.quoteRequest.id)
         .build<TReference<'quote-request'>>();
 
-      const stagedQuote = Reference.presets.stagedQuoteReference
+      const stagedQuote = Reference.presets
         .stagedQuoteReference()
         .id(fields.stagedQuote.id)
         .build<TReference<'staged-quote'>>();
 
-      const customer = Reference.presets.customerReference
+      const customer = Reference.presets
         .customerReference()
         .id(fields.customer.id)
         .build<TReference<'customer'>>();
 
-      const customerGroup = Reference.presets.customerGroupReference
+      const customerGroup = Reference.presets
         .customerGroupReference()
         .id(fields.customerGroup?.id)
         .build<TReference<'customer-group'>>();
@@ -81,7 +81,7 @@ const transformers = {
         .key(fields.store?.key)
         .buildRest<StoreKeyReference>();
 
-      const state = Reference.presets.stateReference
+      const state = Reference.presets
         .stateReference()
         .id(fields.state?.id)
         .build<TReference<'state'>>();
@@ -124,37 +124,34 @@ const transformers = {
       'lastModifiedBy',
     ],
     addFields: ({ fields }) => {
-      const quoteRequestRef: TReferenceGraphql =
-        Reference.presets.quoteRequestReference
-          .quoteRequestReference()
-          .id(fields.quoteRequest.id)
-          .buildGraphql();
+      const quoteRequestRef: TReferenceGraphql = Reference.presets
+        .quoteRequestReference()
+        .id(fields.quoteRequest.id)
+        .buildGraphql();
 
-      const stagedQuoteRef: TReferenceGraphql =
-        Reference.presets.stagedQuoteReference
-          .stagedQuoteReference()
-          .id(fields.stagedQuote.id)
-          .buildGraphql();
+      const stagedQuoteRef: TReferenceGraphql = Reference.presets
+        .stagedQuoteReference()
+        .id(fields.stagedQuote.id)
+        .buildGraphql();
 
-      const customerRef: TReferenceGraphql = Reference.presets.customerReference
+      const customerRef: TReferenceGraphql = Reference.presets
         .customerReference()
         .id(fields.customer.id)
         .typeId('customer')
         .buildGraphql();
 
-      const customerGroupRef: TReferenceGraphql =
-        Reference.presets.customerGroupReference
-          .customerGroupReference()
-          .id(fields.customerGroup?.id)
-          .typeId('customer-group')
-          .buildGraphql();
+      const customerGroupRef: TReferenceGraphql = Reference.presets
+        .customerGroupReference()
+        .id(fields.customerGroup?.id)
+        .typeId('customer-group')
+        .buildGraphql();
 
       const storeRef: TKeyReferenceGraphql = KeyReference.presets
         .store()
         .key(fields.store?.key)
         .buildGraphql();
 
-      const stateRef: TReferenceGraphql = Reference.presets.stateReference
+      const stateRef: TReferenceGraphql = Reference.presets
         .stateReference()
         .id(fields.state?.id)
         .typeId('state')

--- a/models/staged-quote/src/transformers.ts
+++ b/models/staged-quote/src/transformers.ts
@@ -39,22 +39,22 @@ const transformers = {
       'lastModifiedBy',
     ],
     replaceFields: ({ fields }) => {
-      const customer = Reference.presets.customerReference
+      const customer = Reference.presets
         .customerReference()
         .id(fields.customer.id)
         .build<TReference<'customer'>>();
 
-      const quoteRequest = Reference.presets.quoteRequestReference
+      const quoteRequest = Reference.presets
         .quoteRequestReference()
         .id(fields.quoteRequest.id)
         .build<TReference<'quote-request'>>();
 
-      const quotationCart = Reference.presets.cartReference
+      const quotationCart = Reference.presets
         .cartReference()
         .id(fields.quotationCart.id)
         .build<TReference<'cart'>>();
 
-      const state = Reference.presets.stateReference
+      const state = Reference.presets
         .stateReference()
         .id(fields.state?.id)
         .build<TReference<'state'>>();
@@ -86,27 +86,25 @@ const transformers = {
       'lastModifiedBy',
     ],
     addFields: ({ fields }) => {
-      const customerRef: TReferenceGraphql = Reference.presets.customerReference
+      const customerRef: TReferenceGraphql = Reference.presets
         .customerReference()
         .id(fields.customer.id)
         .typeId('customer')
         .buildGraphql();
 
-      const quoteRequestRef: TReferenceGraphql =
-        Reference.presets.quoteRequestReference
-          .quoteRequestReference()
-          .id(fields.quoteRequest.id)
-          .typeId('quote-request')
-          .buildGraphql();
+      const quoteRequestRef: TReferenceGraphql = Reference.presets
+        .quoteRequestReference()
+        .id(fields.quoteRequest.id)
+        .typeId('quote-request')
+        .buildGraphql();
 
-      const quotationCartRef: TReferenceGraphql =
-        Reference.presets.cartReference
-          .cartReference()
-          .id(fields.quotationCart.id)
-          .typeId('cart')
-          .buildGraphql();
+      const quotationCartRef: TReferenceGraphql = Reference.presets
+        .cartReference()
+        .id(fields.quotationCart.id)
+        .typeId('cart')
+        .buildGraphql();
 
-      const stateRef: TReferenceGraphql = Reference.presets.stateReference
+      const stateRef: TReferenceGraphql = Reference.presets
         .stateReference()
         .id(fields.state?.id)
         .typeId('state')


### PR DESCRIPTION
This PR updates the exports for Reference and ReferenceDraft presets to simplify the way we call them in other models. For example, this changes the call to build a stateReference entity from `Reference.presets.stateReference.stateReference()` to `Reference.presets.stateReference()`. 

🚨 This will break a [cypress test](https://github.com/commercetools/merchant-center-prices/blob/640cebc7c50b048da2b284d78bde24b20f955e72/cypress/support/commands.ts#L599) in the Prices application, and may definitely be a breaking change elsewhere, ie in the MC-frontend migration from the shared/test-data models to this repo's models. 🚨 