### PR TITLE
FCT-fix update b2c test data to match types for specific products and product-variants

### DIFF
--- a/.changeset/silent-colts-hunt.md
+++ b/.changeset/silent-colts-hunt.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/product-type': patch
+'@commercetools-test-data/product': patch
+---
+
+Fixes for the B2C sample data import attributes.

--- a/.changeset/silent-colts-hunt.md
+++ b/.changeset/silent-colts-hunt.md
@@ -1,6 +1,0 @@
----
-'@commercetools-test-data/product-type': patch
-'@commercetools-test-data/product': patch
----
-
-Fixes for the B2C sample data import attributes.

--- a/.changeset/stupid-dolls-peel.md
+++ b/.changeset/stupid-dolls-peel.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/product-type': patch
+'@commercetools-test-data/product': patch
+---
+
+"fix(b2c presets): update product-set product-type to include 'finish' attribute, update 'serenity-queen-bed' product-draft to declare 'color' attribute correctly"

--- a/models/product-type/src/product-type/product-type-draft/presets/sample-data-b2c-lifestyle/product-sets.spec.ts
+++ b/models/product-type/src/product-type/product-type-draft/presets/sample-data-b2c-lifestyle/product-sets.spec.ts
@@ -50,6 +50,25 @@ describe(`with productSets preset`, () => {
         "name": "ltext",
       },
     },
+    {
+      "attributeConstraint": "None",
+      "inputHint": "SingleLine",
+      "inputTip": undefined,
+      "isRequired": false,
+      "isSearchable": false,
+      "label": {
+        "de": undefined,
+        "de-DE": "Fertig",
+        "en": undefined,
+        "en-GB": "Finish",
+        "en-US": "Finish",
+        "fr": undefined,
+      },
+      "name": "finish",
+      "type": {
+        "name": "ltext",
+      },
+    },
   ],
   "description": "products also sold as sets with their variants",
   "key": "product-sets",
@@ -116,6 +135,33 @@ describe(`with productSets preset`, () => {
         },
       ],
       "name": "color",
