### PR TITLE
FEC-39: Create `Attribute-group` model

### DIFF
--- a/.changeset/ten-ants-act.md
+++ b/.changeset/ten-ants-act.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/attribute-group': minor
+---
+
+Add `AttributeGroup` test data model

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,7 @@
 /models @commercetools/merchant-center-tech-leadership
 
 /models/associate-role @commercetools/customers-team-fe
+/models/attribute-group @commercetools/pacman-team-fe
 /models/business-unit @commercetools/customers-team-fe
 /models/cart @commercetools/checkout-team-fe
 /models/cart-discount @commercetools/priceless-team-fe

--- a/models/attribute-group/LICENSE
+++ b/models/attribute-group/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) commercetools GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/models/attribute-group/README.md
+++ b/models/attribute-group/README.md
@@ -11,3 +11,12 @@ $ pnpm add -D @commercetools-test-data/attribute-group
 ```
 
 # Usage
+
+```ts
+import {
+  AttributeGroup,
+  type TAttributeGroup,
+} from '@commercetools-test-data/attribute-group';
+
+const attributeGroup = AttributeGroup.random().build<TAttributeGroup>();
+```

--- a/models/attribute-group/README.md
+++ b/models/attribute-group/README.md
@@ -16,7 +16,13 @@ $ pnpm add -D @commercetools-test-data/attribute-group
 import {
   AttributeGroup,
   type TAttributeGroup,
+  type TAttributeGroupGraphql,
 } from '@commercetools-test-data/attribute-group';
 
 const attributeGroup = AttributeGroup.random().build<TAttributeGroup>();
+// For REST entities
+const attributeGroupRest = AttributeGroup.random().buildRest<TAttributeGroup>();
+// For Graphql entities
+const attributeGroupGraphql =
+  AttributeGroup.random().buildGraphql<TAttributeGroupGraphql>();
 ```

--- a/models/attribute-group/README.md
+++ b/models/attribute-group/README.md
@@ -1,0 +1,13 @@
+# @commercetools-test-data/attribute-group
+
+This package provides the data model for the commercetools platform `attributeGroup` representations
+
+https://docs.commercetools.com/api/projects/attribute-groups#attributegroup
+
+# Install
+
+```bash
+$ pnpm add -D @commercetools-test-data/attribute-group
+```
+
+# Usage

--- a/models/attribute-group/package.json
+++ b/models/attribute-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/attribute-group",
-  "version": "10.1.4",
+  "version": "10.3.0",
   "description": "Model for attribute-group",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,9 +19,9 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "10.1.4",
-    "@commercetools-test-data/core": "10.1.4",
-    "@commercetools-test-data/utils": "10.1.4",
+    "@commercetools-test-data/commons": "10.3.0",
+    "@commercetools-test-data/core": "10.3.0",
+    "@commercetools-test-data/utils": "10.3.0",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0",
     "omit-deep": "^0.3.0"

--- a/models/attribute-group/package.json
+++ b/models/attribute-group/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@commercetools-test-data/attribute-group",
+  "version": "0.1.0",
+  "description": "Model for attribute-group",
+  "bugs": "https://github.com/commercetools/test-data/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/test-data.git",
+    "directory": "models/attribute-group"
+  },
+  "keywords": [
+    "javascript",
+    "typescript",
+    "test-data"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/commercetools-test-data-attribute-group.cjs.js",
+  "module": "dist/commercetools-test-data-attribute-group.esm.js",
+  "files": [
+    "dist",
+    "package.json",
+    "LICENSE",
+    "README.md"
+  ],
+  "dependencies": {
+    "@babel/runtime": "^7.17.9",
+    "@babel/runtime-corejs3": "^7.17.9",
+    "@commercetools-test-data/commons": "10.1.4",
+    "@commercetools-test-data/core": "10.1.4",
+    "@commercetools-test-data/utils": "10.1.4",
+    "@commercetools/platform-sdk": "^7.0.0",
+    "@faker-js/faker": "^8.0.0",
+    "omit-deep": "^0.3.0"
+  }
+}

--- a/models/attribute-group/package.json
+++ b/models/attribute-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/attribute-group",
-  "version": "1.0.0",
+  "version": "10.1.4",
   "description": "Model for attribute-group",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {

--- a/models/attribute-group/package.json
+++ b/models/attribute-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/attribute-group",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Model for attribute-group",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -8,23 +8,14 @@
     "url": "https://github.com/commercetools/test-data.git",
     "directory": "models/attribute-group"
   },
