### PR TITLE
Update management of locale-based props for GraphQL transformers (alternative)

### DIFF
--- a/core/src/transformer.ts
+++ b/core/src/transformer.ts
@@ -58,7 +58,7 @@ function Transformer<Model, TransformedModel>(
         );
       }
       return fieldsReplacer({
-        fields: transformedFields,
+        fields: transformedFields as unknown as TransformedModel,
       }) as unknown as TransformedModel;
     }
 

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -48,7 +48,11 @@ export type TTransformBuildName = 'build' | 'buildGraphql' | 'buildRest';
 export type TTransformerOptions<Model, TransformedModel> = {
   addFields?: (args: { fields: Model }) => Partial<TransformedModel>;
   removeFields?: (keyof Model)[];
-  replaceFields?: (args: { fields: Model }) => TransformedModel;
+  replaceFields?: <
+    TIntermediateModel extends unknown = TransformedModel,
+  >(args: {
+    fields: TIntermediateModel;
+  }) => TransformedModel;
   buildFields?: (keyof Model)[];
 };
 
@@ -100,21 +104,21 @@ export type TBuilder<OriginalModel> = {
 
 export type TDefaultTransformer<
   TransformerType extends TTransformType,
-  Model
+  Model,
 > = 'default' extends TransformerType
   ? { default: TTransformer<Model> }
   : never;
 
 export type TGraphqlTransformer<
   TransformerType extends TTransformType,
-  Model
+  Model,
 > = 'graphql' extends TransformerType
   ? { graphql: TTransformer<Model> }
   : never;
 
 export type TRestTransformer<
   TransformerType extends TTransformType,
-  Model
+  Model,
 > = 'rest' extends TransformerType ? { rest: TTransformer<Model> } : never;
 
 export type TBuilderOptions<Model> = {

--- a/models/category/package.json
+++ b/models/category/package.json
@@ -21,6 +21,7 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/commons": "9.0.7",
     "@commercetools-test-data/core": "9.0.7",
+    "@commercetools-test-data/type": "9.0.7",
     "@commercetools-test-data/utils": "9.0.7",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"

--- a/models/category/src/builder.spec.ts
+++ b/models/category/src/builder.spec.ts
@@ -2,6 +2,7 @@
 /* eslint-disable jest/valid-title */
 import { LocalizedString } from '@commercetools-test-data/commons';
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { CustomFieldBooleanType } from '@commercetools-test-data/type';
 import type { TCategory, TCategoryGraphql } from './types';
 import * as Category from './index';
 
@@ -66,23 +67,7 @@ describe('builder', () => {
       Category.random().name(LocalizedString.random().en('Pants').de('Hosen')),
       expect.objectContaining({
         __typename: 'Category',
-        name: expect.arrayContaining([
-          expect.objectContaining({
-            __typename: 'LocalizedString',
-            locale: 'de',
-            value: 'Hosen',
-          }),
-          expect.objectContaining({
-            __typename: 'LocalizedString',
-            locale: 'en',
-            value: 'Pants',
-          }),
-          expect.objectContaining({
-            __typename: 'LocalizedString',
-            locale: 'fr',
-            value: expect.any(String),
-          }),
-        ]),
+        name: expect.any(String),
         nameAllLocales: expect.arrayContaining([
           expect.objectContaining({
             __typename: 'LocalizedString',
@@ -113,4 +98,80 @@ describe('builder', () => {
       })
     )
   );
+
+  it('should allow customization', () => {
+    const category = Category.random()
+      .ancestors([Category.random().key('category-ancestor-id-1')])
+      .custom(CustomFieldBooleanType.random())
+      .description(LocalizedString.random().en('Trendy pants'))
+      .externalId('external-id-123')
+      .id('category-123')
+      .key('key-pants')
+      .metaDescription(LocalizedString.random().en('Trendy pants (meta)'))
+      .metaKeywords(LocalizedString.random().en('pants (meta)'))
+      .metaTitle(LocalizedString.random().en('Pants (meta)'))
+      .name(LocalizedString.random().en('Pants'))
+      .orderHint('0.5')
+      .parent(Category.random().key('category-parent-id-1'))
+      .slug(LocalizedString.random().en('product-slug-1'))
+      .version(200)
+      .buildGraphql();
+
+    expect(category).toEqual(
+      expect.objectContaining({
+        ancestors: expect.arrayContaining([
+          expect.objectContaining({
+            key: 'category-ancestor-id-1',
+          }),
+        ]),
+        custom: expect.objectContaining({
+          name: 'Boolean',
+        }),
+        description: 'Trendy pants',
+        descriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'Trendy pants',
+          }),
+        ]),
+        externalId: 'external-id-123',
+        id: 'category-123',
+        key: 'key-pants',
+        metaTitle: 'Pants (meta)',
+        metaTitleAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'Pants (meta)',
+          }),
+        ]),
+        metaKeywords: 'pants (meta)',
+        metaKeywordsAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'pants (meta)',
+          }),
+        ]),
+        metaDescription: 'Trendy pants (meta)',
+        metaDescriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'Trendy pants (meta)',
+          }),
+        ]),
+        name: 'Pants',
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'Pants',
+          }),
+        ]),
+        orderHint: '0.5',
+        parent: expect.objectContaining({
+          key: 'category-parent-id-1',
+        }),
+        slug: 'product-slug-1',
+        version: 200,
+      })
+    );
+  });
 });