+      "type": {
+        "ltext": {
+          "dummy": null,
+        },
+      },
+    },
+    {
+      "attributeConstraint": "None",
+      "inputHint": "SingleLine",
+      "inputTip": undefined,
+      "isRequired": false,
+      "isSearchable": false,
+      "label": [
+        {
+          "locale": "en-GB",
+          "value": "Finish",
+        },
+        {
+          "locale": "en-US",
+          "value": "Finish",
+        },
+        {
+          "locale": "de-DE",
+          "value": "Fertig",
+        },
+      ],
+      "name": "finish",
       "type": {
         "ltext": {
           "dummy": null,

--- a/models/product-type/src/product-type/product-type-draft/presets/sample-data-b2c-lifestyle/product-sets.ts
+++ b/models/product-type/src/product-type/product-type-draft/presets/sample-data-b2c-lifestyle/product-sets.ts
@@ -53,6 +53,22 @@ const productSets = (): TProductTypeDraftBuilder =>
         .attributeConstraint(attributeConstraints.None)
         .isSearchable(false)
         .inputHint(inputHints.SingleLine),
+
+      AttributeDefinitionDraft.presets
+        .empty()
+        .name('finish')
+        .type(AttributeLocalizableTextTypeDraft.random())
+        .label(
+          LocalizedStringDraft.presets
+            .empty()
+            ['en-GB']('Finish')
+            ['en-US']('Finish')
+            ['de-DE']('Fertig')
+        )
+        .isRequired(false)
+        .attributeConstraint(attributeConstraints.None)
+        .isSearchable(false)
+        .inputHint(inputHints.SingleLine),
     ]);
 
 export default productSets;

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-b2c-lifestyle/serenity-queen-bed-01.spec.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-b2c-lifestyle/serenity-queen-bed-01.spec.ts
@@ -20,12 +20,9 @@ describe(`with serenityQueenBed01 preset`, () => {
     {
       "name": "color",
       "value": {
-        "key": "#808080",
-        "label": {
-          "de-DE": "Beige:#F5F5DC",
-          "en-GB": "Beige:#F5F5DC",
-          "en-US": "Beige:#F5F5DC",
-        },
+        "de-DE": "Beige:#F5F5DC",
+        "en-GB": "Beige:#F5F5DC",
+        "en-US": "Beige:#F5F5DC",
       },
     },
   ],
@@ -105,7 +102,7 @@ describe(`with serenityQueenBed01 preset`, () => {
     },
     {
       "name": "color",
-      "value": "{"key":"#808080","label":{"de-DE":"Beige:#F5F5DC","en-GB":"Beige:#F5F5DC","en-US":"Beige:#F5F5DC"}}",
+      "value": "{"de-DE":"Beige:#F5F5DC","en-GB":"Beige:#F5F5DC","en-US":"Beige:#F5F5DC"}",
     },
   ],
   "images": [

--- a/models/product/src/product-variant/product-variant-draft/presets/sample-data-b2c-lifestyle/serenity-queen-bed-01.ts
+++ b/models/product/src/product-variant/product-variant-draft/presets/sample-data-b2c-lifestyle/serenity-queen-bed-01.ts
@@ -36,16 +36,11 @@ const serenityQueenBed01 = (): TProductVariantDraftBuilder =>
         'en-US': '- Assembly included in delivery',
         'de-DE': '- Montage im Lieferumfang enthalten',
       }),
-      AttributeDraft.random()
-        .name('color')
-        .value({
-          key: '#808080',
-          label: {
-            'de-DE': 'Beige:#F5F5DC',
-            'en-GB': 'Beige:#F5F5DC',
-            'en-US': 'Beige:#F5F5DC',
-          },
-        }),
+      AttributeDraft.random().name('color').value({
+        'de-DE': 'Beige:#F5F5DC',
+        'en-GB': 'Beige:#F5F5DC',
+        'en-US': 'Beige:#F5F5DC',
+      }),
     ]);
 
 export default serenityQueenBed01;

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/serenity-queen-bed.spec.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/serenity-queen-bed.spec.ts
@@ -44,12 +44,9 @@ describe(`with serenityQueenBed preset`, () => {
       {
         "name": "color",
         "value": {
-          "key": "#808080",
-          "label": {
-            "de-DE": "Beige:#F5F5DC",
-            "en-GB": "Beige:#F5F5DC",
-            "en-US": "Beige:#F5F5DC",
-          },
+          "de-DE": "Beige:#F5F5DC",
+          "en-GB": "Beige:#F5F5DC",
+          "en-US": "Beige:#F5F5DC",
         },
       },
     ],
@@ -193,7 +190,7 @@ describe(`with serenityQueenBed preset`, () => {
       },
       {
         "name": "color",
-        "value": "{"key":"#808080","label":{"de-DE":"Beige:#F5F5DC","en-GB":"Beige:#F5F5DC","en-US":"Beige:#F5F5DC"}}",
+        "value": "{"de-DE":"Beige:#F5F5DC","en-GB":"Beige:#F5F5DC","en-US":"Beige:#F5F5DC"}",
       },
     ],
     "images": [


### PR DESCRIPTION
This pull request includes several changes aimed at fixing and updating attributes for the B2C sample data import. The most important changes include adding a new attribute to the product type and correcting the declaration of an existing attribute in the product draft.

### Attribute Updates:

* Added a new `finish` attribute to the `product-sets` product type in multiple locales (`en-GB`, `en-US`, `de-DE`). (`models/product-type/src/product-type/product-type-draft/presets/sample-data-b2c-lifestyle/product-sets.spec.ts`: [[1]](diffhunk://#diff-ae3a29babb97604b9d6fd97d9243bc43ecdbdb57dc506d3d9db5197d7eb4a1d6R53-R71) [[2]](diffhunk://#diff-ae3a29babb97604b9d6fd97d9243bc43ecdbdb57dc506d3d9db5197d7eb4a1d6R144-R170); `models/product-type/src/product-type/product-type-draft/presets/sample-data-b2c-lifestyle/product-sets.ts`: [[3]](diffhunk://#diff-afd04ccadfc79d3080bc09881f85c67062aed0fb449b3d34170f8976fa20b32dR56-R71)
* Corrected the `color` attribute declaration for the `serenity-queen-bed` product draft to remove the `key` field and ensure proper locale-specific labels. (`models/product/src/product-variant/product-variant-draft/presets/sample-data-b2c-lifestyle/serenity-queen-bed-01.spec.ts`: [[1]](diffhunk://#diff-314f0274f54416e72439bbda746aea7d1d09583264b87bc2b9e6b346d1d0c007L23-L30) [[2]](diffhunk://#diff-314f0274f54416e72439bbda746aea7d1d09583264b87bc2b9e6b346d1d0c007L108-R105); `models/product/src/product-variant/product-variant-draft/presets/sample-data-b2c-lifestyle/serenity-queen-bed-01.ts`: [[3]](diffhunk://#diff-5bfbf6b3a071a61e28eb38bf1b706adc68c195c55ffe5be51ae0ccc6eb1aae51L39-L47); `models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/serenity-queen-bed.spec.ts`: [[4]](diffhunk://#diff-969dafcca0c234b989a1f0f9dec7e90fa575b559834659afbf542c01e07b5d44L47-L54) [[5]](diffhunk://#diff-969dafcca0c234b989a1f0f9dec7e90fa575b559834659afbf542c01e07b5d44L196-R193)

### Documentation:

* Added changeset files to document the updates and fixes for the B2C sample data import attributes. (`.changeset/silent-colts-hunt.md`: [[1]](diffhunk://#diff-0e60d9fc36c367fb59e1337c3aa895736a5ecf3e6b665e8b144681e09cfb027fR1-R6) `.changeset/stupid-dolls-peel.md`: [[2]](diffhunk://#diff-5224ba76420b82925670ebf71ac87d010073790373828c5a39adb1a35b6f39c5R1-R6)