-  "keywords": [
-    "javascript",
-    "typescript",
-    "test-data"
-  ],
+  "keywords": ["javascript", "typescript", "test-data"],
   "license": "MIT",
   "publishConfig": {
     "access": "public"
   },
   "main": "dist/commercetools-test-data-attribute-group.cjs.js",
   "module": "dist/commercetools-test-data-attribute-group.esm.js",
-  "files": [
-    "dist",
-    "package.json",
-    "LICENSE",
-    "README.md"
-  ],
+  "files": ["dist", "package.json", "LICENSE", "README.md"],
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",

--- a/models/attribute-group/src/builder.spec.ts
+++ b/models/attribute-group/src/builder.spec.ts
@@ -14,7 +14,13 @@ describe('builder', () => {
         id: expect.any(String),
         version: expect.any(Number),
         createdAt: expect.any(String),
+        createdBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+        }),
         lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+        }),
         name: expect.any(String),
         nameAllLocales: expect.arrayContaining([
           expect.objectContaining({

--- a/models/attribute-group/src/builder.spec.ts
+++ b/models/attribute-group/src/builder.spec.ts
@@ -1,0 +1,34 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import type { TAttributeGroup, TAttributeGroupGraphql } from './types';
+import * as AttributeGroup from './index';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TAttributeGroup, TAttributeGroupGraphql>(
+      'graphql',
+      AttributeGroup.random(),
+      expect.objectContaining({
+        __typename: 'AttributeGroup',
+        id: expect.any(String),
+        version: expect.any(Number),
+        createdAt: expect.any(String),
+        lastModifiedAt: expect.any(String),
+        name: expect.any(String),
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+          }),
+        ]),
+        descriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+          }),
+        ]),
+      })
+    )
+  );
+});

--- a/models/attribute-group/src/builder.spec.ts
+++ b/models/attribute-group/src/builder.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
+import { LocalizedString } from '@commercetools-test-data/commons';
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import type { TAttributeGroup, TAttributeGroupGraphql } from './types';
 import * as AttributeGroup from './index';
@@ -24,17 +25,49 @@ describe('builder', () => {
         name: expect.any(String),
         nameAllLocales: expect.arrayContaining([
           expect.objectContaining({
-            locale: 'en',
-            value: expect.any(String),
+            __typename: 'LocalizedString',
           }),
         ]),
+        description: expect.any(String),
         descriptionAllLocales: expect.arrayContaining([
           expect.objectContaining({
-            locale: 'en',
-            value: expect.any(String),
+            __typename: 'LocalizedString',
           }),
         ]),
       })
     )
   );
+
+  it('should allow customization', () => {
+    const name = LocalizedString.random().en('my-attribute-group');
+    const description = LocalizedString.random().en('my-description');
+    const attributes = [{ key: 'my-attribute' }];
+    const attributeGroup = AttributeGroup.random()
+      .name(name)
+      .description(description)
+      .attributes(attributes)
+      .buildGraphql<TAttributeGroupGraphql>();
+
+    expect(attributeGroup.name).toEqual('my-attribute-group');
+    expect(attributeGroup.description).toEqual('my-description');
+    expect(attributeGroup.attributes).toEqual([{ key: 'my-attribute' }]);
+    expect(attributeGroup.nameAllLocales).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          locale: 'en',
+          value: 'my-attribute-group',
+          __typename: 'LocalizedString',
+        }),
+      ])
+    );
+    expect(attributeGroup.descriptionAllLocales).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          locale: 'en',
+          value: 'my-description',
+          __typename: 'LocalizedString',
+        }),
+      ])
+    );
+  });
 });

--- a/models/attribute-group/src/builder.ts
+++ b/models/attribute-group/src/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import { TAttributeGroup, TCreateAssociateRoleBuilder } from './types';
+
+const Model: TCreateAssociateRoleBuilder = () =>
+  Builder<TAttributeGroup>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/attribute-group/src/builder.ts
+++ b/models/attribute-group/src/builder.ts
@@ -1,9 +1,9 @@
 import { Builder } from '@commercetools-test-data/core';
 import generator from './generator';
 import transformers from './transformers';
-import { TAttributeGroup, TCreateAssociateRoleBuilder } from './types';
+import { TAttributeGroup, TCreateAttributeGroupBuilder } from './types';
 
