### PR TITLE
Update management of locale-based props for GraphQL transformers

### DIFF
--- a/.changeset/clever-taxis-carry.md
+++ b/.changeset/clever-taxis-carry.md
@@ -1,0 +1,24 @@
+---
+'@commercetools-test-data/category': patch
+---
+
+Fixed the return type for some properties in the GraphQL representation:
+
+- name
+- description
+- slug
+- metaTitle
+- metaKeywords
+- metaDescription
+
+They all were returning a value with type `TLocalizedStringGraphql` where they should be returning a `string`.
+
+From the consumer point of view, mocking those values won't change so they can still use the `LocalizedString` common model to set it up:
+
+```js
+Category.random()
+  .name(LocalizedString.random().en('Shoes').de('Schuhe'))
+  .buildGraphql();
+```
+
+The actual `string` returned will be the one with the default locale (`en`) or the first one if that one does not exist.

--- a/.changeset/curvy-cycles-switch.md
+++ b/.changeset/curvy-cycles-switch.md
@@ -1,0 +1,24 @@
+---
+'@commercetools-test-data/product': patch
+---
+
+Fixed the return type for some properties in the GraphQL representation:
+
+- name
+- description
+- slug
+- metaTitle
+- metaKeywords
+- metaDescription
+
+They all were returning a value with type `TLocalizedStringGraphql` where they should be returning a `string`.
+
+From the consumer point of view, mocking those values won't change so they can still use the `LocalizedString` common model to set it up:
+
+```js
+Product.random()
+  .name(LocalizedString.random().en('Shoes').de('Schuhe'))
+  .buildGraphql();
+```
+
+The actual `string` returned will be the one with the default locale (`en`) or the first one if that one does not exist.

--- a/.changeset/yellow-rats-wait.md
+++ b/.changeset/yellow-rats-wait.md
@@ -1,0 +1,9 @@
+---
+'@commercetools-test-data/commons': minor
+---
+
+Added a new helper in the `LocalizedString` model which allows to get the default locale value out of all configured ones.
+
+The default value has been configured to be `en`.
+
+In case the model does not have that one configured, the helper will return the first one configured.

--- a/models/category/package.json
+++ b/models/category/package.json
@@ -21,6 +21,7 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/commons": "9.0.7",
     "@commercetools-test-data/core": "9.0.7",
+    "@commercetools-test-data/type": "9.0.7",
     "@commercetools-test-data/utils": "9.0.7",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"

--- a/models/category/src/builder.spec.ts
+++ b/models/category/src/builder.spec.ts
@@ -2,6 +2,7 @@
 /* eslint-disable jest/valid-title */
 import { LocalizedString } from '@commercetools-test-data/commons';
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { CustomFieldBooleanType } from '@commercetools-test-data/type';
 import type { TCategory, TCategoryGraphql } from './types';
 import * as Category from './index';
 
