### PR TITLE
FEC-56: Add `CustomersSearchListMyView` my view model

### DIFF
--- a/models/customers-search-list-my-view/LICENSE
+++ b/models/customers-search-list-my-view/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) commercetools GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/models/customers-search-list-my-view/README.md
+++ b/models/customers-search-list-my-view/README.md
@@ -15,9 +15,9 @@ $ pnpm add -D @commercetools-test-data/customers-search-list-my-view
 ```ts
 import type {
   CustomersSearchListMyView,
-  type TCustomersSearchListMyView,
+  type TCustomersSearchListMyViewGraphql,
 } from '@commercetools-test-data/customers-search-list-my-view';
 
 const customersSearchListMyView =
-  CustomersSearchListMyView.random().build<TCustomersSearchListMyView>();
+  CustomersSearchListMyView.random().buildGraphl<TCustomersSearchListMyViewGraphql>();
 ```

--- a/models/customers-search-list-my-view/README.md
+++ b/models/customers-search-list-my-view/README.md
@@ -1,0 +1,23 @@
+# @commercetools-test-data/customers-search-list-my-view
+
+This package provides the data model for the commercetools internal API `CustomersSearchListMyView` type
+
+https://github.com/commercetools/merchant-center-services/blob/main/packages/settings/lib/schemas/customers-search-list-my-view.graphql
+
+# Install
+
+```bash
+$ pnpm add -D @commercetools-test-data/customers-search-list-my-view
+```
+
+# Usage
+
+```ts
+import type {
+  CustomersSearchListMyView,
+  type TCustomersSearchListMyView,
+} from '@commercetools-test-data/customers-search-list-my-view';
+
+const customersSearchListMyView =
+  CustomersSearchListMyView.random().build<TCustomersSearchListMyView>();
+```

--- a/models/customers-search-list-my-view/package.json
+++ b/models/customers-search-list-my-view/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@commercetools-test-data/customers-search-list-my-view",
+  "version": "1.0.0",
+  "description": "Data model for internal Merchan Center API CustomersSearchListMyView",
+  "bugs": "https://github.com/commercetools/test-data/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/test-data.git",
+    "directory": "models/customers-search-list-my-view"
+  },
+  "keywords": ["javascript", "typescript", "test-data"],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/commercetools-test-data-customers-search-list-my-view.cjs.js",
+  "module": "dist/commercetools-test-data-customers-search-list-my-view.esm.js",
+  "files": ["dist", "package.json", "LICENSE", "README.md"],
+  "dependencies": {
+    "@babel/runtime": "^7.17.9",
+    "@babel/runtime-corejs3": "^7.17.9",
+    "@commercetools-test-data/commons": "10.1.4",
+    "@commercetools-test-data/core": "10.1.4",
+    "@commercetools-test-data/graphql-types": "10.1.4",
+    "@commercetools-test-data/utils": "10.1.4",
+    "@commercetools/platform-sdk": "^7.0.0",
+    "@faker-js/faker": "^8.0.0"
+  }
+}

--- a/models/customers-search-list-my-view/package.json
+++ b/models/customers-search-list-my-view/package.json
@@ -21,6 +21,7 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/commons": "10.1.4",
     "@commercetools-test-data/core": "10.1.4",
+    "@commercetools-test-data/filter-values": "10.1.4",
     "@commercetools-test-data/graphql-types": "10.1.4",
     "@commercetools-test-data/utils": "10.1.4",
     "@commercetools/platform-sdk": "^7.0.0",

--- a/models/customers-search-list-my-view/src/builder.spec.ts
+++ b/models/customers-search-list-my-view/src/builder.spec.ts
@@ -45,6 +45,7 @@ describe('building as GraphQL', () => {
   it('should remove `name`', () => {
     const built: TCustomersSearchListMyViewGraphql =
       CustomersSearchListMyView().buildGraphql();
+    // @ts-ignore
     expect(built.name).not.toBeDefined();
   });
 });

