### PR TITLE
fix: `DiscountsCustomView.filters` and `DiscountsCustomViewInput.filter` generated data

### DIFF
--- a/.changeset/tough-terms-mix.md
+++ b/.changeset/tough-terms-mix.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/discounts-custom-view': patch
+---
+
+Fix `DiscountsCustomView.filters` and `DiscountsCustomViewInput.filter` generated data

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@
 /models/customer @commercetools/customers-team-fe
 /models/customer-group @commercetools/customers-team-fe
 /models/discount-code @commercetools/priceless-team-fe
+/models/discounts-custom-view @commercetools/priceless-team-fe
 /models/filter-values @commercetools/priceless-team-fe
 /models/inventory-entry @commercetools/pacman-team-fe
 /models/order @commercetools/checkout-team-fe

--- a/models/discounts-custom-view/src/builder.spec.ts
+++ b/models/discounts-custom-view/src/builder.spec.ts
@@ -22,9 +22,11 @@ describe('builder', () => {
         table: null,
         search: expect.any(String),
         type: expect.any(String),
-        filters: expect.objectContaining({
-          id: expect.any(String),
-        }),
+        filters: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+          }),
+        ]),
         sort: null,
       })
     )
@@ -47,9 +49,11 @@ describe('builder', () => {
         table: null,
         search: expect.any(String),
         type: expect.any(String),
-        filters: expect.objectContaining({
-          id: expect.any(String),
-        }),
+        filters: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+          }),
+        ]),
         sort: null,
       })
     )
@@ -76,10 +80,12 @@ describe('builder', () => {
         table: null,
         search: expect.any(String),
         type: expect.any(String),
-        filters: expect.objectContaining({
-          id: expect.any(String),
-          __typename: 'FilterValues',
-        }),
+        filters: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+            __typename: 'FilterValues',
+          }),
+        ]),
         sort: null,
         __typename: 'DiscountsCustomView',
       })

--- a/models/discounts-custom-view/src/discounts-custom-view-input/builder.spec.ts
+++ b/models/discounts-custom-view/src/discounts-custom-view-input/builder.spec.ts
@@ -18,9 +18,11 @@ describe('builder', () => {
         }),
         table: null,
         search: expect.any(String),
-        filters: expect.objectContaining({
-          id: expect.any(String),
-        }),
+        filters: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+          }),
+        ]),
         sort: null,
       })
     )
@@ -36,9 +38,11 @@ describe('builder', () => {
         }),
         table: null,
         search: expect.any(String),
-        filters: expect.objectContaining({
-          id: expect.any(String),
-        }),
+        filters: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+          }),
+        ]),
         sort: null,
       })
     )
@@ -61,10 +65,12 @@ describe('builder', () => {
         ]),
         table: null,
         search: expect.any(String),
-        filters: expect.objectContaining({
-          id: expect.any(String),
-          __typename: 'FilterValues',
-        }),
+        filters: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+            __typename: 'FilterValues',
+          }),
+        ]),
         sort: null,
       })
     )

--- a/models/discounts-custom-view/src/discounts-custom-view-input/generator.ts
+++ b/models/discounts-custom-view/src/discounts-custom-view-input/generator.ts
@@ -8,7 +8,7 @@ const generator = Generator<TDiscountsCustomViewInput>({
     name: fake(() => LocalizedString.random()),
     table: null,
     search: fake((f) => f.lorem.word()),
-    filters: fake(() => FilterValues.random()),
+    filters: fake(() => [FilterValues.random()]),
     sort: null,
   },
 });

--- a/models/discounts-custom-view/src/generator.ts
+++ b/models/discounts-custom-view/src/generator.ts
@@ -18,7 +18,7 @@ const generator = Generator<TDiscountsCustomView>({
     table: null,
     search: fake((f) => f.lorem.word()),
     type: oneOf('ProductDiscount', 'CartDiscount', 'DiscountCode'),
-    filters: fake(() => FilterValues.random()),
+    filters: fake(() => [FilterValues.random()]),
     sort: null,
   },
 });


### PR DESCRIPTION
Generated `DiscountsCustomView.filters` and `DiscountsCustomViewInput.filter` must be an array.

Added `/models/discounts-custom-view` to `CODEOWNERS` file.