@@ -66,23 +67,7 @@ describe('builder', () => {
       Category.random().name(LocalizedString.random().en('Pants').de('Hosen')),
       expect.objectContaining({
         __typename: 'Category',
-        name: expect.arrayContaining([
-          expect.objectContaining({
-            __typename: 'LocalizedString',
-            locale: 'de',
-            value: 'Hosen',
-          }),
-          expect.objectContaining({
-            __typename: 'LocalizedString',
-            locale: 'en',
-            value: 'Pants',
-          }),
-          expect.objectContaining({
-            __typename: 'LocalizedString',
-            locale: 'fr',
-            value: expect.any(String),
-          }),
-        ]),
+        name: expect.any(String),
         nameAllLocales: expect.arrayContaining([
           expect.objectContaining({
             __typename: 'LocalizedString',
@@ -101,6 +86,7 @@ describe('builder', () => {
           }),
         ]),
         orderHint: expect.any(String),
+        description: undefined,
         descriptionAllLocales: null,
         createdBy: expect.objectContaining({
           customerRef: expect.objectContaining({ typeId: 'customer' }),
@@ -113,4 +99,80 @@ describe('builder', () => {
       })
     )
   );
+
+  it('should allow customization', () => {
+    const category = Category.random()
+      .ancestors([Category.random().key('category-ancestor-id-1')])
+      .custom(CustomFieldBooleanType.random())
+      .description(LocalizedString.random().en('Trendy pants'))
+      .externalId('external-id-123')
+      .id('category-123')
+      .key('key-pants')
+      .metaDescription(LocalizedString.random().en('Trendy pants (meta)'))
+      .metaKeywords(LocalizedString.random().en('pants (meta)'))
+      .metaTitle(LocalizedString.random().en('Pants (meta)'))
+      .name(LocalizedString.random().en('Pants'))
+      .orderHint('0.5')
+      .parent(Category.random().key('category-parent-id-1'))
+      .slug(LocalizedString.random().en('product-slug-1'))
+      .version(200)
+      .buildGraphql();
+
+    expect(category).toEqual(
+      expect.objectContaining({
+        ancestors: expect.arrayContaining([
+          expect.objectContaining({
+            key: 'category-ancestor-id-1',
+          }),
+        ]),
+        custom: expect.objectContaining({
+          name: 'Boolean',
+        }),
+        description: 'Trendy pants',
+        descriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'Trendy pants',
+          }),
+        ]),
+        externalId: 'external-id-123',
+        id: 'category-123',
+        key: 'key-pants',
+        metaTitle: 'Pants (meta)',
+        metaTitleAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'Pants (meta)',
+          }),
+        ]),
+        metaKeywords: 'pants (meta)',
+        metaKeywordsAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'pants (meta)',
+          }),
+        ]),
+        metaDescription: 'Trendy pants (meta)',
+        metaDescriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'Trendy pants (meta)',
+          }),
+        ]),
+        name: 'Pants',
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'Pants',
+          }),
+        ]),
+        orderHint: '0.5',
+        parent: expect.objectContaining({
+          key: 'category-parent-id-1',
+        }),
+        slug: 'product-slug-1',
+        version: 200,
+      })
+    );
+  });
 });

--- a/models/category/src/transformers.ts
+++ b/models/category/src/transformers.ts
@@ -25,17 +25,52 @@ const transformers = {
     buildFields,
   }),
   graphql: Transformer<TCategory, TCategoryGraphql>('graphql', {
-    buildFields,
-    addFields: ({ fields }) => {
+    buildFields: [
+      'createdBy',
+      'lastModifiedBy',
+      'ancestors',
+      'parent',
+      'custom',
+      'assets',
+    ],
+    replaceFields: ({ fields }) => {
       const nameAllLocales = LocalizedString.toLocalizedField(fields.name);
       const descriptionAllLocales = LocalizedString.toLocalizedField(
         fields.description
       );
+      const slugAllLocales = LocalizedString.toLocalizedField(fields.slug);
+      const metaTitleAllLocales = LocalizedString.toLocalizedField(
+        fields.metaTitle
+      );
+      const metaKeywordsAllLocales = LocalizedString.toLocalizedField(
+        fields.metaKeywords
+      );
+      const metaDescriptionAllLocales = LocalizedString.toLocalizedField(
+        fields.metaDescription
+      );
 
       return {
+        ...(fields as unknown as TCategoryGraphql),
         __typename: 'Category',
+        name: LocalizedString.resolveGraphqlDefaultLocaleValue(nameAllLocales)!,
         nameAllLocales,
+        description: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          descriptionAllLocales
+        ),
         descriptionAllLocales,
+        slug: LocalizedString.resolveGraphqlDefaultLocaleValue(slugAllLocales)!,
+        slugAllLocales,
+        metaTitle:
+          LocalizedString.resolveGraphqlDefaultLocaleValue(metaTitleAllLocales),
+        metaTitleAllLocales,
+        metaKeywords: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          metaKeywordsAllLocales
+        ),
+        metaKeywordsAllLocales,
+        metaDescription: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          metaDescriptionAllLocales
+        ),
+        metaDescriptionAllLocales,
       };
     },
   }),

--- a/models/category/src/types.ts
+++ b/models/category/src/types.ts
@@ -33,18 +33,29 @@ export type TCategoryBuilder = TBuilder<TCategory>;
 export type TCreateCategoryBuilder = () => TCategoryBuilder;
 export type TCategoryGraphql = Omit<
   TCategory,
-  // In GraphQL, we prefer to use `nameAllLocales` instead of `name`.
+  // The shape of these props is different in GraphQL
   | 'name'
-  // In GraphQL, we prefer to use `descriptionAllLocales` instead of `description`.
   | 'description'
-  // In GraphQL, the object shape is different.
+  | 'slug'
   | 'createdBy'
