### PR TITLE
fix(attribute-enum-type): add missing results wrapper

### DIFF
--- a/models/product-type/src/attribute-enum-type/builder.spec.ts
+++ b/models/product-type/src/attribute-enum-type/builder.spec.ts
@@ -43,13 +43,17 @@ describe('builder', () => {
       AttributeEnumType.random(),
       expect.objectContaining({
         name: 'enum',
-        values: expect.arrayContaining([
-          expect.objectContaining({
-            key: expect.any(String),
-            label: expect.any(String),
-          }),
-        ]),
-        __typename: 'EnumAttributionDefinitionType',
+        values: expect.objectContaining({
+          results: [
+            expect.objectContaining({
+              key: expect.any(String),
+              label: expect.any(String),
+              __typename: 'PlainEnumValue',
+            }),
+          ],
+          __typename: 'PlainEnumValueResult',
+        }),
+        __typename: 'EnumAttributeDefinitionType',
       })
     )
   );

--- a/models/product-type/src/attribute-enum-type/transformers.ts
+++ b/models/product-type/src/attribute-enum-type/transformers.ts
@@ -1,4 +1,4 @@
-import { Transformer } from '@commercetools-test-data/core';
+import { Transformer, buildField } from '@commercetools-test-data/core';
 import { TAttributeEnumTypeGraphql, TAttributeEnumType } from './types';
 
 const transformers = {
@@ -11,9 +11,13 @@ const transformers = {
   graphql: Transformer<TAttributeEnumType, TAttributeEnumTypeGraphql>(
     'graphql',
     {
-      buildFields: ['values'],
-      addFields: ({ fields }) => ({
-        __typename: 'EnumAttributionDefinitionType',
+      replaceFields: ({ fields }) => ({
+        ...fields,
+        values: {
+          results: fields.values.map((value) => buildField(value, 'graphql')),
+          __typename: 'PlainEnumValueResult',
+        },
+        __typename: 'EnumAttributeDefinitionType',
       }),
     }
   ),

--- a/models/product-type/src/attribute-enum-type/types.ts
+++ b/models/product-type/src/attribute-enum-type/types.ts
@@ -1,17 +1,22 @@
-import type {
-  AttributeEnumType,
-  AttributePlainEnumValue,
-} from '@commercetools/platform-sdk';
+import type { AttributeEnumType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import {
+  TAttributePlainEnumValueDraftGraphql,
+  TAttributePlainEnumValue,
+} from '../attribute-plain-enum-value';
 
 export type TAttributeEnumType = AttributeEnumType;
 export type TAttributeEnumTypeDraft = AttributeEnumType;
 
-export type TAttributeEnumTypeGraphql = AttributeEnumType & {
-  __typename: 'EnumAttributionDefinitionType';
+export type TAttributeEnumTypeGraphql = Omit<TAttributeEnumType, 'values'> & {
+  values: {
+    results: Array<TAttributePlainEnumValue>;
+    __typename: 'PlainEnumValueResult';
+  };
+  __typename: 'EnumAttributeDefinitionType';
 };
 export type TAttributeEnumTypeDraftGraphql = {
-  enum: { values: Array<AttributePlainEnumValue> };
+  enum: { values: Array<TAttributePlainEnumValueDraftGraphql> };
 };
 
 export type TAttributeEnumTypeBuilder = TBuilder<TAttributeEnumType>;


### PR DESCRIPTION
- Wraps PlainEnumValue type with results, as done on `attribute-localized-enum-type` as seen below:
https://github.com/commercetools/test-data/blob/827861fe7d04e297cfed09efd4646659f8e260d1/models/product-type/src/attribute-localized-enum-type/transformers.ts#L22-L31
- Tested the updated `@commercetools-test-data/product-type` package locally against all products and discounts tests where it is being used.