### PR TITLE
fix: wrong `__typenames` props (CustomFieldEnumType, CustomFieldEnumValue, CustomFieldLocalizedEnumValue)

### DIFF
--- a/.changeset/spotty-kids-cover.md
+++ b/.changeset/spotty-kids-cover.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/type': patch
+---
+
+Fixes wrong `__typenames` props (CustomFieldEnumType, CustomFieldEnumValue, CustomFieldLocalizedEnumValue)

--- a/models/type/src/custom-field-enum-type/builder.spec.ts
+++ b/models/type/src/custom-field-enum-type/builder.spec.ts
@@ -34,7 +34,7 @@ describe('builder', () => {
       expect.objectContaining({
         name: 'Enum',
         values: [],
-        __typename: 'EnumCustomFieldType',
+        __typename: 'EnumType',
       })
     )
   );

--- a/models/type/src/custom-field-enum-type/transformers.ts
+++ b/models/type/src/custom-field-enum-type/transformers.ts
@@ -12,8 +12,8 @@ const transformers = {
     'graphql',
     {
       buildFields: [],
-      addFields: ({ fields }) => ({
-        __typename: 'EnumCustomFieldType',
+      addFields: () => ({
+        __typename: 'EnumType',
       }),
     }
   ),

--- a/models/type/src/custom-field-enum-type/types.ts
+++ b/models/type/src/custom-field-enum-type/types.ts
@@ -8,7 +8,7 @@ export type TCustomFieldEnumType = CustomFieldEnumType;
 export type TCustomFieldEnumTypeDraft = CustomFieldEnumType;
 
 export type TCustomFieldEnumTypeGraphql = CustomFieldEnumType & {
-  __typename: 'EnumCustomFieldType';
+  __typename: 'EnumType';
 };
 export type TCustomFieldEnumTypeDraftGraphql = {
   enum: { values: Array<CustomFieldEnumValue> };

--- a/models/type/src/custom-field-enum-value/builder.spec.ts
+++ b/models/type/src/custom-field-enum-value/builder.spec.ts
@@ -14,11 +14,7 @@ describe('builder', () => {
       CustomFieldEnumValue.random(),
       expect.objectContaining({
         key: expect.any(String),
-        label: expect.objectContaining({
-          de: expect.any(String),
-          en: expect.any(String),
-          fr: expect.any(String),
-        }),
+        label: expect.any(String),
       })
     )
   );
@@ -29,11 +25,7 @@ describe('builder', () => {
       CustomFieldEnumValue.random(),
       expect.objectContaining({
         key: expect.any(String),
-        label: expect.objectContaining({
-          de: expect.any(String),
-          en: expect.any(String),
-          fr: expect.any(String),
-        }),
+        label: expect.any(String),
       })
     )
   );
@@ -44,14 +36,8 @@ describe('builder', () => {
       CustomFieldEnumValue.random(),
       expect.objectContaining({
         key: expect.any(String),
-        labelAllLocales: expect.arrayContaining([
-          expect.objectContaining({
-            locale: 'en',
-            value: expect.any(String),
-            __typename: 'LocalizedString',
-          }),
-        ]),
-        __typename: 'LocalizableEnumValueType',
+        label: expect.any(String),
+        __typename: 'EnumValue',
       })
     )
   );

--- a/models/type/src/custom-field-enum-value/generator.ts
+++ b/models/type/src/custom-field-enum-value/generator.ts
@@ -1,4 +1,3 @@
-import { LocalizedString } from '@commercetools-test-data/commons';
 import { fake, Generator } from '@commercetools-test-data/core';
 import { type TCustomFieldEnumValue } from './types';
 
@@ -7,7 +6,7 @@ import { type TCustomFieldEnumValue } from './types';
 const generator = Generator<TCustomFieldEnumValue>({
   fields: {
     key: fake((f) => f.lorem.slug(2)),
-    label: fake(() => LocalizedString.random()),
+    label: fake((f) => f.word.words({ count: { min: 3, max: 5 } })),
   },
 });
 

--- a/models/type/src/custom-field-enum-value/transformers.ts
+++ b/models/type/src/custom-field-enum-value/transformers.ts
@@ -8,19 +8,17 @@ import {
 const transformers = {
   default: Transformer<TCustomFieldEnumValue, TCustomFieldEnumValue>(
     'default',
-    { buildFields: ['label'] }
+    { buildFields: [] }
   ),
   rest: Transformer<TCustomFieldEnumValue, TCustomFieldEnumValue>('rest', {
-    buildFields: ['label'],
+    buildFields: [],
   }),
   graphql: Transformer<TCustomFieldEnumValue, TCustomFieldEnumValueGraphql>(
     'graphql',
     {
       buildFields: [],
-      removeFields: ['label'],
-      addFields: ({ fields }) => ({
-        labelAllLocales: LocalizedString.toLocalizedField(fields.label),
-        __typename: 'LocalizableEnumValueType',
+      addFields: () => ({
+        __typename: 'EnumValue',
       }),
     }
   ),

--- a/models/type/src/custom-field-enum-value/types.ts
+++ b/models/type/src/custom-field-enum-value/types.ts
@@ -1,17 +1,11 @@
 import { CustomFieldEnumValue } from '@commercetools/platform-sdk';
-import { TLocalizedStringGraphql } from '@commercetools-test-data/commons/src';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TCustomFieldEnumValue = CustomFieldEnumValue;
 export type TCustomFieldEnumValueDraft = CustomFieldEnumValue;
 
-export type TCustomFieldEnumValueGraphql = Omit<
-  TCustomFieldEnumValue,
-  // In GraphQL, we prefer to use `nameAllLocales` instead of `name`.
-  'label'
-> & {
-  labelAllLocales: TLocalizedStringGraphql | null;
-  __typename: 'LocalizableEnumValueType';
+export type TCustomFieldEnumValueGraphql = TCustomFieldEnumValue & {
+  __typename: 'EnumValue';
 };
 export type TCustomFieldEnumValueDraftGraphql = TCustomFieldEnumValueDraft;
 

--- a/models/type/src/custom-field-localized-enum-type/builder.spec.ts
+++ b/models/type/src/custom-field-localized-enum-type/builder.spec.ts
@@ -71,7 +71,7 @@ describe('builder', () => {
                   __typename: 'LocalizedString',
                 }),
               ]),
-              __typename: 'LocalizableEnumValueType',
+              __typename: 'LocalizedEnumValue',
             }),
           ],
           __typename: 'LocalizableEnumValueTypeResult',

--- a/models/type/src/custom-field-localized-enum-value/builder.spec.ts
+++ b/models/type/src/custom-field-localized-enum-value/builder.spec.ts
@@ -60,7 +60,7 @@ describe('builder', () => {
             __typename: 'LocalizedString',
           }),
         ]),
-        __typename: 'LocalizableEnumValueType',
+        __typename: 'LocalizedEnumValue',
       })
     )
   );

