### PR TITLE
Model Generator script

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/*
 **/node_modules/*
+scripts/template/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+./scripts/template

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 .cache
 pnpm-lock.yaml
 pnpm-workspace.yaml
+scripts/template/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ const author2 = Author.random().firstName('Rebecca').buildGraphql<TAuthor>();
 
 For organization & ownership purposes, Pangolin & FCT house their presets under their respective folders (e.g. change-history-data, sample-data-fashion, sample-data-b2c-lifestyle). These should not be altered by an external team; however, if modifications occur for any reason, a corresponding team review is mandatory.
 
+## Generating a new Model using script
+
+```bash
+pnpm create-model <model-name>
+
+pnpm create-model product-type
+```
+
 ## FAQ
 
 #### whose review is mandatory for creating PR?

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "generate-types:settings": "graphql-codegen -r dotenv/config --config codegen.settings.yml",
     "generate-types:mc": "graphql-codegen -r dotenv/config --config codegen.mc.yml",
     "generate-types:core": "graphql-codegen -r dotenv/config --config codegen.core.yml",
-    "generate-types": "pnpm generate-types:settings && generate-types:mc && generate-types:core"
+    "generate-types": "pnpm generate-types:settings && generate-types:mc && generate-types:core",
+    "create-model": "node scripts/create-model.js"
   },
   "dependencies": {
     "@babel/core": "^7.21.0",

--- a/scripts/create-model.js
+++ b/scripts/create-model.js
@@ -1,0 +1,83 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function camelCase(text) {
+  const result = text
+    .toLowerCase()
+    .replace(/[-_\s.]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''));
+  return result.substring(0, 1).toLowerCase() + result.substring(1);
+}
+
+function pascalCase(text) {
+  const camelCased = camelCase(text);
+  return camelCased.charAt(0).toUpperCase() + camelCased.slice(1);
+}
+// Function to copy files recursively and replace placeholders
+function copyAndReplaceTemplate(from, to, modelName, modelNameCamelCase) {
+  fs.mkdirSync(to, { recursive: true });
+  fs.readdirSync(from).forEach((element) => {
+    const fromPath = path.join(from, element);
+    const toPath = path.join(to, element);
+    const stat = fs.statSync(fromPath);
+
+    if (stat.isFile()) {
+      let content = fs.readFileSync(fromPath, 'utf8');
+      content = content.replace(/<model-name>/g, modelName);
+      content = content.replace(/<modelName>/g, modelNameCamelCase);
+      content = content.replace(/<ModelName>/g, pascalCase(modelName));
+      fs.writeFileSync(toPath, content, 'utf8');
+    } else if (stat.isDirectory()) {
+      copyAndReplaceTemplate(fromPath, toPath, modelName, modelNameCamelCase);
+    }
+  });
+}
+
+// Function to customize package.json
+function customizePackageJson(modelName, modelNameCamelCase, destination) {
+  const packageJsonPath = path.join(destination, 'package.json');
+  const packageJson = require(packageJsonPath);
+  packageJson.name = `@commercetools-test-data/${modelName}`;
+  packageJson.version = '0.1.0';
+  packageJson.description = `Model for ${modelName}`;
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+}
+
+// Function to generate the dist folder
+function generateDistFolder(modelDir) {
+  console.log('Generating dist folder...');
+  execSync('pnpm install', { cwd: modelDir, stdio: 'inherit' });
+}
+
+// Main function to create a new model
+function createModel(modelName) {
+  const templateDir = path.join(__dirname, 'template'); // Assuming template is in root_path/template
+  const rootDir = path.resolve(__dirname, '..'); // Adjust the root path
+  const newModelDir = path.join(rootDir, 'models', modelName);
+
+  if (fs.existsSync(newModelDir)) {
+    console.log(`Model folder ${modelName} already exists.`);
+    return;
+  }
+
+  const modelNameCamelCase = camelCase(modelName);
+
+  copyAndReplaceTemplate(
+    templateDir,
+    newModelDir,
+    modelName,
+    modelNameCamelCase
+  );
+  customizePackageJson(modelName, modelNameCamelCase, newModelDir);
+  generateDistFolder(newModelDir);
+  console.log(`Model ${modelName} created successfully!`);
+}
+
+// Run the script
+const modelName = process.argv[2];
+if (!modelName) {
+  console.error('Please provide a model name.');
+  process.exit(1);
+}
+
+createModel(modelName);

--- a/scripts/template/LICENSE
+++ b/scripts/template/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) commercetools GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/template/README.md
+++ b/scripts/template/README.md
@@ -1,0 +1,14 @@
+# @commercetools-test-data/<model-name>
+
+This package provides the data model for the commercetools platform `<modelName>` representations
+
+https://docs.commercetools.com/api/projects/<model-name>#representations
+
+# Install
+
+```bash
+$ pnpm add -D @commercetools-test-data/<model-name>
+```
+
+# Usage
+

--- a/scripts/template/package.json
+++ b/scripts/template/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@commercetools-test-data/<model-name>",
+  "version": "1.0.0",
+  "description": "Data model for commercetools API <model-name>",
+  "bugs": "https://github.com/commercetools/test-data/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/test-data.git",
+    "directory": "models/<model-name>"
+  },
+  "keywords": ["javascript", "typescript", "test-data"],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/commercetools-test-data-<model-name>.cjs.js",
+  "module": "dist/commercetools-test-data-<model-name>.esm.js",
+  "files": ["dist", "package.json", "LICENSE", "README.md"],
+  "dependencies": {
+    "@babel/runtime": "^7.17.9",
+    "@babel/runtime-corejs3": "^7.17.9",
+    "@commercetools-test-data/commons": "10.1.4",
+    "@commercetools-test-data/core": "10.1.4",
+    "@commercetools-test-data/utils": "10.1.4",
+    "@commercetools/platform-sdk": "^7.0.0",
+    "@faker-js/faker": "^8.0.0"
+  }
+}

--- a/scripts/template/src/builder.ts
+++ b/scripts/template/src/builder.ts
@@ -1,0 +1,11 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+
+const AttributeGroup = () =>
+  Builder({
+    generator,
+    transformers,
+  });
+
+export default AttributeGroup;

--- a/scripts/template/src/generator.ts
+++ b/scripts/template/src/generator.ts
@@ -1,0 +1,13 @@
+import { fake, Generator } from '@commercetools-test-data/core';
+import { createRelatedDates } from '@commercetools-test-data/utils';
+
+const [getOlderDate] = createRelatedDates();
+
+const generator = Generator({
+  fields: {
+    id: fake((f) => f.string.uuid()),
+    createdAt: fake(getOlderDate),
+  },
+});
+
+export default generator;

--- a/scripts/template/src/index.ts
+++ b/scripts/template/src/index.ts
@@ -1,0 +1,1 @@
+export { default as random } from './builder';

--- a/scripts/template/src/transformers.ts
+++ b/scripts/template/src/transformers.ts
@@ -1,0 +1,19 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type { T<ModelName>, T<ModelName>Graphql } from './types';
+
+const transformers = {
+  default: Transformer<T<ModelName>, T<ModelName>>('default', {
+    buildFields: ['createdBy'],
+  }),
+  rest: Transformer<T<ModelName>, T<ModelName>>('rest', {
+    buildFields: ['createdBy'],
+  }),
+  graphql: Transformer<T<ModelName>, T<ModelName>Graphql>('graphql', {
+    buildFields: ['createdBy'],
+    addFields: () => ({
+      __typename: '<ModelName>',
+    }),
+  }),
+};
+
+export default transformers;

--- a/scripts/template/src/types.ts
+++ b/scripts/template/src/types.ts
@@ -1,0 +1,7 @@
+export type T<ModelName> = {
+    id: string;
+    createdBy: string;
+};
+export type T<ModelName>Graphql = T<ModelName> & {
+  __typename: '<ModelName>';
+};


### PR DESCRIPTION
### Summary

While working on the test data model, I had to copy/paste a bunch of files and modify them to create new models. I wrote a simple script which generates a model based on the template to make the developer job easier.

Developers can easily create a new model by running the command.

```bash
pnpm create-model <model-name>

pnpm create-model attribute-groups
```

### Generated model based on the template
<img width="245" alt="Screenshot 2024-08-27 at 08 59 05" src="https://github.com/user-attachments/assets/f29b4f8f-d478-4b9c-a029-5915272e651d">


Let me know if this would be helpful or not. Also, any feedback or suggestions are welcome.