--- a/models/category/src/transformers.ts
+++ b/models/category/src/transformers.ts
@@ -1,6 +1,10 @@
 import { LocalizedString } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
-import type { TCategory, TCategoryGraphql } from './types';
+import type {
+  TCategory,
+  TCategoryGraphql,
+  TIntermediateCategoryGraphql,
+} from './types';
 
 const buildFields: Array<keyof TCategory> = [
   'createdBy',
@@ -26,16 +30,30 @@ const transformers = {
   }),
   graphql: Transformer<TCategory, TCategoryGraphql>('graphql', {
     buildFields,
-    addFields: ({ fields }) => {
-      const nameAllLocales = LocalizedString.toLocalizedField(fields.name);
-      const descriptionAllLocales = LocalizedString.toLocalizedField(
-        fields.description
-      );
-
+    replaceFields: <TIntermediateCategoryGraphql>({ fields }) => {
       return {
+        ...fields,
         __typename: 'Category',
-        nameAllLocales,
-        descriptionAllLocales,
+        name: LocalizedString.resolveGraphqlDefaultLocaleValue(fields.name)!,
+        nameAllLocales: fields.name,
+        description: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          fields.description
+        ),
+        descriptionAllLocales: fields.description,
+        slug: LocalizedString.resolveGraphqlDefaultLocaleValue(fields.slug)!,
+        slugAllLocales: fields.slug,
+        metaTitle: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          fields.metaTitle
+        ),
+        metaTitleAllLocales: fields.metaTitle,
+        metaKeywords: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          fields.metaKeywords
+        ),
+        metaKeywordsAllLocales: fields.metaKeywords,
+        metaDescription: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          fields.metaDescription
+        ),
+        metaDescriptionAllLocales: fields.metaDescription,
       };
     },
   }),

--- a/models/category/src/types.ts
+++ b/models/category/src/types.ts
@@ -33,18 +33,45 @@ export type TCategoryBuilder = TBuilder<TCategory>;
 export type TCreateCategoryBuilder = () => TCategoryBuilder;
 export type TCategoryGraphql = Omit<
   TCategory,
-  // In GraphQL, we prefer to use `nameAllLocales` instead of `name`.
+  // The shape of these props is different in GraphQL
   | 'name'
-  // In GraphQL, we prefer to use `descriptionAllLocales` instead of `description`.
   | 'description'
-  // In GraphQL, the object shape is different.
+  | 'slug'
   | 'createdBy'
-  // In GraphQL, the object shape is different.
   | 'lastModifiedBy'
