### PR TITLE
fix: `AttributePlainEnumValue` GraphQL `__typename` field

### DIFF
--- a/.changeset/twelve-bikes-yell.md
+++ b/.changeset/twelve-bikes-yell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product-type': patch
+---
+
+Fix `AttributePlainEnumValue` GraphQL `__typename` field

--- a/models/product-type/src/attribute-plain-enum-value/builder.spec.ts
+++ b/models/product-type/src/attribute-plain-enum-value/builder.spec.ts
@@ -38,7 +38,7 @@ describe('builder', () => {
       'graphql',
       AttributePlainEnumValue.random(),
       expect.objectContaining({
-        __typename: 'AttributePlainEnumValue',
+        __typename: 'PlainEnumValue',
         key: expect.any(String),
         label: expect.any(String),
       })

--- a/models/product-type/src/attribute-plain-enum-value/transformers.ts
+++ b/models/product-type/src/attribute-plain-enum-value/transformers.ts
@@ -23,7 +23,7 @@ const transformers = {
   >('graphql', {
     buildFields: [],
     addFields: () => ({
-      __typename: 'AttributePlainEnumValue',
+      __typename: 'PlainEnumValue',
     }),
   }),
 };

--- a/models/product-type/src/attribute-plain-enum-value/types.ts
+++ b/models/product-type/src/attribute-plain-enum-value/types.ts
@@ -5,7 +5,7 @@ export type TAttributePlainEnumValue = AttributePlainEnumValue;
 export type TAttributePlainEnumValueDraft = AttributePlainEnumValue;
 
 export type TAttributePlainEnumValueGraphql = TAttributePlainEnumValue & {
-  __typename: 'AttributePlainEnumValue';
+  __typename: 'PlainEnumValue';
 };
 export type TAttributePlainEnumValueDraftGraphql = AttributePlainEnumValue;
 


### PR DESCRIPTION
`AttributePlainEnumValue` is building a wrong `__typename` prop.