-  // In GraphQL, the object shape is different.
   | 'lastModifiedBy'
+  | 'metaTitle'
+  | 'metaKeywords'
+  | 'metaDescription'
 > & {
   __typename: 'Category';
   createdBy: TClientLoggingGraphql;
   lastModifiedBy: TClientLoggingGraphql;
+  name: string;
   nameAllLocales?: TLocalizedStringGraphql | null;
+  description?: string;
   descriptionAllLocales?: TLocalizedStringGraphql | null;
+  slug: string;
+  slugAllLocales?: TLocalizedStringGraphql | null;
+  metaTitle?: string;
+  metaTitleAllLocales?: TLocalizedStringGraphql | null;
+  metaKeywords?: string;
+  metaKeywordsAllLocales?: TLocalizedStringGraphql | null;
+  metaDescription?: string;
+  metaDescriptionAllLocales?: TLocalizedStringGraphql | null;
 };

--- a/models/commons/src/localized-string/helpers.ts
+++ b/models/commons/src/localized-string/helpers.ts
@@ -13,4 +13,18 @@ const toLocalizedField = <Model>(value?: Model) => {
   return localizedField;
 };
 
-export { toLocalizedField };
+const DEFAULT_LOCALE = 'en';
+
+const resolveGraphqlDefaultLocaleValue = (
+  allLocales: TLocalizedStringGraphql | null
+) => {
+  if (!allLocales) {
+    return undefined;
+  }
+  const defaultLocaleName = allLocales.find(
+    (name) => name.locale === DEFAULT_LOCALE
+  );
+  return defaultLocaleName ? defaultLocaleName.value : allLocales[0].value;
+};
+
+export { resolveGraphqlDefaultLocaleValue, toLocalizedField };

--- a/models/commons/src/localized-string/index.ts
+++ b/models/commons/src/localized-string/index.ts
@@ -2,4 +2,4 @@ export * as LocalizedStringDraft from './localized-string-draft';
 
 export { default as random } from './builder';
 export { default as presets } from './presets';
-export { toLocalizedField } from './helpers';
+export { resolveGraphqlDefaultLocaleValue, toLocalizedField } from './helpers';

--- a/models/product/src/product-data/builder.spec.ts
+++ b/models/product/src/product-data/builder.spec.ts
@@ -1,6 +1,9 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
+import { Category } from '@commercetools-test-data/category';
+import { LocalizedString } from '@commercetools-test-data/commons';
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import * as ProductVariant from '../product-variant';
 import { TProductData, TProductDataGraphql } from './types';
 import * as ProductData from './index';
 
