### PR TITLE
Ma fix wrong money value on product discount

### DIFF
--- a/.changeset/hot-tips-serve.md
+++ b/.changeset/hot-tips-serve.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product-discount': patch
+---
+
+fix product type discount value generator money needs to return an array of money

--- a/models/product-discount/src/product-discount-value-absolute/builder.spec.ts
+++ b/models/product-discount/src/product-discount-value-absolute/builder.spec.ts
@@ -17,9 +17,11 @@ describe('builder', () => {
       ProductDiscountValueAbsolute.random(),
       expect.objectContaining({
         type: 'absolute',
-        money: expect.objectContaining({
-          type: 'centPrecision',
-        }),
+        money: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'centPrecision',
+          }),
+        ]),
       })
     )
   );
@@ -33,9 +35,11 @@ describe('builder', () => {
       ProductDiscountValueAbsolute.random(),
       expect.objectContaining({
         type: 'absolute',
-        money: expect.objectContaining({
-          type: 'centPrecision',
-        }),
+        money: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'centPrecision',
+          }),
+        ]),
       })
     )
   );
@@ -49,9 +53,11 @@ describe('builder', () => {
       ProductDiscountValueAbsolute.random(),
       expect.objectContaining({
         type: 'absolute',
-        money: expect.objectContaining({
-          type: 'centPrecision',
-        }),
+        money: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'centPrecision',
+          }),
+        ]),
         __typename: 'AbsoluteDiscountValue',
       })
     )

--- a/models/product-discount/src/product-discount-value-absolute/generator.ts
+++ b/models/product-discount/src/product-discount-value-absolute/generator.ts
@@ -7,7 +7,7 @@ import type { TProductDiscountValueAbsolute } from './types';
 const generator = Generator<TProductDiscountValueAbsolute>({
   fields: {
     type: 'absolute',
-    money: fake(() => CentPrecisionMoney.random()),
+    money: [fake(() => CentPrecisionMoney.random())],
   },
 });
 


### PR DESCRIPTION
ProductDiscountValueAbsolute  money  must return an array of the type [CentPrecisionMoney](https://docs.commercetools.com/api/types#ctp:api:type:CentPrecisionMoney)
https://docs.commercetools.com/api/projects/productDiscounts#productdiscountvalueabsolute

this fix also fixes the flakiness when using the ProductDiscount.random() test model.