--- a/models/customers-search-list-my-view/src/builder.spec.ts
+++ b/models/customers-search-list-my-view/src/builder.spec.ts
@@ -1,14 +1,11 @@
-import {
-  LocalizedString,
-  LocalizedField,
-} from '@commercetools-test-data/commons';
+import { LocalizedField } from '@commercetools-test-data/commons';
 import { FilterValues } from '@commercetools-test-data/filter-values';
 import {
   TMcSettingsFilterValues,
   TMcSettingsSortOrder,
 } from '@commercetools-test-data/graphql-types';
 import CustomersSearchListMyView from './builder';
-import { TCustomersSearchListMyViewGraphql } from './types';
+import { TCustomersSearchListMyView } from './types';
 
 describe('building', () => {
   it('should build all primitive properties', () => {
@@ -22,7 +19,12 @@ describe('building', () => {
         updatedAt: expect.any(String),
         userId: expect.any(String),
         isActive: true,
-        nameAllLocales: null,
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: expect.any(String),
+            value: expect.any(String),
+          }),
+        ]),
         sort: null,
         filters: null,
         table: null,
@@ -33,25 +35,14 @@ describe('building', () => {
 
 describe('building as GraphQL', () => {
   it('should add the __typename', () => {
-    const built: TCustomersSearchListMyViewGraphql =
+    const built: TCustomersSearchListMyView =
       CustomersSearchListMyView().buildGraphql();
     expect(built.__typename).toEqual('CustomersSearchListMyView');
-  });
-  it('should add the nameAllLocales', () => {
-    const built: TCustomersSearchListMyViewGraphql =
-      CustomersSearchListMyView().buildGraphql();
-    expect(built.nameAllLocales).toBeDefined();
-  });
-  it('should remove `name`', () => {
-    const built: TCustomersSearchListMyViewGraphql =
-      CustomersSearchListMyView().buildGraphql();
-    // @ts-ignore
-    expect(built.name).not.toBeDefined();
   });
 });
 
 it('should allow customization', () => {
-  const name = LocalizedString.random().en('my-view');
+  const name = LocalizedField.random();
   const filterValues =
     FilterValues.random().buildGraphql() as TMcSettingsFilterValues;
   const CustomersSearchListMyViewMock = CustomersSearchListMyView()
@@ -60,15 +51,14 @@ it('should allow customization', () => {
     .updatedAt('2022-08-26T22:00:00.123Z')
     .userId('user-123')
     .projectKey('my-project')
-    .nameAllLocales(name)
-    .name('my-view')
+    .nameAllLocales([name])
     .isActive(true)
     .table({
       visibleColumns: ['name', 'email'],
     })
     .sort({ key: 'createdAt', order: TMcSettingsSortOrder.Asc })
     .filters([filterValues])
-    .buildGraphql<TCustomersSearchListMyViewGraphql>();
+    .buildGraphql<TCustomersSearchListMyView>();
 
   expect(CustomersSearchListMyViewMock).toEqual(
     expect.objectContaining({
@@ -77,7 +67,7 @@ it('should allow customization', () => {
       updatedAt: '2022-08-26T22:00:00.123Z',
       userId: 'user-123',
       projectKey: 'my-project',
-      nameAllLocales: [LocalizedField.random().value(name).buildGraphql()],
+      nameAllLocales: [name.buildGraphql()],
       table: {
         visibleColumns: ['name', 'email'],
       },

--- a/models/customers-search-list-my-view/src/builder.spec.ts
+++ b/models/customers-search-list-my-view/src/builder.spec.ts
@@ -1,3 +1,12 @@
+import {
+  LocalizedString,
+  LocalizedField,
+} from '@commercetools-test-data/commons';
+import { FilterValues } from '@commercetools-test-data/filter-values';
+import {
+  TMcSettingsFilterValues,
+  TMcSettingsSortOrder,
+} from '@commercetools-test-data/graphql-types';
 import CustomersSearchListMyView from './builder';
 import { TCustomersSearchListMyViewGraphql } from './types';
 
@@ -38,4 +47,45 @@ describe('building as GraphQL', () => {
       CustomersSearchListMyView().buildGraphql();
     expect(built.name).not.toBeDefined();
   });
+});
+
+it('should allow customization', () => {
+  const name = LocalizedString.random().en('my-view');
+  const filterValues =
+    FilterValues.random().buildGraphql() as TMcSettingsFilterValues;
+  const CustomersSearchListMyViewMock = CustomersSearchListMyView()
+    .id('123')
+    .createdAt('2022-07-26T22:00:00.123Z')
+    .updatedAt('2022-08-26T22:00:00.123Z')
+    .userId('user-123')
+    .projectKey('my-project')
+    .nameAllLocales(name)
+    .name('my-view')
+    .isActive(true)
+    .table({
+      visibleColumns: ['name', 'email'],
+    })
+    .sort({ key: 'createdAt', order: TMcSettingsSortOrder.Asc })
+    .filters([filterValues])
+    .buildGraphql<TCustomersSearchListMyViewGraphql>();
+
+  expect(CustomersSearchListMyViewMock).toEqual(
+    expect.objectContaining({
+      id: '123',
+      createdAt: '2022-07-26T22:00:00.123Z',
+      updatedAt: '2022-08-26T22:00:00.123Z',
+      userId: 'user-123',
+      projectKey: 'my-project',
+      nameAllLocales: [LocalizedField.random().value(name).buildGraphql()],
+      table: {
+        visibleColumns: ['name', 'email'],
+      },
+      sort: {
+        key: 'createdAt',
+        order: TMcSettingsSortOrder.Asc,
+      },
+      filters: [filterValues],
+      __typename: 'CustomersSearchListMyView',
+    })
+  );
 });

--- a/models/customers-search-list-my-view/src/builder.spec.ts
+++ b/models/customers-search-list-my-view/src/builder.spec.ts
@@ -1,0 +1,41 @@
+import CustomersSearchListMyView from './builder';
+import { TCustomersSearchListMyViewGraphql } from './types';
+
+describe('building', () => {
+  it('should build all primitive properties', () => {
+    const built = CustomersSearchListMyView().build();
+
+    expect(built).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        projectKey: expect.any(String),
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+        userId: expect.any(String),
+        isActive: true,
+        nameAllLocales: null,
+        sort: null,
+        filters: null,
+        table: null,
+      })
+    );
+  });
+});
+
+describe('building as GraphQL', () => {
+  it('should add the __typename', () => {
+    const built: TCustomersSearchListMyViewGraphql =
+      CustomersSearchListMyView().buildGraphql();
+    expect(built.__typename).toEqual('CustomersSearchListMyView');
+  });
+  it('should add the nameAllLocales', () => {
+    const built: TCustomersSearchListMyViewGraphql =
+      CustomersSearchListMyView().buildGraphql();
+    expect(built.nameAllLocales).toBeDefined();
+  });
+  it('should remove `name`', () => {
+    const built: TCustomersSearchListMyViewGraphql =
+      CustomersSearchListMyView().buildGraphql();
+    expect(built.name).not.toBeDefined();
+  });
+});

--- a/models/customers-search-list-my-view/src/builder.ts
+++ b/models/customers-search-list-my-view/src/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type {
+  TCustomersSearchListMyView,
+  TCreateCustomersSearchListMyView,
+} from './types';
+
+const Model: TCreateCustomersSearchListMyView = () =>
+  Builder<TCustomersSearchListMyView>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/customers-search-list-my-view/src/generator.ts
+++ b/models/customers-search-list-my-view/src/generator.ts
@@ -1,0 +1,57 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { Generator, fake } from '@commercetools-test-data/core';
+import { createRelatedDates } from '@commercetools-test-data/utils';
+import { TCustomersSearchListMyView } from './types';
+
+const [getOlderDate, getNewerDate] = createRelatedDates();
+
+// ref https://github.com/commercetools/merchant-center-services/blob/main/packages/settings/lib/schemas/customers-search-list-my-view.graphql
+const generator = Generator<TCustomersSearchListMyView>({
+  fields: {
+    /**
+     * id: ID!
+     */
+    id: fake((f) => f.string.uuid()),
+    /**
+     * createdAt: DateTime!
+     */
+    createdAt: fake(getOlderDate),
+    /**
+     * updatedAt: DateTime!
+     */
+    updatedAt: fake(getNewerDate),
+    /**
+     * userId: String!
+     */
+    userId: fake((f) => f.string.uuid()),
+    /**
+     * projectKey: String!
+     */
+    projectKey: fake((f) => f.lorem.slug(2)),
+    /**
+     * nameAllLocales [LocalizedField!]
+     */
+    nameAllLocales: null,
+    name: fake(() => LocalizedString.random()),
+    /**
+     * isActive: Boolean!
+     */
+    isActive: fake(() => true),
+    /**
+     * table: Table
+     * { visibleColumns: [] }
+     */
+    table: null,
+    /**
+     * sort: Sort
+     * { order: String, key: String  }
+     */
+    sort: null,
+    /**
+     * filters: [FilterValues!]!
+     */
+    filters: null,
+  },
+});
+
+export default generator;

--- a/models/customers-search-list-my-view/src/generator.ts
+++ b/models/customers-search-list-my-view/src/generator.ts
@@ -1,4 +1,4 @@
-import { LocalizedString } from '@commercetools-test-data/commons';
+import { LocalizedField } from '@commercetools-test-data/commons';
 import { Generator, fake } from '@commercetools-test-data/core';
 import { createRelatedDates } from '@commercetools-test-data/utils';
 import { TCustomersSearchListMyView } from './types';
@@ -8,48 +8,15 @@ const [getOlderDate, getNewerDate] = createRelatedDates();
 // ref https://github.com/commercetools/merchant-center-services/blob/main/packages/settings/lib/schemas/customers-search-list-my-view.graphql
 const generator = Generator<TCustomersSearchListMyView>({
   fields: {
-    /**
-     * id: ID!
-     */
     id: fake((f) => f.string.uuid()),
-    /**
-     * createdAt: DateTime!
-     */
     createdAt: fake(getOlderDate),
-    /**
-     * updatedAt: DateTime!
-     */
     updatedAt: fake(getNewerDate),
-    /**
-     * userId: String!
-     */
     userId: fake((f) => f.string.uuid()),
-    /**
-     * projectKey: String!
-     */
     projectKey: fake((f) => f.lorem.slug(2)),
-    /**
-     * nameAllLocales [LocalizedField!]
-     */
-    nameAllLocales: null,
-    name: fake(() => LocalizedString.random()),
-    /**
-     * isActive: Boolean!
-     */
+    nameAllLocales: fake(() => [LocalizedField.random()]),
     isActive: fake(() => true),
-    /**
-     * table: Table
-     * { visibleColumns: [] }
-     */
     table: null,
-    /**
-     * sort: Sort
-     * { order: String, key: String  }
-     */
     sort: null,
-    /**
-     * filters: [FilterValues!]!
-     */
     filters: null,
   },
 });

--- a/models/customers-search-list-my-view/src/index.ts
+++ b/models/customers-search-list-my-view/src/index.ts
@@ -1,0 +1,5 @@
+export * as CustomersSearchListMyView from '.';
+
+export { default as random } from './builder';
+export { default as presets } from './presets';
+export * from './types';

--- a/models/customers-search-list-my-view/src/presets/index.ts
+++ b/models/customers-search-list-my-view/src/presets/index.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/models/customers-search-list-my-view/src/transformers.ts
+++ b/models/customers-search-list-my-view/src/transformers.ts
@@ -1,0 +1,27 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TCustomersSearchListMyView,
+  TCustomersSearchListMyViewGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<TCustomersSearchListMyView, TCustomersSearchListMyView>(
+    'default',
+    {
+      buildFields: ['name'],
+    }
+  ),
+  graphql: Transformer<
+    TCustomersSearchListMyView,
+    TCustomersSearchListMyViewGraphql
+  >('graphql', {
+    removeFields: ['name'],
+    addFields: ({ fields }) => ({
+      nameAllLocales: LocalizedString.toLocalizedField(fields.name),
+      __typename: 'CustomersSearchListMyView',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/customers-search-list-my-view/src/transformers.ts
+++ b/models/customers-search-list-my-view/src/transformers.ts
@@ -1,29 +1,20 @@
-import { LocalizedField } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
-import {
-  TCustomersSearchListMyView,
-  TCustomersSearchListMyViewGraphql,
-} from './types';
+import { TCustomersSearchListMyView } from './types';
 
 const transformers = {
   default: Transformer<TCustomersSearchListMyView, TCustomersSearchListMyView>(
     'default',
+    { buildFields: ['nameAllLocales'] }
+  ),
+  graphql: Transformer<TCustomersSearchListMyView, TCustomersSearchListMyView>(
+    'graphql',
     {
-      buildFields: ['name'],
+      buildFields: ['nameAllLocales'],
+      addFields: () => ({
+        __typename: 'CustomersSearchListMyView',
+      }),
     }
   ),
-  graphql: Transformer<
-    TCustomersSearchListMyView,
-    TCustomersSearchListMyViewGraphql
-  >('graphql', {
-    removeFields: ['name'],
-    addFields: ({ fields }) => ({
-      nameAllLocales: [
-        LocalizedField.random().value(fields.name).buildGraphql(),
-      ],
-      __typename: 'CustomersSearchListMyView',
-    }),
-  }),
 };
 
 export default transformers;

--- a/models/customers-search-list-my-view/src/transformers.ts
+++ b/models/customers-search-list-my-view/src/transformers.ts
@@ -1,4 +1,4 @@
-import { LocalizedString } from '@commercetools-test-data/commons';
+import { LocalizedField } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import {
   TCustomersSearchListMyView,
@@ -18,7 +18,9 @@ const transformers = {
   >('graphql', {
     removeFields: ['name'],
     addFields: ({ fields }) => ({
-      nameAllLocales: LocalizedString.toLocalizedField(fields.name),
+      nameAllLocales: [
+        LocalizedField.random().value(fields.name).buildGraphql(),
+      ],
       __typename: 'CustomersSearchListMyView',
     }),
   }),

--- a/models/customers-search-list-my-view/src/types.ts
+++ b/models/customers-search-list-my-view/src/types.ts
@@ -6,9 +6,8 @@ export type TCustomersSearchListMyView =
     name: string;
   };
 
-export type TCustomersSearchListMyViewGraphql = TCustomersSearchListMyView & {
-  __typename: 'CustomersSearchListMyView';
-};
+export type TCustomersSearchListMyViewGraphql =
+  TMcSettingsCustomersSearchListMyView;
 
 export type TCustomersSearchListMyViewBuilder =
   TBuilder<TCustomersSearchListMyView>;

--- a/models/customers-search-list-my-view/src/types.ts
+++ b/models/customers-search-list-my-view/src/types.ts
@@ -1,4 +1,3 @@
-import { TLocalizedStringGraphql } from '@commercetools-test-data/commons';
 import { TBuilder } from '@commercetools-test-data/core';
 import type { TMcSettingsCustomersSearchListMyView } from '@commercetools-test-data/graphql-types';
 
@@ -7,11 +6,7 @@ export type TCustomersSearchListMyView =
     name: string;
   };
 
-export type TCustomersSearchListMyViewGraphql = Omit<
-  TCustomersSearchListMyView,
-  'nameAllLocales'
-> & {
-  nameAllLocales: TLocalizedStringGraphql | null;
+export type TCustomersSearchListMyViewGraphql = TCustomersSearchListMyView & {
   __typename: 'CustomersSearchListMyView';
 };
 

--- a/models/customers-search-list-my-view/src/types.ts
+++ b/models/customers-search-list-my-view/src/types.ts
@@ -1,0 +1,21 @@
+import { TLocalizedStringGraphql } from '@commercetools-test-data/commons';
+import { TBuilder } from '@commercetools-test-data/core';
+import type { TMcSettingsCustomersSearchListMyView } from '@commercetools-test-data/graphql-types';
+
+export type TCustomersSearchListMyView =
+  TMcSettingsCustomersSearchListMyView & {
+    name: string;
+  };
+
+export type TCustomersSearchListMyViewGraphql = Omit<
+  TCustomersSearchListMyView,
+  'nameAllLocales'
+> & {
+  nameAllLocales: TLocalizedStringGraphql | null;
+  __typename: 'CustomersSearchListMyView';
+};
+
+export type TCustomersSearchListMyViewBuilder =
+  TBuilder<TCustomersSearchListMyView>;
+export type TCreateCustomersSearchListMyView =
+  () => TCustomersSearchListMyViewBuilder;

--- a/models/customers-search-list-my-view/src/types.ts
+++ b/models/customers-search-list-my-view/src/types.ts
@@ -1,13 +1,7 @@
 import { TBuilder } from '@commercetools-test-data/core';
 import type { TMcSettingsCustomersSearchListMyView } from '@commercetools-test-data/graphql-types';
 
-export type TCustomersSearchListMyView =
-  TMcSettingsCustomersSearchListMyView & {
-    name: string;
-  };
-
-export type TCustomersSearchListMyViewGraphql =
-  TMcSettingsCustomersSearchListMyView;
+export type TCustomersSearchListMyView = TMcSettingsCustomersSearchListMyView;
 
 export type TCustomersSearchListMyViewBuilder =
   TBuilder<TCustomersSearchListMyView>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,33 @@ importers:
         specifier: ^8.0.0
         version: 8.4.1
 
+  models/customers-search-list-my-view:
+    dependencies:
+      '@babel/runtime':
+        specifier: ^7.17.9
+        version: 7.24.6
+      '@babel/runtime-corejs3':
+        specifier: ^7.17.9
+        version: 7.24.6
+      '@commercetools-test-data/commons':
+        specifier: 10.1.4
+        version: 10.1.4
+      '@commercetools-test-data/core':
+        specifier: 10.1.4
+        version: 10.1.4
+      '@commercetools-test-data/graphql-types':
+        specifier: 10.1.4
+        version: 10.1.4
+      '@commercetools-test-data/utils':
+        specifier: 10.1.4
+        version: 10.1.4
+      '@commercetools/platform-sdk':
+        specifier: ^7.0.0
+        version: 7.8.0
+      '@faker-js/faker':
+        specifier: ^8.0.0
+        version: 8.4.1
+
   models/discount-code:
     dependencies:
       '@babel/runtime':
@@ -2135,6 +2162,18 @@ packages:
     engines: {node: 16.x || >=18.0.0}
     peerDependencies:
       eslint: 8.x
+
+  '@commercetools-test-data/commons@10.1.4':
+    resolution: {integrity: sha512-u9mlD5Xc87RHLRsftNV8Lnoz2rs9T4D5j1ygjGlBxuSEWhz2r3MR+wKKrwmj+mFCQBl0SO6Ws1Pp0l4cFUYZRA==}
+
+  '@commercetools-test-data/core@10.1.4':
+    resolution: {integrity: sha512-LNfTR35FM/X2aia47vGoJy6dyCbYhR0fNunkyMFn7lRE9uGScc5o4vTMaWjcmU8PfV5Df08AWwSqUAgrAaCPjA==}
+
+  '@commercetools-test-data/graphql-types@10.1.4':
+    resolution: {integrity: sha512-QcBCXqCl3scatlsV+TOgK6ntSn9S+iqGsCTzlAiNoQzdIw6VIubZwtVM64115Dm4BazFYH6c9ARCjQ3a0DAu0Q==}
+
+  '@commercetools-test-data/utils@10.1.4':
+    resolution: {integrity: sha512-M9vcm38nbTDoKIygCwjtoRuKqI+vl3FxiVXm+35swiFrXPtfkzY5z3MUKiB/7Fqy6UkgEKw4v5flAGOoQdhHeQ==}
 
   '@commercetools/platform-sdk@7.8.0':
     resolution: {integrity: sha512-7dpUG8kVULm286dyL1N5IZ6A+0iNwjHdeck7CZdUkVeJ697XN/YwPQkjQ2z62ZkaJRL0efPN5277TWttsU6uLA==}
@@ -7573,6 +7612,35 @@ snapshots:
       - eslint-import-resolver-webpack
       - jest
       - supports-color
+
+  '@commercetools-test-data/commons@10.1.4':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@babel/runtime-corejs3': 7.24.6
+      '@commercetools-test-data/core': 10.1.4
+      '@commercetools-test-data/utils': 10.1.4
+      '@commercetools/platform-sdk': 7.8.0
+      '@faker-js/faker': 8.4.1
+      '@types/lodash': 4.17.4
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - encoding
+
+  '@commercetools-test-data/core@10.1.4':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@babel/runtime-corejs3': 7.24.6
+      '@faker-js/faker': 8.4.1
+      '@types/lodash': 4.17.4
+      lodash: 4.17.21
+
+  '@commercetools-test-data/graphql-types@10.1.4': {}
+
+  '@commercetools-test-data/utils@10.1.4':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@babel/runtime-corejs3': 7.24.6
+      '@faker-js/faker': 8.4.1
 
   '@commercetools/platform-sdk@7.8.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,9 @@ importers:
       '@commercetools-test-data/core':
         specifier: 10.1.4
         version: 10.1.4
+      '@commercetools-test-data/filter-values':
+        specifier: 10.1.4
+        version: 10.1.4
       '@commercetools-test-data/graphql-types':
         specifier: 10.1.4
         version: 10.1.4
@@ -2168,6 +2171,9 @@ packages:
 
   '@commercetools-test-data/core@10.1.4':
     resolution: {integrity: sha512-LNfTR35FM/X2aia47vGoJy6dyCbYhR0fNunkyMFn7lRE9uGScc5o4vTMaWjcmU8PfV5Df08AWwSqUAgrAaCPjA==}
+
+  '@commercetools-test-data/filter-values@10.1.4':
+    resolution: {integrity: sha512-axaajIUD6djniOrlOXR0xFMEv3u6/M0elneBp+Eu2Qfu5gG5xftbR2Aq7AmbtLYCDqbZYzcYHeU2ziwik5HZAQ==}
 
   '@commercetools-test-data/graphql-types@10.1.4':
     resolution: {integrity: sha512-QcBCXqCl3scatlsV+TOgK6ntSn9S+iqGsCTzlAiNoQzdIw6VIubZwtVM64115Dm4BazFYH6c9ARCjQ3a0DAu0Q==}
@@ -7633,6 +7639,15 @@ snapshots:
       '@faker-js/faker': 8.4.1
       '@types/lodash': 4.17.4
       lodash: 4.17.21
+
+  '@commercetools-test-data/filter-values@10.1.4':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@babel/runtime-corejs3': 7.24.6
+      '@commercetools-test-data/core': 10.1.4
+      '@commercetools-test-data/graphql-types': 10.1.4
+      '@commercetools-test-data/utils': 10.1.4
+      '@faker-js/faker': 8.4.1
 
   '@commercetools-test-data/graphql-types@10.1.4': {}
 


### PR DESCRIPTION
### Summary
A new model `CustomersSearchListMyView` is created based on the existing test-data in the FE repository. This model is related to internal [MC-settings graphql](https://github.com/commercetools/merchant-center-services/blob/main/packages/settings/lib/schemas/customers-search-list-my-view.graphql)