@@ -84,6 +87,7 @@ describe('builder', () => {
       'graphql',
       ProductData.random(),
       expect.objectContaining({
+        name: expect.any(String),
         nameAllLocales: expect.arrayContaining([
           expect.objectContaining({
             locale: 'en',
@@ -91,6 +95,7 @@ describe('builder', () => {
             __typename: 'LocalizedString',
           }),
         ]),
+        description: expect.any(String),
         descriptionAllLocales: expect.arrayContaining([
           expect.objectContaining({
             locale: 'en',
@@ -98,6 +103,7 @@ describe('builder', () => {
             __typename: 'LocalizedString',
           }),
         ]),
+        slug: expect.any(String),
         slugAllLocales: expect.arrayContaining([
           expect.objectContaining({
             locale: 'en',
@@ -129,6 +135,7 @@ describe('builder', () => {
         ]),
         searchKeyword: expect.arrayContaining([]),
         searchKeywords: expect.arrayContaining([]),
+        metaTitle: expect.any(String),
         metaTitleAllLocales: expect.arrayContaining([
           expect.objectContaining({
             locale: 'en',
@@ -136,6 +143,7 @@ describe('builder', () => {
             __typename: 'LocalizedString',
           }),
         ]),
+        metaKeywords: expect.any(String),
         metaKeywordsAllLocales: expect.arrayContaining([
           expect.objectContaining({
             locale: 'en',
@@ -143,6 +151,7 @@ describe('builder', () => {
             __typename: 'LocalizedString',
           }),
         ]),
+        metaDescription: expect.any(String),
         metaDescriptionAllLocales: expect.arrayContaining([
           expect.objectContaining({
             locale: 'en',
@@ -159,4 +168,107 @@ describe('builder', () => {
       })
     )
   );
+
+  it('should allow customization', () => {
+    const productData = ProductData.random()
+      .allVariants([ProductVariant.presets.happyCowMilkMasterVariant()])
+      .categories([Category.random().id('category-id-1')])
+      .categoryOrderHints({ 'category-id-1': '0.5' })
+      .description(LocalizedString.random().en('product description #1'))
+      .masterVariant(ProductVariant.presets.happyCowMilkMasterVariant())
+      .metaTitle(LocalizedString.random().en('product meta title #1'))
+      .metaKeywords(LocalizedString.random().en('product meta keywords #1'))
+      .metaDescription(
+        LocalizedString.random().en('product meta description #1')
+      )
+      .name(LocalizedString.random().en('product name #1'))
+      .searchKeyword([{ text: 'search-keyword-1' }])
+      .searchKeywords({ en: [{ text: 'search-keyword-2' }] })
+      .skus(['sku-1', 'sku-2'])
+      .slug(LocalizedString.random().en('product-slug-1'))
+      .variant(ProductVariant.presets.happyCowMilkMasterVariant())
+      .buildGraphql<TProductDataGraphql>();
+
+    expect(productData).toEqual(
+      expect.objectContaining({
+        allVariants: expect.arrayContaining([
+          expect.objectContaining({
+            key: 'happy-cow-master-variant-key',
+          }),
+        ]),
+        categories: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'category-id-1',
+          }),
+        ]),
+        categoryOrderHints: expect.arrayContaining([
+          expect.objectContaining({
+            categoryId: 'category-id-1',
+            orderHint: '0.5',
+          }),
+        ]),
+        description: 'product description #1',
+        descriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'product description #1',
+          }),
+        ]),
+        masterVariant: expect.objectContaining({
+          key: 'happy-cow-master-variant-key',
+        }),
+        metaTitle: 'product meta title #1',
+        metaTitleAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'product meta title #1',
+          }),
+        ]),
+        metaKeywords: 'product meta keywords #1',
+        metaKeywordsAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'product meta keywords #1',
+          }),
+        ]),
+        metaDescription: 'product meta description #1',
+        metaDescriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'product meta description #1',
+          }),
+        ]),
+        name: 'product name #1',
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'product name #1',
+          }),
+        ]),
+        searchKeyword: expect.arrayContaining([
+          expect.objectContaining({
+            text: 'search-keyword-1',
+          }),
+        ]),
+        searchKeywords: expect.objectContaining({
+          en: expect.arrayContaining([
+            expect.objectContaining({
+              text: 'search-keyword-2',
+            }),
+          ]),
+        }),
+        skus: expect.arrayContaining(['sku-1', 'sku-2']),
+        slug: 'product-slug-1',
+        slugAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'product-slug-1',
+          }),
+        ]),
+        variant: expect.objectContaining({
+          key: 'happy-cow-master-variant-key',
+        }),
+      })
+    );
+  });
 });

