### PR TITLE
fix: `ProductDiscountValueAbsolute`, `ProductDiscountValueExternal`, and `ProductDiscountValueRelative` `__typename` fields

### DIFF
--- a/.changeset/many-ads-drive.md
+++ b/.changeset/many-ads-drive.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product-discount': patch
+---
+
+Fixes `ProductDiscountValueAbsolute`, `ProductDiscountValueExternal`, and `ProductDiscountValueRelative` `__typename` fields

--- a/models/product-discount/src/product-discount-value-absolute/builder.spec.ts
+++ b/models/product-discount/src/product-discount-value-absolute/builder.spec.ts
@@ -52,7 +52,7 @@ describe('builder', () => {
         money: expect.objectContaining({
           type: 'centPrecision',
         }),
-        __typename: 'ProductDiscountValueAbsolute',
+        __typename: 'AbsoluteDiscountValue',
       })
     )
   );

--- a/models/product-discount/src/product-discount-value-absolute/transformers.ts
+++ b/models/product-discount/src/product-discount-value-absolute/transformers.ts
@@ -23,7 +23,7 @@ const transformers = {
   >('graphql', {
     buildFields: ['money'],
     addFields: () => ({
-      __typename: 'ProductDiscountValueAbsolute',
+      __typename: 'AbsoluteDiscountValue',
     }),
   }),
 };

--- a/models/product-discount/src/product-discount-value-absolute/types.ts
+++ b/models/product-discount/src/product-discount-value-absolute/types.ts
@@ -10,7 +10,7 @@ export type TProductDiscountValueAbsoluteDraft =
 
 export type TProductDiscountValueAbsoluteGraphql =
   TProductDiscountValueAbsolute & {
-    __typename: 'ProductDiscountValueAbsolute';
+    __typename: 'AbsoluteDiscountValue';
   };
 export type TProductDiscountValueAbsoluteDraftGraphql = {
   absolute: Omit<TProductDiscountValueAbsoluteDraft, 'type'>;

--- a/models/product-discount/src/product-discount-value-external/builder.spec.ts
+++ b/models/product-discount/src/product-discount-value-external/builder.spec.ts
@@ -43,7 +43,7 @@ describe('builder', () => {
       ProductDiscountValueExternal.random(),
       expect.objectContaining({
         type: 'external',
-        __typename: 'ProductDiscountValueExternal',
+        __typename: 'ExternalDiscountValue',
       })
     )
   );

--- a/models/product-discount/src/product-discount-value-external/transformers.ts
+++ b/models/product-discount/src/product-discount-value-external/transformers.ts
@@ -23,7 +23,7 @@ const transformers = {
   >('graphql', {
     buildFields: [],
     addFields: () => ({
-      __typename: 'ProductDiscountValueExternal',
+      __typename: 'ExternalDiscountValue',
     }),
   }),
 };

--- a/models/product-discount/src/product-discount-value-external/types.ts
+++ b/models/product-discount/src/product-discount-value-external/types.ts
@@ -10,7 +10,7 @@ export type TProductDiscountValueExternalDraft =
 
 export type TProductDiscountValueExternalGraphql =
   TProductDiscountValueExternal & {
-    __typename: 'ProductDiscountValueExternal';
+    __typename: 'ExternalDiscountValue';
   };
 export type TProductDiscountValueExternalDraftGraphql = {
   external: Omit<TProductDiscountValueExternalDraft, 'type'>;

--- a/models/product-discount/src/product-discount-value-relative/builder.spec.ts
+++ b/models/product-discount/src/product-discount-value-relative/builder.spec.ts
@@ -46,7 +46,7 @@ describe('builder', () => {
       expect.objectContaining({
         type: 'relative',
         permyriad: expect.any(Number),
-        __typename: 'ProductDiscountValueRelative',
+        __typename: 'RelativeDiscountValue',
       })
     )
   );

--- a/models/product-discount/src/product-discount-value-relative/transformers.ts
+++ b/models/product-discount/src/product-discount-value-relative/transformers.ts
@@ -23,7 +23,7 @@ const transformers = {
   >('graphql', {
     buildFields: [],
     addFields: () => ({
-      __typename: 'ProductDiscountValueRelative',
+      __typename: 'RelativeDiscountValue',
     }),
   }),
 };

--- a/models/product-discount/src/product-discount-value-relative/types.ts
+++ b/models/product-discount/src/product-discount-value-relative/types.ts
@@ -10,7 +10,7 @@ export type TProductDiscountValueRelativeDraft =
 
 export type TProductDiscountValueRelativeGraphql =
   TProductDiscountValueRelative & {
-    __typename: 'ProductDiscountValueRelative';
+    __typename: 'RelativeDiscountValue';
   };
 export type TProductDiscountValueRelativeDraftGraphql = {
   relative: Omit<TProductDiscountValueRelativeDraft, 'type'>;


### PR DESCRIPTION
Due to wrong typenames, Apollo Client is not caching the queries in tests.