### PR TITLE
fix: build `labelAllLocales` property for GraphQL `FieldDefinition` model

### DIFF
--- a/.changeset/honest-toys-run.md
+++ b/.changeset/honest-toys-run.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/type': patch
+---
+
+Build `labelAllLocales` property for GraphQL `FieldDefinition` model

--- a/.changeset/tough-terms-mix.md
+++ b/.changeset/tough-terms-mix.md
@@ -1,5 +1,0 @@
----
-'@commercetools-test-data/discounts-custom-view': patch
----
-
-Fix `DiscountsCustomView.filters` and `DiscountsCustomViewInput.filter` generated data

--- a/.changeset/tough-terms-mix.md
+++ b/.changeset/tough-terms-mix.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/discounts-custom-view': patch
+---
+
+Fix `DiscountsCustomView.filters` and `DiscountsCustomViewInput.filter` generated data

--- a/models/type/src/field-definition/builder.spec.ts
+++ b/models/type/src/field-definition/builder.spec.ts
@@ -58,6 +58,13 @@ describe('builder', () => {
             value: expect.any(String),
           }),
         ]),
+        labelAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            __typename: 'LocalizedString',
+            locale: expect.any(String),
+            value: expect.any(String),
+          }),
+        ]),
         required: expect.any(Boolean),
         inputHint: expect.any(String),
         __typename: 'FieldDefinition',

--- a/models/type/src/field-definition/transformers.ts
+++ b/models/type/src/field-definition/transformers.ts
@@ -1,3 +1,4 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type { TFieldDefinition, TFieldDefinitionGraphql } from './types';
 
@@ -10,7 +11,10 @@ const transformers = {
   }),
   graphql: Transformer<TFieldDefinition, TFieldDefinitionGraphql>('graphql', {
     buildFields: ['label', 'type'],
-    addFields: () => ({ __typename: 'FieldDefinition' }),
+    addFields: ({ fields }) => ({
+      labelAllLocales: LocalizedString.toLocalizedField(fields.label),
+      __typename: 'FieldDefinition',
+    }),
   }),
 };
 


### PR DESCRIPTION
Add missing `labelAllLocales` property to `FieldDefinition` model (GraphQL variant)

![Screenshot 2024-07-01 at 11 31 38](https://github.com/commercetools/test-data/assets/13467563/61f334bc-f74d-499d-bff4-571e0d22d5d5)