-const Model: TCreateAssociateRoleBuilder = () =>
+const Model: TCreateAttributeGroupBuilder = () =>
   Builder<TAttributeGroup>({
     generator,
     transformers,

--- a/models/attribute-group/src/generator.ts
+++ b/models/attribute-group/src/generator.ts
@@ -1,4 +1,7 @@
-import { ClientLogging } from '@commercetools-test-data/commons';
+import {
+  ClientLogging,
+  LocalizedString,
+} from '@commercetools-test-data/commons';
 import { fake, Generator, sequence } from '@commercetools-test-data/core';
 import { createRelatedDates } from '@commercetools-test-data/utils';
 import { TAttributeGroup } from './types';
@@ -11,8 +14,8 @@ const generator = Generator<TAttributeGroup>({
     version: sequence(),
     createdAt: fake(getOlderDate),
     lastModifiedAt: fake(getNewerDate),
-    name: fake((f) => f.lorem.words(2)),
-    description: fake((f) => f.lorem.sentences(2)),
+    name: fake(() => LocalizedString.random()),
+    description: fake((f) => LocalizedString.random().en(f.lorem.sentences(2))),
     key: fake((f) => f.lorem.slug(2)),
     attributes: [],
     createdBy: fake(() => ClientLogging.random()),

--- a/models/attribute-group/src/generator.ts
+++ b/models/attribute-group/src/generator.ts
@@ -1,6 +1,6 @@
+import { ClientLogging } from '@commercetools-test-data/commons';
 import { fake, Generator, sequence } from '@commercetools-test-data/core';
 import { createRelatedDates } from '@commercetools-test-data/utils';
-import { ClientLogging } from '../../commons/src';
 import { TAttributeGroup } from './types';
 
 const [getOlderDate, getNewerDate] = createRelatedDates();

--- a/models/attribute-group/src/generator.ts
+++ b/models/attribute-group/src/generator.ts
@@ -1,0 +1,22 @@
+import { fake, Generator, sequence } from '@commercetools-test-data/core';
+import { createRelatedDates } from '@commercetools-test-data/utils';
+import { TAttributeGroup } from './types';
+
+const [getOlderDate, getNewerDate] = createRelatedDates();
+
+const generator = Generator<TAttributeGroup>({
+  fields: {
+    id: fake((f) => f.string.uuid()),
+    version: sequence(),
+    createdAt: fake(getOlderDate),
+    lastModifiedAt: fake(getNewerDate),
+    name: fake((f) => f.lorem.words(2)),
+    description: fake((f) => f.lorem.sentences(2)),
+    key: fake((f) => f.lorem.slug(2)),
+    attributes: [],
+    createdBy: null,
+    lastModifiedBy: null,
+  },
+});
+
+export default generator;

--- a/models/attribute-group/src/generator.ts
+++ b/models/attribute-group/src/generator.ts
@@ -1,5 +1,6 @@
 import { fake, Generator, sequence } from '@commercetools-test-data/core';
 import { createRelatedDates } from '@commercetools-test-data/utils';
+import { ClientLogging } from '../../commons/src';
 import { TAttributeGroup } from './types';
 
 const [getOlderDate, getNewerDate] = createRelatedDates();
@@ -14,8 +15,8 @@ const generator = Generator<TAttributeGroup>({
     description: fake((f) => f.lorem.sentences(2)),
     key: fake((f) => f.lorem.slug(2)),
     attributes: [],
-    createdBy: null,
-    lastModifiedBy: null,
+    createdBy: fake(() => ClientLogging.random()),
+    lastModifiedBy: fake(() => ClientLogging.random()),
   },
 });
 

--- a/models/attribute-group/src/index.ts
+++ b/models/attribute-group/src/index.ts
@@ -1,0 +1,1 @@
+export { default as random } from './builder';

--- a/models/attribute-group/src/index.ts
+++ b/models/attribute-group/src/index.ts
@@ -1,1 +1,5 @@
+export * as AttributeGroup from '.';
+
 export { default as random } from './builder';
+export * as presets from './presets';
+export * from './types';

--- a/models/attribute-group/src/presets/index.ts
+++ b/models/attribute-group/src/presets/index.ts
@@ -1,0 +1,3 @@
+const presets = {};
+
+export default presets;

--- a/models/attribute-group/src/transformers.ts
+++ b/models/attribute-group/src/transformers.ts
@@ -2,6 +2,7 @@ import { Transformer } from '@commercetools-test-data/core';
 import type { TAttributeGroup, TAttributeGroupGraphql } from './types';
 const transformers = {
   graphql: Transformer<TAttributeGroup, TAttributeGroupGraphql>('graphql', {
+    buildFields: ['createdBy', 'lastModifiedBy'],
     addFields: ({ fields }) => ({
       __typename: 'AttributeGroup',
       nameAllLocales: [

--- a/models/attribute-group/src/transformers.ts
+++ b/models/attribute-group/src/transformers.ts
@@ -1,23 +1,28 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type { TAttributeGroup, TAttributeGroupGraphql } from './types';
 const transformers = {
+  rest: Transformer<TAttributeGroup, TAttributeGroup>('rest', {
+    buildFields: ['createdBy', 'lastModifiedBy'],
+  }),
   graphql: Transformer<TAttributeGroup, TAttributeGroupGraphql>('graphql', {
     buildFields: ['createdBy', 'lastModifiedBy'],
-    addFields: ({ fields }) => ({
-      __typename: 'AttributeGroup',
-      nameAllLocales: [
-        {
-          locale: 'en',
-          value: fields.name,
-        },
-      ],
-      descriptionAllLocales: [
-        {
-          locale: 'en',
-          value: fields.description,
-        },
-      ],
-    }),
+    replaceFields: ({ fields }) => {
+      const nameAllLocales = LocalizedString.toLocalizedField(fields.name);
+      const descriptionAllLocales = LocalizedString.toLocalizedField(
+        fields.description
+      );
+      return {
+        ...fields,
+        __typename: 'AttributeGroup',
+        nameAllLocales,
+        name: LocalizedString.resolveGraphqlDefaultLocaleValue(nameAllLocales)!,
+        description: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          descriptionAllLocales
+        ),
+        descriptionAllLocales,
+      };
+    },
   }),
 };
 

--- a/models/attribute-group/src/transformers.ts
+++ b/models/attribute-group/src/transformers.ts
@@ -1,0 +1,23 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type { TAttributeGroup, TAttributeGroupGraphql } from './types';
+const transformers = {
+  graphql: Transformer<TAttributeGroup, TAttributeGroupGraphql>('graphql', {
+    addFields: ({ fields }) => ({
+      __typename: 'AttributeGroup',
+      nameAllLocales: [
+        {
+          locale: 'en',
+          value: fields.name,
+        },
+      ],
+      descriptionAllLocales: [
+        {
+          locale: 'en',
+          value: fields.description,
+        },
+      ],
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/attribute-group/src/types.ts
+++ b/models/attribute-group/src/types.ts
@@ -1,10 +1,19 @@
 import type { AttributeGroup } from '@commercetools/platform-sdk';
+import { TLocalizedStringGraphql } from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TAttributeGroup = AttributeGroup;
-export type TAttributeGroupGraphql = TAttributeGroup & {
+
+export type TAttributeGroupGraphql = Omit<
+  TAttributeGroup,
+  'name' | 'description'
+> & {
+  name: string;
+  nameAllLocales?: TLocalizedStringGraphql | null;
+  description?: string;
+  descriptionAllLocales?: TLocalizedStringGraphql | null;
   __typename: 'AttributeGroup';
 };
 
 export type TAttributeGroupBuilder = TBuilder<AttributeGroup>;
-export type TCreateAssociateRoleBuilder = () => TAttributeGroupBuilder;
+export type TCreateAttributeGroupBuilder = () => TAttributeGroupBuilder;

--- a/models/attribute-group/src/types.ts
+++ b/models/attribute-group/src/types.ts
@@ -1,0 +1,10 @@
+import type { AttributeGroup } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@commercetools-test-data/core';
+
+export type TAttributeGroup = AttributeGroup;
+export type TAttributeGroupGraphql = TAttributeGroup & {
+  __typename: 'AttributeGroup';
+};
+
+export type TAttributeGroupBuilder = TBuilder<AttributeGroup>;
+export type TCreateAssociateRoleBuilder = () => TAttributeGroupBuilder;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,13 +164,13 @@ importers:
         specifier: ^7.17.9
         version: 7.24.6
       '@commercetools-test-data/commons':
-        specifier: 10.1.4
+        specifier: 10.3.0
         version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 10.1.4
+        specifier: 10.3.0
         version: link:../../core
       '@commercetools-test-data/utils':
-        specifier: 10.1.4
+        specifier: 10.3.0
         version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,33 @@ importers:
         specifier: ^8.0.0
         version: 8.4.1
 
+  models/attribute-group:
+    dependencies:
+      '@babel/runtime':
+        specifier: ^7.17.9
+        version: 7.24.6
+      '@babel/runtime-corejs3':
+        specifier: ^7.17.9
+        version: 7.24.6
+      '@commercetools-test-data/commons':
+        specifier: 10.1.4
+        version: link:../commons
+      '@commercetools-test-data/core':
+        specifier: 10.1.4
+        version: link:../../core
+      '@commercetools-test-data/utils':
+        specifier: 10.1.4
+        version: link:../../utils
+      '@commercetools/platform-sdk':
+        specifier: ^7.0.0
+        version: 7.8.0
+      '@faker-js/faker':
+        specifier: ^8.0.0
+        version: 8.4.1
+      omit-deep:
+        specifier: ^0.3.0
+        version: 0.3.0
+
   models/business-unit:
     dependencies:
       '@babel/runtime':
@@ -4202,6 +4229,10 @@ packages:
   get-tsconfig@4.7.5:
     resolution: {integrity: sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==}
 
+  get-value@2.0.6:
+    resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
+    engines: {node: '>=0.10.0'}
+
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
@@ -4325,6 +4356,14 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
+
+  has-value@0.3.1:
+    resolution: {integrity: sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==}
+    engines: {node: '>=0.10.0'}
+
+  has-values@0.1.4:
+    resolution: {integrity: sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==}
+    engines: {node: '>=0.10.0'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -4663,11 +4702,18 @@ packages:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isobject@2.1.0:
+    resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
+    engines: {node: '>=0.10.0'}
 
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
@@ -5311,6 +5357,10 @@ packages:
   object.values@1.2.0:
     resolution: {integrity: sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==}
     engines: {node: '>= 0.4'}
+
+  omit-deep@0.3.0:
+    resolution: {integrity: sha512-Lbl/Ma59sss2b15DpnWnGmECBRL8cRl/PjPbPMVW+Y8zIQzRrwMaI65Oy6HvxyhYeILVKBJb2LWeG81bj5zbMg==}
+    engines: {node: '>=0.10.0'}
 
   omit-empty-es@1.2.0:
     resolution: {integrity: sha512-4g0KMUt/IvlnnMt0lONaOStBsWs2R9Vi5dDOrBvu36m4J7KBx6EDcdqCrTrnTWknWQgo3VLj4Tjfcxf1Hs+0uA==}
@@ -6237,6 +6287,10 @@ packages:
 
   unixify@1.0.0:
     resolution: {integrity: sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==}
+    engines: {node: '>=0.10.0'}
+
+  unset-value@0.1.2:
+    resolution: {integrity: sha512-yhv5I4TsldLdE3UcVQn0hD2T5sNCPv4+qm/CTUpRKIpwthYRIipsAPdsrNpOI79hPQa0rTTeW22Fq6JWRcTgNg==}
     engines: {node: '>=0.10.0'}
 
   update-browserslist-db@1.0.16:
@@ -10469,6 +10523,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-value@2.0.6: {}
+
   git-raw-commits@4.0.0:
     dependencies:
       dargs: 8.1.0
@@ -10610,6 +10666,14 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.0.3
+
+  has-value@0.3.1:
+    dependencies:
+      get-value: 2.0.6
+      has-values: 0.1.4
+      isobject: 2.1.0
+
+  has-values@0.1.4: {}
 
   hasown@2.0.2:
     dependencies:
@@ -10925,9 +10989,15 @@ snapshots:
 
   is-windows@1.0.2: {}
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isobject@2.1.0:
+    dependencies:
+      isarray: 1.0.0
 
   isobject@3.0.1: {}
 
@@ -11809,6 +11879,11 @@ snapshots:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
+
+  omit-deep@0.3.0:
+    dependencies:
+      is-plain-object: 2.0.4
+      unset-value: 0.1.2
 
   omit-empty-es@1.2.0:
     dependencies:
@@ -12726,6 +12801,11 @@ snapshots:
   unixify@1.0.0:
     dependencies:
       normalize-path: 2.1.1
+
+  unset-value@0.1.2:
+    dependencies:
+      has-value: 0.3.1
+      isobject: 3.0.1
 
   update-browserslist-db@1.0.16(browserslist@4.23.0):
     dependencies:


### PR DESCRIPTION
### Summary

A new model `attribute-group` is created based on the existing test-data in the FE repository. 

Note: The parent PR is in draft mode due to the `inventory-entry` update being done in a separate PR. This PR can be reviewed independently. I will merge this PR only after parent PR is unblocked and reviewed.