### PR TITLE
Fix stage-linting issue when committing spec files containing ‘build’ in their path or file name

### DIFF
--- a/jest.eslint.config.js
+++ b/jest.eslint.config.js
@@ -5,7 +5,7 @@ module.exports = {
   runner: 'jest-runner-eslint',
   displayName: 'eslint',
   moduleFileExtensions: ['js', 'ts', 'tsx'],
-  modulePathIgnorePatterns: ['build', 'dist', 'public', 'generated'],
+  modulePathIgnorePatterns: ['/build/', 'dist', 'public', 'generated'],
   testMatch: ['<rootDir>/**/*.js', '<rootDir>/**/*.ts', '<rootDir>/**/*.tsx'],
   watchPlugins: ['jest-watch-typeahead/filename'],
 };


### PR DESCRIPTION
This PR fixes an issue where staged linting would fail when committing **only** spec files containing the word `build` in their name (e.g., builder.spec.ts).
Curiously, the commit would succeed if any other file was staged alongside the spec file.

The linter misinterpreted `build` as part of the main `build` directory path.
This issue was resolved by adding slashes around `build` in `modulePathIgnorePatterns` to target the `build` directory more specifically.

For more details
https://commercetools.slack.com/archives/GCSJ9T12P/p1724329299796769