+  | 'metaTitle'
+  | 'metaKeywords'
+  | 'metaDescription'
 > & {
   __typename: 'Category';
   createdBy: TClientLoggingGraphql;
   lastModifiedBy: TClientLoggingGraphql;
+  name: string;
   nameAllLocales?: TLocalizedStringGraphql | null;
+  description?: string;
   descriptionAllLocales?: TLocalizedStringGraphql | null;
+  slug: string;
+  slugAllLocales?: TLocalizedStringGraphql | null;
+  metaTitle?: string;
+  metaTitleAllLocales?: TLocalizedStringGraphql | null;
+  metaKeywords?: string;
+  metaKeywordsAllLocales?: TLocalizedStringGraphql | null;
+  metaDescription?: string;
+  metaDescriptionAllLocales?: TLocalizedStringGraphql | null;
+};
+export type TIntermediateCategoryGraphql = Omit<
+  TCategoryGraphql,
+  | 'description'
+  | 'name'
+  | 'metaDescription'
+  | 'metaKeywords'
+  | 'metaTitle'
+  | 'slug'
+> & {
+  description?: TLocalizedStringGraphql;
+  name: TLocalizedStringGraphql;
+  metaDescription?: TLocalizedStringGraphql;
+  metaKeywords?: TLocalizedStringGraphql;
+  metaTitle?: TLocalizedStringGraphql;
+  slug: TLocalizedStringGraphql;
 };

--- a/models/commons/src/localized-string/helpers.ts
+++ b/models/commons/src/localized-string/helpers.ts
@@ -13,4 +13,18 @@ const toLocalizedField = <Model>(value?: Model) => {
   return localizedField;
 };
 
-export { toLocalizedField };
+const DEFAULT_LOCALE = 'en';
+
+const resolveGraphqlDefaultLocaleValue = (
+  allLocales: TLocalizedStringGraphql | null
+) => {
+  if (!allLocales) {
+    return undefined;
+  }
+  const defaultLocaleName = allLocales.find(
+    (name) => name.locale === DEFAULT_LOCALE
+  );
+  return defaultLocaleName ? defaultLocaleName.value : allLocales[0]?.value;
+};
+
+export { resolveGraphqlDefaultLocaleValue, toLocalizedField };

--- a/models/commons/src/localized-string/index.ts
+++ b/models/commons/src/localized-string/index.ts
@@ -2,4 +2,4 @@ export * as LocalizedStringDraft from './localized-string-draft';
 
 export { default as random } from './builder';
 export { default as presets } from './presets';
-export { toLocalizedField } from './helpers';
+export { resolveGraphqlDefaultLocaleValue, toLocalizedField } from './helpers';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       '@commercetools-test-data/core':
         specifier: 9.0.7
         version: link:../../core
+      '@commercetools-test-data/type':
+        specifier: 9.0.7
+        version: link:../type
       '@commercetools-test-data/utils':
         specifier: 9.0.7
         version: link:../../utils


### PR DESCRIPTION
## Description

This is an alternative proposal for the issue explained in #629.

In this one, we let the GraphQL transformer build the **name** property (to a [TLocalizedStringGraphql](https://github.com/commercetools/test-data/blob/main/models/commons/src/localized-string/types.ts#L6) type), we use it directly to return the `nameAllLocales` property value, and we replace the `name` property with the default locale of the latter.

The issue here is the typing for the `replaceFields` transformer fuction.
Currently the `fields` property that function is called with, is defined as the original model (`TCategory` in this case) but that's not actually true as the "buildable" fields have already been built with the respective graphql transformers. However, we can't just change the type of the `fields` property to `TCategoryGraphql` because over there we need the name to be a `string` but the value we get from the build phase of that property is a `TLocalizedStringGraphql` type.

I was trying to make the `replaceFields` function more generic so that we could provide a new type describing the shape of the actual `fields` property that the function is called with. However, this is not working for me yet (typescript issues) and maybe it's not even the right approach.