--- a/models/product/src/product-data/transformers.ts
+++ b/models/product/src/product-data/transformers.ts
@@ -59,7 +59,13 @@ const transformers = {
     },
   }),
   graphql: Transformer<TProductData, TProductDataGraphql>('graphql', {
-    buildFields: ['categories', 'masterVariant'],
+    buildFields: [
+      'categories',
+      'masterVariant',
+      'variant',
+      'variants',
+      'allVariants',
+    ],
     replaceFields: ({ fields }) => {
       const nameAllLocales = LocalizedString.toLocalizedField(fields.name);
       const descriptionAllLocales = LocalizedString.toLocalizedField(
@@ -95,11 +101,24 @@ const transformers = {
 
       return {
         ...fields,
+        name: LocalizedString.resolveGraphqlDefaultLocaleValue(nameAllLocales)!,
         nameAllLocales,
+        description: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          descriptionAllLocales
+        ),
         descriptionAllLocales,
+        slug: LocalizedString.resolveGraphqlDefaultLocaleValue(slugAllLocales)!,
         slugAllLocales,
+        metaTitle:
+          LocalizedString.resolveGraphqlDefaultLocaleValue(metaTitleAllLocales),
         metaTitleAllLocales,
+        metaKeywords: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          metaKeywordsAllLocales
+        ),
         metaKeywordsAllLocales,
+        metaDescription: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          metaDescriptionAllLocales
+        ),
         metaDescriptionAllLocales,
         categoryOrderHints,
         categoryOrderHint,

--- a/models/product/src/product-data/types.ts
+++ b/models/product/src/product-data/types.ts
@@ -38,17 +38,29 @@ export type TCategoryReferenceGraphql = CategoryReference & {
 // Fields here must be transformable from the base model
 export type TProductDataGraphql = Omit<
   TProductData,
-  'categories' | 'categoryOrderHints'
+  // The shape of these props is different in GraphQL
+  | 'categoryOrderHints'
+  | 'name'
+  | 'description'
+  | 'slug'
+  | 'metaTitle'
+  | 'metaKeywords'
+  | 'metaDescription'
 > & {
   categoryOrderHints: Array<TCategoryOrderHintGraphql>;
   categoryOrderHint: String | null;
   categoriesRef: Array<TCategoryReferenceGraphql>;
-  categories: Array<Category>;
+  name: string;
   nameAllLocales?: TLocalizedStringGraphql | null;
+  description?: string;
   descriptionAllLocales?: TLocalizedStringGraphql | null;
+  slug: string;
   slugAllLocales?: TLocalizedStringGraphql | null;
+  metaTitle?: string;
   metaTitleAllLocales?: TLocalizedStringGraphql | null;
+  metaKeywords?: string;
   metaKeywordsAllLocales?: TLocalizedStringGraphql | null;
+  metaDescription?: string;
   metaDescriptionAllLocales?: TLocalizedStringGraphql | null;
   __typename: 'ProductData';
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       '@commercetools-test-data/core':
         specifier: 9.0.7
         version: link:../../core
+      '@commercetools-test-data/type':
+        specifier: 9.0.7
+        version: link:../type
       '@commercetools-test-data/utils':
         specifier: 9.0.7
         version: link:../../utils


### PR DESCRIPTION
## Description

There are some properties in the test data models that are locale based but we're not handling them in a way that resembles the way they are handled in the GraphQL context.

Let's take the Category model `name` property as an example.

In the Core definition for that model, the `name` property is a `LocalizedString` type, which is an object that contains a map of locale to string, so that's what we configure [in the model's generator](https://github.com/commercetools/test-data/blob/main/models/category/src/generator.ts#L20).

However, the GraphQL representation of that property is defined as an array of [TLocalizedStringGraphql](https://github.com/commercetools/test-data/blob/main/models/commons/src/localized-string/types.ts#L6) type, which is an object that contains the locale and the value.

Also, in GraphQL we prefer to use the calculated **nameAllLocales** property which [is created](https://github.com/commercetools/test-data/blob/main/models/category/src/transformers.ts#L30) in the GraphQL transformer of the Category model, but that does not mean that the **name** property can't be used. Actually, in the MC frontend we are using it ([example](https://github.com/commercetools/merchant-center-frontend/blob/main/packages-application/application-products/src/components/pim-search-list/pim-product-list-connector/products.ctp.graphql#L109)).

The issue is that, if you check the previous example, the expected **name** property is just a string, but the data model is returning a `TLocalizedStringGraphql` object instead.
This is how the Category entity looks like in the GraphQL API:
![image](https://github.com/user-attachments/assets/d676a0c4-0f79-4c7b-a771-14e6301e0f9c)

The GraphQL api is expecting the **name** to be consumed using a locale so that the server will return a string in the requested locale.


So, the GraphQL transformer for the Category model should be updated to handle the **name** property in a way that it returns a string instead of an array of `TLocalizedStringGraphql` objects.

I've been thinking about different approaches and the one I'm proposing here is about the GraphQL transformer to not build the **name** property automatically, "manually" build the `nameAllLocales` property and then use the latter to get the value we will be replacing the **name** property for so instead of returning a `LocalizedString` object, we will be returning a string.

Since the `LocalizedString` value of the `name` property which gets to the GraphQL transformer will contain potentially several names for different locales, we would be returning the english (decided default locale) version, or the first one in the list if the english version is not present.
(_Using english as the default locale is what we were [already doing](https://github.com/commercetools/merchant-center-frontend/blob/main/packages-shared/test-data/src/product-data/transformers.js#L78) in the local test-data of the MC repository_)

This way we can keep a very similar API from the consumer perspective (they can configure different names per locale which can be consumed in the `nameAllLocales` property) and know the plain string `name` value will be the english version they provided. 


There's an alternative approach I'm exploring here: #630 