--- a/models/type/src/custom-field-localized-enum-value/transformers.ts
+++ b/models/type/src/custom-field-localized-enum-value/transformers.ts
@@ -22,7 +22,7 @@ const transformers = {
     removeFields: ['label'],
     addFields: ({ fields }) => ({
       labelAllLocales: LocalizedString.toLocalizedField(fields.label),
-      __typename: 'LocalizableEnumValueType',
+      __typename: 'LocalizedEnumValue',
     }),
   }),
 };

--- a/models/type/src/custom-field-localized-enum-value/types.ts
+++ b/models/type/src/custom-field-localized-enum-value/types.ts
@@ -11,7 +11,7 @@ export type TCustomFieldLocalizedEnumValueGraphql = Omit<
   'label'
 > & {
   labelAllLocales: TLocalizedStringGraphql | null;
-  __typename: 'LocalizableEnumValueType';
+  __typename: 'LocalizedEnumValue';
 };
 export type TCustomFieldLocalizedEnumValueDraftGraphql =
   TCustomFieldLocalizedEnumValueDraft;


### PR DESCRIPTION
Changes in this PR:

- CustomFieldEnumType:
  - `__typename` changed: from `EnumCustomFieldType` to `EnumType`.
- CustomFieldEnumValue
  - `label` field is a string.
  - `labelAllLocales` field removed and `label` field added to GraphQL model.
  - `__typename` changed: from `LocalizableEnumValueType` to `EnumValue`.
- CustomFieldLocalizedEnumValue
  - `__typename` changed: from `LocalizableEnumValueType` to `LocalizedEnumValue`.