### PR TITLE
FEC-57: Add platform-limits model (Part 2)

### DIFF
--- a/.changeset/strong-eagles-smell.md
+++ b/.changeset/strong-eagles-smell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/platform-limits': minor
+---
+
+Add `PlatformLimit` test data model

--- a/models/platform-limits/README.md
+++ b/models/platform-limits/README.md
@@ -12,6 +12,251 @@ $ pnpm add -D @commercetools-test-data/platform-limits
 
 # Usage
 
-```ts
+- [BusinessUnitLimitsProjection](#businessunitlimitsprojection)<br>
+- [CartDiscountLimitsProjection](#cartdiscountlimitsprojection)<br>
+- [CartLimitsProjection](#cartlimitsprojection)<br>
+- [CustomerLimitsProjection](#customerlimitsprojection)<br>
+- [CustomerGroupLimitsProjection](#customergrouplimitsprojection)<br>
+- [PlatformLimits](#platformlimits)<br>
+- [LimitWithCurrent](#limitwithcurrent)<br>
+- [ProductDiscountLimitsProjection](#productdiscountlimitsprojection)<br>
+- [ShippingMethodLimitsProjection](#shippingmethodlimitsprojection)<br>
+- [ShoppingListLimitsProjection](#shoppinglistlimitsprojection)<br>
+- [StoreLimitsProjection](#storelimitsprojection)<br><br>
+- [TaxCategoryLimitsProjection](#taxcategorylimitsprojection)<br>
+- [ZoneLimitsProjection](#zonelimitsprojection)
 
+## `BusinessUnitLimitsProjection`
+
+```ts
+import {
+  BusinessUnitLimitsProjection,
+  type TBusinessUnitLimitsProjection,
+} from '@commercetools-test-data/platform-limits';
+
+const businessUnitLimitsProjection =
+  BusinessUnitLimitsProjection.random().build<TBusinessUnitLimitsProjection>();
+
+// Presets
+const BusinessUnitWithLimit = businessUnitLimitsProjection.presets
+  .withLimit()
+  .build<TBusinessUnitLimitsProjection>();
+```
+
+## `CartDiscountLimitsProjection`
+
+```ts
+import {
+  CartDiscountLimitsProjection,
+  type TCartDiscountLimitsProjection,
+} from '@commercetools-test-data/platform-limits';
+
+const cartDiscountLimitsProjection =
+  CartDiscountLimitsProjection.random().build<TCartDiscountLimitsProjection>();
+
+// Presets
+const cartDiscountLimitsProjectionWithLimitAndCurrent =
+  CartDiscountLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TCartDiscountLimitsProjection>();
+```
+
+## `CartLimitsProjection`
+
+```ts
+import {
+  CartLimitsProjection,
+  type TCartLimitsProjection,
+} from '@commercetools-test-data/platform-limits';
+
+const cartLimitsProjection =
+  CartLimitsProjection.random().build<TCartLimitsProjection>();
+
+// Presets
+const cartLimitsProjectionWithLimitAndCurrent = CartLimitsProjection.presets
+  .withLimitAndCurrent()
+  .build<TCartLimitsProjection>();
+```
+
+## `CustomerLimitsProjection`
+
+```ts
+import {
+  CustomerLimitsProjection,
+  type TCustomerLimitsProjection,
+} from '@commercetools-test-data/platform-limits';
+
+const customerLimitsProjection =
+  CustomerLimitsProjection.random().build<TCustomerLimitsProjection>();
+
+// Presets
+const customerLimitsProjectionWithLimitAndCurrent =
+  CustomerLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TCustomerLimitsProjection>();
+```
+
+## `CustomerGroupLimitsProjection`
+
+```ts
+import {
+  CustomerGroupLimitsProjection,
+  type TCustomerGroupLimitsProjection,
+} from '@commercetools-test-data/platform-limits';
+
+const customerGroupLimitsProjection =
+  CustomerGroupLimitsProjection.random().build<TCustomerGroupLimitsProjection>();
+
+// Presets
+const customerGroupLimitsProjectionWithLimitAndCurrent =
+  CustomerGroupLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TCustomerGroupLimitsProjection>();
+```
+
+## `PlatformLimits`
+
+```ts
+import {
+  PlatformLimits,
+  type TPlatformLimits,
+} from '@commercetools-test-data/platform-limits';
+
+const PlatformLimits = PlatformLimits.random().build<TPlatformLimits>();
+
+// Presets
+const PlatformLimitsWithLimitAndCurrent = PlatformLimits.presets
+  .withAllPlatformLimits()
+  .build<TPlatformLimits>();
+```
+
+## `LimitWithCurrent`
+
+```ts
+import {
+  LimitWithCurrent,
+  type TLimitWithCurrent,
+} from '@commercetools-test-data/platform-limits';
+
+const limitWithCurrent = LimitWithCurrent.random().build<TLimitWithCurrent>();
+
+// Presets
+const limitWithCurrentWithExceeded = LimitWithCurrent.presets
+  .withExceeded()
+  .build<TLimitWithCurrent>();
+const limitWithCurrentWithNonExceeded = LimitWithCurrent.presets
+  .withNonExceeded()
+  .build<TLimitWithCurrent>();
+const limitWithCurrentWithUndefined = LimitWithCurrent.presets
+  .withUndefined()
+  .build<TLimitWithCurrent>();
+const limitWithCurrentWithWarningExceeded = LimitWithCurrent.presets
+  .withWarningExceeded()
+  .build<TLimitWithCurrent>();
+```
+
+## `ProductDiscountLimitsProjection`
+
+```ts
+import {
+  ProductDiscountLimitsProjection,
+  type TProductDiscountLimitsProjection,
+} from '@commercetools-test-data/platform-limits';
+
+const productDiscountLimitsProjection =
+  ProductDiscountLimitsProjection.random().build<TProductDiscountLimitsProjection>();
+
+// Presets
+const productDiscountLimitsProjectionWithLimitAndCurrent =
+  ProductDiscountLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TProductDiscountLimitsProjection>();
+```
+
+## `ShippingMethodLimitsProjection`
+
+```ts
+import {
+  ShippingMethodLimitsProjection,
+  type TShippingMethodLimitsProjection,
+} from '@commercetools-test-data/platform-limits';
+
+const shippingMethodLimitsProjection =
+  ShippingMethodLimitsProjection.random().build<TShippingMethodLimitsProjection>();
+
+// Presets
+const shippingMethodLimitsProjectionWithLimitAndCurrent =
+  ShippingMethodLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TShippingMethodLimitsProjection>();
+```
+
+## `ShoppingListLimitsProjection`
+
+```ts
+import {
+  ShoppingListLimitsProjection,
+  type TShoppingListLimitsProjection,
+} from '@commercetools-test-data/platform-limits';
+
+const ShoppingListLimitsProjection =
+  ShoppingListLimitsProjection.random().build<TShoppingListLimitsProjection>();
+
+// Presets
+const ShoppingListLimitsProjectionWithLimitAndCurrent =
+  ShoppingListLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TShoppingListLimitsProjection>();
+```
+
+## `StoreLimitsProjection`
+
+```ts
+import {
+  StoreLimitsProjection,
+  type TStoreLimitsProjection,
+} from '@commercetools-test-data/platform-limits';
+
+const StoreLimitsProjection =
+  StoreLimitsProjection.random().build<TStoreLimitsProjection>();
+
+// Presets
+const StoreLimitsProjectionWithLimitAndCurrent = StoreLimitsProjection.presets
+  .withLimitAndCurrent()
+  .build<TStoreLimitsProjection>();
+```
+
+## `TaxCategoryLimitsProjection`
+
+```ts
+import {
+  TaxCategoryLimitsProjection,
+  type TTaxCategoryLimitsProjection,
+} from '@commercetools-test-data/platform-limits';
+
+const taxCategoryLimitsProjection =
+  TaxCategoryLimitsProjection.random().build<TTaxCategoryLimitsProjection>();
+
+// Presets
+const taxCategoryLimitsProjectionWithLimitAndCurrent =
+  TaxCategoryLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TTaxCategoryLimitsProjection>();
+```
+
+## `ZoneLimitsProjection`
+
+```ts
+import {
+  ZoneLimitsProjection,
+  type TZoneLimitsProjection,
+} from '@commercetools-test-data/platform-limits';
+
+const zoneLimitsProjection =
+  ZoneLimitsProjection.random().build<TZoneLimitsProjection>();
+
+// Presets
+const zoneLimitsProjectionWithLimitAndCurrent = ZoneLimitsProjection.presets
+  .withLimitAndCurrent()
+  .build<TZoneLimitsProjection>();
 ```

--- a/models/platform-limits/src/cart-discounts/builder.spec.ts
+++ b/models/platform-limits/src/cart-discounts/builder.spec.ts
@@ -4,6 +4,10 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TCartDiscountLimitsProjection } from './types';
 import * as CartDiscountsPlatformLimits from './index';
 
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
 describe('building', () => {
   it(
     ...createBuilderSpec<
@@ -11,9 +15,9 @@ describe('building', () => {
       TCartDiscountLimitsProjection
     >(
       'default',
-      CartDiscountsPlatformLimits.random(),
+      CartDiscountsPlatformLimits.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        totalActiveWithoutDiscountCodes: expect.any(Object),
+        totalActiveWithoutDiscountCodes: expectedLimitWithCurrent,
       })
     )
   );
@@ -23,9 +27,9 @@ describe('building', () => {
       TCartDiscountLimitsProjection
     >(
       'rest',
-      CartDiscountsPlatformLimits.random(),
+      CartDiscountsPlatformLimits.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        totalActiveWithoutDiscountCodes: expect.any(Object),
+        totalActiveWithoutDiscountCodes: expectedLimitWithCurrent,
       })
     )
   );
@@ -35,9 +39,9 @@ describe('building', () => {
       TCartDiscountLimitsProjection
     >(
       'graphql',
-      CartDiscountsPlatformLimits.random(),
+      CartDiscountsPlatformLimits.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        totalActiveWithoutDiscountCodes: expect.any(Object),
+        totalActiveWithoutDiscountCodes: expectedLimitWithCurrent,
         __typename: 'CartDiscountLimitsProjection',
       })
     )

--- a/models/platform-limits/src/cart-discounts/builder.spec.ts
+++ b/models/platform-limits/src/cart-discounts/builder.spec.ts
@@ -1,0 +1,45 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TCartDiscountLimitsProjection } from './types';
+import * as CartDiscountsPlatformLimits from './index';
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TCartDiscountLimitsProjection,
+      TCartDiscountLimitsProjection
+    >(
+      'default',
+      CartDiscountsPlatformLimits.random(),
+      expect.objectContaining({
+        totalActiveWithoutDiscountCodes: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TCartDiscountLimitsProjection,
+      TCartDiscountLimitsProjection
+    >(
+      'rest',
+      CartDiscountsPlatformLimits.random(),
+      expect.objectContaining({
+        totalActiveWithoutDiscountCodes: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TCartDiscountLimitsProjection,
+      TCartDiscountLimitsProjection
+    >(
+      'graphql',
+      CartDiscountsPlatformLimits.random(),
+      expect.objectContaining({
+        totalActiveWithoutDiscountCodes: expect.any(Object),
+        __typename: 'CartDiscountLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/cart-discounts/builder.ts
+++ b/models/platform-limits/src/cart-discounts/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TCartDiscountLimitsProjection,
+  TCreateCartDiscountLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateCartDiscountLimitsProjectionBuilder = () =>
+  Builder<TCartDiscountLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/cart-discounts/generator.ts
+++ b/models/platform-limits/src/cart-discounts/generator.ts
@@ -1,0 +1,13 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TCartDiscountLimitsProjection } from './types';
+
+/**
+ * total - reference to LimitWithCurrent
+ */
+const generator = Generator<TCartDiscountLimitsProjection>({
+  fields: {
+    totalActiveWithoutDiscountCodes: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/cart-discounts/index.ts
+++ b/models/platform-limits/src/cart-discounts/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/cart-discounts/presets/index.ts
+++ b/models/platform-limits/src/cart-discounts/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/cart-discounts/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/cart-discounts/presets/with-limit-and-current.ts
@@ -1,0 +1,9 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import CartDiscountsPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  CartDiscountsPlatformLimits().totalActiveWithoutDiscountCodes(
+    LimitWithCurrent.random()
+  );
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/cart-discounts/transformers.ts
+++ b/models/platform-limits/src/cart-discounts/transformers.ts
@@ -1,0 +1,31 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TCartDiscountLimitsProjection,
+  TCartDiscountLimitsProjectionGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<
+    TCartDiscountLimitsProjection,
+    TCartDiscountLimitsProjection
+  >('default', {
+    buildFields: ['totalActiveWithoutDiscountCodes'],
+  }),
+  rest: Transformer<
+    TCartDiscountLimitsProjection,
+    TCartDiscountLimitsProjection
+  >('rest', {
+    buildFields: ['totalActiveWithoutDiscountCodes'],
+  }),
+  graphql: Transformer<
+    TCartDiscountLimitsProjection,
+    TCartDiscountLimitsProjectionGraphql
+  >('graphql', {
+    buildFields: ['totalActiveWithoutDiscountCodes'],
+    addFields: () => ({
+      __typename: 'CartDiscountLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/cart-discounts/types.ts
+++ b/models/platform-limits/src/cart-discounts/types.ts
@@ -1,0 +1,16 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TCartDiscountLimitsProjection = {
+  totalActiveWithoutDiscountCodes: TLimitWithCurrent;
+};
+
+export type TCartDiscountLimitsProjectionGraphql =
+  TCartDiscountLimitsProjection & {
+    __typename: 'CartDiscountLimitsProjection';
+  };
+
+export type TCartDiscountLimitsProjectionBuilder =
+  TBuilder<TCartDiscountLimitsProjection>;
+export type TCreateCartDiscountLimitsProjectionBuilder =
+  () => TCartDiscountLimitsProjectionBuilder;

--- a/models/platform-limits/src/carts/builder.spec.ts
+++ b/models/platform-limits/src/carts/builder.spec.ts
@@ -4,31 +4,35 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TCartLimitsProjection } from './types';
 import * as CartLimitsProjection from './index';
 
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
 describe('building', () => {
   it(
     ...createBuilderSpec<TCartLimitsProjection, TCartLimitsProjection>(
       'default',
-      CartLimitsProjection.random(),
+      CartLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
   it(
     ...createBuilderSpec<TCartLimitsProjection, TCartLimitsProjection>(
       'rest',
-      CartLimitsProjection.random(),
+      CartLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
   it(
     ...createBuilderSpec<TCartLimitsProjection, TCartLimitsProjection>(
       'graphql',
-      CartLimitsProjection.random(),
+      CartLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
         __typename: 'CartLimitsProjection',
       })
     )

--- a/models/platform-limits/src/carts/builder.spec.ts
+++ b/models/platform-limits/src/carts/builder.spec.ts
@@ -1,0 +1,36 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TCartLimitsProjection } from './types';
+import * as CartLimitsProjection from './index';
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<TCartLimitsProjection, TCartLimitsProjection>(
+      'default',
+      CartLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TCartLimitsProjection, TCartLimitsProjection>(
+      'rest',
+      CartLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TCartLimitsProjection, TCartLimitsProjection>(
+      'graphql',
+      CartLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+        __typename: 'CartLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/carts/builder.ts
+++ b/models/platform-limits/src/carts/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TCartLimitsProjection,
+  TCreateCartLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateCartLimitsProjectionBuilder = () =>
+  Builder<TCartLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/carts/generator.ts
+++ b/models/platform-limits/src/carts/generator.ts
@@ -1,0 +1,13 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TCartLimitsProjection } from './types';
+
+/**
+ * total - reference to LimitWithCurrent
+ */
+const generator = Generator<TCartLimitsProjection>({
+  fields: {
+    total: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/carts/index.ts
+++ b/models/platform-limits/src/carts/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/carts/presets/index.ts
+++ b/models/platform-limits/src/carts/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/carts/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/carts/presets/with-limit-and-current.ts
@@ -1,0 +1,7 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import CartsPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  CartsPlatformLimits().total(LimitWithCurrent.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/carts/transformers.ts
+++ b/models/platform-limits/src/carts/transformers.ts
@@ -1,0 +1,25 @@
+import { Transformer } from '@commercetools-test-data/core';
+import { TCartLimitsProjection, TCartLimitsProjectionGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TCartLimitsProjection, TCartLimitsProjection>(
+    'default',
+    {
+      buildFields: ['total'],
+    }
+  ),
+  rest: Transformer<TCartLimitsProjection, TCartLimitsProjection>('rest', {
+    buildFields: ['total'],
+  }),
+  graphql: Transformer<TCartLimitsProjection, TCartLimitsProjectionGraphql>(
+    'graphql',
+    {
+      buildFields: ['total'],
+      addFields: () => ({
+        __typename: 'CartLimitsProjection',
+      }),
+    }
+  ),
+};
+
+export default transformers;

--- a/models/platform-limits/src/carts/types.ts
+++ b/models/platform-limits/src/carts/types.ts
@@ -1,0 +1,14 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TCartLimitsProjection = {
+  total: TLimitWithCurrent;
+};
+
+export type TCartLimitsProjectionGraphql = TCartLimitsProjection & {
+  __typename: 'CartLimitsProjection';
+};
+
+export type TCartLimitsProjectionBuilder = TBuilder<TCartLimitsProjection>;
+export type TCreateCartLimitsProjectionBuilder =
+  () => TCartLimitsProjectionBuilder;

--- a/models/platform-limits/src/customer-groups/builder.spec.ts
+++ b/models/platform-limits/src/customer-groups/builder.spec.ts
@@ -1,0 +1,45 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TCustomerGroupLimitsProjection } from './types';
+import * as CustomerGroupLimitsProjection from './index';
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TCustomerGroupLimitsProjection,
+      TCustomerGroupLimitsProjection
+    >(
+      'default',
+      CustomerGroupLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TCustomerGroupLimitsProjection,
+      TCustomerGroupLimitsProjection
+    >(
+      'rest',
+      CustomerGroupLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TCustomerGroupLimitsProjection,
+      TCustomerGroupLimitsProjection
+    >(
+      'graphql',
+      CustomerGroupLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+        __typename: 'CustomerGroupLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/customer-groups/builder.spec.ts
+++ b/models/platform-limits/src/customer-groups/builder.spec.ts
@@ -4,6 +4,10 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TCustomerGroupLimitsProjection } from './types';
 import * as CustomerGroupLimitsProjection from './index';
 
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
 describe('building', () => {
   it(
     ...createBuilderSpec<
@@ -11,9 +15,9 @@ describe('building', () => {
       TCustomerGroupLimitsProjection
     >(
       'default',
-      CustomerGroupLimitsProjection.random(),
+      CustomerGroupLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
@@ -23,9 +27,9 @@ describe('building', () => {
       TCustomerGroupLimitsProjection
     >(
       'rest',
-      CustomerGroupLimitsProjection.random(),
+      CustomerGroupLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
@@ -35,9 +39,9 @@ describe('building', () => {
       TCustomerGroupLimitsProjection
     >(
       'graphql',
-      CustomerGroupLimitsProjection.random(),
+      CustomerGroupLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
         __typename: 'CustomerGroupLimitsProjection',
       })
     )

--- a/models/platform-limits/src/customer-groups/builder.ts
+++ b/models/platform-limits/src/customer-groups/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TCustomerGroupLimitsProjection,
+  TCreateCustomerGroupLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateCustomerGroupLimitsProjectionBuilder = () =>
+  Builder<TCustomerGroupLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/customer-groups/generator.ts
+++ b/models/platform-limits/src/customer-groups/generator.ts
@@ -1,0 +1,13 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TCustomerGroupLimitsProjection } from './types';
+
+/**
+ * total - reference to LimitWithCurrent
+ */
+const generator = Generator<TCustomerGroupLimitsProjection>({
+  fields: {
+    total: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/customer-groups/index.ts
+++ b/models/platform-limits/src/customer-groups/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/customer-groups/presets/index.ts
+++ b/models/platform-limits/src/customer-groups/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/customer-groups/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/customer-groups/presets/with-limit-and-current.ts
@@ -1,0 +1,7 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import CustomerGroupsPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  CustomerGroupsPlatformLimits().total(LimitWithCurrent.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/customer-groups/transformers.ts
+++ b/models/platform-limits/src/customer-groups/transformers.ts
@@ -1,0 +1,31 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TCustomerGroupLimitsProjection,
+  TCustomerGroupLimitsProjectionGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<
+    TCustomerGroupLimitsProjection,
+    TCustomerGroupLimitsProjection
+  >('default', {
+    buildFields: ['total'],
+  }),
+  rest: Transformer<
+    TCustomerGroupLimitsProjection,
+    TCustomerGroupLimitsProjection
+  >('rest', {
+    buildFields: ['total'],
+  }),
+  graphql: Transformer<
+    TCustomerGroupLimitsProjection,
+    TCustomerGroupLimitsProjectionGraphql
+  >('graphql', {
+    buildFields: ['total'],
+    addFields: () => ({
+      __typename: 'CustomerGroupLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/customer-groups/types.ts
+++ b/models/platform-limits/src/customer-groups/types.ts
@@ -1,0 +1,16 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TCustomerGroupLimitsProjection = {
+  total: TLimitWithCurrent;
+};
+
+export type TCustomerGroupLimitsProjectionGraphql =
+  TCustomerGroupLimitsProjection & {
+    __typename: 'CustomerGroupLimitsProjection';
+  };
+
+export type TCustomerGroupLimitsProjectionBuilder =
+  TBuilder<TCustomerGroupLimitsProjection>;
+export type TCreateCustomerGroupLimitsProjectionBuilder =
+  () => TCustomerGroupLimitsProjectionBuilder;

--- a/models/platform-limits/src/customers/builder.spec.ts
+++ b/models/platform-limits/src/customers/builder.spec.ts
@@ -1,0 +1,36 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TCustomerLimitsProjection } from './types';
+import * as CustomerLimitsProjection from './index';
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<TCustomerLimitsProjection, TCustomerLimitsProjection>(
+      'default',
+      CustomerLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TCustomerLimitsProjection, TCustomerLimitsProjection>(
+      'rest',
+      CustomerLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TCustomerLimitsProjection, TCustomerLimitsProjection>(
+      'graphql',
+      CustomerLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+        __typename: 'CustomerLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/customers/builder.spec.ts
+++ b/models/platform-limits/src/customers/builder.spec.ts
@@ -4,31 +4,35 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TCustomerLimitsProjection } from './types';
 import * as CustomerLimitsProjection from './index';
 
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
 describe('building', () => {
   it(
     ...createBuilderSpec<TCustomerLimitsProjection, TCustomerLimitsProjection>(
       'default',
-      CustomerLimitsProjection.random(),
+      CustomerLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
   it(
     ...createBuilderSpec<TCustomerLimitsProjection, TCustomerLimitsProjection>(
       'rest',
-      CustomerLimitsProjection.random(),
+      CustomerLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
   it(
     ...createBuilderSpec<TCustomerLimitsProjection, TCustomerLimitsProjection>(
       'graphql',
-      CustomerLimitsProjection.random(),
+      CustomerLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
         __typename: 'CustomerLimitsProjection',
       })
     )

--- a/models/platform-limits/src/customers/builder.ts
+++ b/models/platform-limits/src/customers/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TCustomerLimitsProjection,
+  TCreateCustomerLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateCustomerLimitsProjectionBuilder = () =>
+  Builder<TCustomerLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/customers/generator.ts
+++ b/models/platform-limits/src/customers/generator.ts
@@ -1,0 +1,13 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TCustomerLimitsProjection } from './types';
+
+/**
+ * total - reference to LimitWithCurrent
+ */
+const generator = Generator<TCustomerLimitsProjection>({
+  fields: {
+    total: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/customers/index.ts
+++ b/models/platform-limits/src/customers/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';

--- a/models/platform-limits/src/customers/presets/index.ts
+++ b/models/platform-limits/src/customers/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/customers/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/customers/presets/with-limit-and-current.ts
@@ -1,0 +1,7 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import CustomersPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  CustomersPlatformLimits().total(LimitWithCurrent.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/customers/transformers.ts
+++ b/models/platform-limits/src/customers/transformers.ts
@@ -1,0 +1,31 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TCustomerLimitsProjection,
+  TCustomerLimitsProjectionGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<TCustomerLimitsProjection, TCustomerLimitsProjection>(
+    'default',
+    {
+      buildFields: ['total'],
+    }
+  ),
+  rest: Transformer<TCustomerLimitsProjection, TCustomerLimitsProjection>(
+    'rest',
+    {
+      buildFields: ['total'],
+    }
+  ),
+  graphql: Transformer<
+    TCustomerLimitsProjection,
+    TCustomerLimitsProjectionGraphql
+  >('graphql', {
+    buildFields: ['total'],
+    addFields: () => ({
+      __typename: 'CustomerLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/customers/types.ts
+++ b/models/platform-limits/src/customers/types.ts
@@ -1,0 +1,15 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TCustomerLimitsProjection = {
+  total: TLimitWithCurrent;
+};
+
+export type TCustomerLimitsProjectionGraphql = TCustomerLimitsProjection & {
+  __typename: 'CustomerLimitsProjection';
+};
+
+export type TCustomerLimitsProjectionBuilder =
+  TBuilder<TCustomerLimitsProjection>;
+export type TCreateCustomerLimitsProjectionBuilder =
+  () => TCustomerLimitsProjectionBuilder;

--- a/models/platform-limits/src/general/builder.spec.ts
+++ b/models/platform-limits/src/general/builder.spec.ts
@@ -1,0 +1,92 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TProjectCustomLimitsProjection } from './types';
+import * as ProjectCustomLimitsProjection from './index';
+
+const expectedLimit = expect.objectContaining({
+  limit: expect.any(Number),
+});
+
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
+const expectedResult = {
+  customers: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  customerGroups: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  zones: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  taxCategories: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  shippingMethods: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  productDiscounts: expect.objectContaining({
+    totalActive: expectedLimitWithCurrent,
+  }),
+  cartDiscounts: expect.objectContaining({
+    totalActiveWithoutDiscountCodes: expectedLimitWithCurrent,
+  }),
+  stores: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+    inventorySupplyChannels: expectedLimit,
+    productDistributionChannels: expectedLimit,
+  }),
+  carts: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  shoppingLists: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+    lineItems: expectedLimit,
+    textLineItems: expectedLimit,
+  }),
+  businessUnits: expect.objectContaining({
+    maxDivisions: expectedLimit,
+    maxDepthLimit: expectedLimit,
+    maxAssociates: expectedLimit,
+    maxAssociateRoles: expectedLimit,
+  }),
+};
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TProjectCustomLimitsProjection,
+      TProjectCustomLimitsProjection
+    >(
+      'default',
+      ProjectCustomLimitsProjection.presets.withAllPlatformLimits(),
+      expect.objectContaining(expectedResult)
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TProjectCustomLimitsProjection,
+      TProjectCustomLimitsProjection
+    >(
+      'rest',
+      ProjectCustomLimitsProjection.presets.withAllPlatformLimits(),
+      expect.objectContaining(expectedResult)
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TProjectCustomLimitsProjection,
+      TProjectCustomLimitsProjection
+    >(
+      'graphql',
+      ProjectCustomLimitsProjection.presets.withAllPlatformLimits(),
+      expect.objectContaining({
+        ...expectedResult,
+        __typename: 'ProjectCustomLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/general/builder.ts
+++ b/models/platform-limits/src/general/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TProjectCustomLimitsProjection,
+  TCreateProjectCustomLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateProjectCustomLimitsProjectionBuilder = () =>
+  Builder<TProjectCustomLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/general/generator.ts
+++ b/models/platform-limits/src/general/generator.ts
@@ -1,0 +1,20 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TProjectCustomLimitsProjection } from './types';
+
+const generator = Generator<TProjectCustomLimitsProjection>({
+  fields: {
+    customers: null,
+    customerGroups: null,
+    zones: null,
+    taxCategories: null,
+    shippingMethods: null,
+    productDiscounts: null,
+    cartDiscounts: null,
+    stores: null,
+    shoppingLists: null,
+    carts: null,
+    businessUnits: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/general/index.ts
+++ b/models/platform-limits/src/general/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/general/presets/index.ts
+++ b/models/platform-limits/src/general/presets/index.ts
@@ -1,0 +1,5 @@
+import withAllPlatformLimits from './with-all-platform-limits';
+
+export default {
+  withAllPlatformLimits,
+};

--- a/models/platform-limits/src/general/presets/with-all-platform-limits.ts
+++ b/models/platform-limits/src/general/presets/with-all-platform-limits.ts
@@ -1,0 +1,78 @@
+import * as BusinessUnitsPlatformLimits from '../../business-units';
+import * as CartDiscountsPlatformLimits from '../../cart-discounts';
+import * as CartsPlatformLimits from '../../carts';
+import * as CustomerGroupsPlatformLimits from '../../customer-groups';
+import * as CustomersPlatformLimits from '../../customers';
+import * as Limit from '../../limit';
+import * as LimitWithCurrent from '../../limit-with-current';
+import * as ProductDiscountsPlatformLimits from '../../product-discounts';
+import * as ShippingMethodsPlatformLimits from '../../shipping-methods';
+import * as ShoppingListsPlatformLimits from '../../shopping-lists';
+import * as StoresPlatformLimits from '../../stores';
+import * as TaxCategoriesPlatformLimits from '../../tax-categories';
+import * as ZonesPlatformLimits from '../../zones';
+import PlatformLimits from '../builder';
+
+const withAllPlatformLimits = () =>
+  PlatformLimits()
+    .businessUnits(
+      BusinessUnitsPlatformLimits.random()
+        .maxAssociateRoles(Limit.random().limit(5))
+        .maxAssociates(Limit.random().limit(2000))
+        .maxDepthLimit(Limit.random().limit(5))
+        .maxDivisions(Limit.random().limit(4000))
+    )
+    .customers(
+      CustomersPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .customerGroups(
+      CustomerGroupsPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .zones(
+      ZonesPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .taxCategories(
+      TaxCategoriesPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .shippingMethods(
+      ShippingMethodsPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .productDiscounts(
+      ProductDiscountsPlatformLimits.random().totalActive(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .cartDiscounts(
+      CartDiscountsPlatformLimits.random().totalActiveWithoutDiscountCodes(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .stores(
+      StoresPlatformLimits.random()
+        .total(LimitWithCurrent.presets.withNonExceeded())
+        .inventorySupplyChannels(Limit.random())
+        .productDistributionChannels(Limit.random())
+    )
+    .carts(
+      CartsPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .shoppingLists(
+      ShoppingListsPlatformLimits.random()
+        .total(LimitWithCurrent.presets.withNonExceeded())
+        .lineItems(Limit.random().limit(10))
+        .textLineItems(Limit.random().limit(10))
+    );
+
+export default withAllPlatformLimits;

--- a/models/platform-limits/src/general/transformers.ts
+++ b/models/platform-limits/src/general/transformers.ts
@@ -1,0 +1,45 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TProjectCustomLimitsProjection,
+  TProjectCustomLimitsProjectionGraphql,
+} from './types';
+
+const buildFields: (keyof TProjectCustomLimitsProjection)[] = [
+  'customers',
+  'customerGroups',
+  'zones',
+  'taxCategories',
+  'shippingMethods',
+  'productDiscounts',
+  'cartDiscounts',
+  'stores',
+  'shoppingLists',
+  'carts',
+  'businessUnits',
+];
+
+const transformers = {
+  default: Transformer<
+    TProjectCustomLimitsProjection,
+    TProjectCustomLimitsProjection
+  >('default', {
+    buildFields,
+  }),
+  rest: Transformer<
+    TProjectCustomLimitsProjection,
+    TProjectCustomLimitsProjection
+  >('rest', {
+    buildFields,
+  }),
+  graphql: Transformer<
+    TProjectCustomLimitsProjection,
+    TProjectCustomLimitsProjectionGraphql
+  >('graphql', {
+    buildFields,
+    addFields: () => ({
+      __typename: 'ProjectCustomLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/general/types.ts
+++ b/models/platform-limits/src/general/types.ts
@@ -1,0 +1,38 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type {
+  TCustomerLimitsProjection,
+  TCustomerGroupLimitsProjection,
+  TZoneLimitsProjection,
+  TTaxCategoryLimitsProjection,
+  TShippingMethodLimitsProjection,
+  TProductDiscountLimitsProjection,
+  TCartDiscountLimitsProjection,
+  TStoreLimitsProjection,
+  TShoppingListLimitsProjection,
+  TCartLimitsProjection,
+  TBusinessUnitLimitsProjection,
+} from '../index';
+
+export type TProjectCustomLimitsProjection = {
+  customers: TCustomerLimitsProjection;
+  customerGroups: TCustomerGroupLimitsProjection;
+  zones: TZoneLimitsProjection;
+  taxCategories: TTaxCategoryLimitsProjection;
+  shippingMethods: TShippingMethodLimitsProjection;
+  productDiscounts: TProductDiscountLimitsProjection;
+  cartDiscounts: TCartDiscountLimitsProjection;
+  stores: TStoreLimitsProjection;
+  shoppingLists: TShoppingListLimitsProjection;
+  carts: TCartLimitsProjection;
+  businessUnits: TBusinessUnitLimitsProjection;
+};
+
+export type TProjectCustomLimitsProjectionGraphql =
+  TProjectCustomLimitsProjection & {
+    __typename: 'ProjectCustomLimitsProjection';
+  };
+
+export type TProjectCustomLimitsProjectionBuilder =
+  TBuilder<TProjectCustomLimitsProjection>;
+export type TCreateProjectCustomLimitsProjectionBuilder =
+  () => TProjectCustomLimitsProjectionBuilder;

--- a/models/platform-limits/src/index.ts
+++ b/models/platform-limits/src/index.ts
@@ -1,7 +1,15 @@
 // Export types
 export * from './business-units/types';
+export * from './cart-discounts/types';
+export * from './carts/types';
+export * from './customers/types';
+export * from './customer-groups/types';
 export * from './limit-with-current/types';
 
 // Export models
 export * as BusinessUnitLimitsProjection from './business-units';
+export * as CartDiscountLimitsProjection from './cart-discounts';
+export * as CartLimitsProjection from './carts';
+export * as CustomerLimitsProjection from './customers';
+export * as CustomerGroupLimitsProjection from './customer-groups';
 export * as LimitWithCurrent from './limit-with-current';

--- a/models/platform-limits/src/index.ts
+++ b/models/platform-limits/src/index.ts
@@ -4,7 +4,14 @@ export * from './cart-discounts/types';
 export * from './carts/types';
 export * from './customers/types';
 export * from './customer-groups/types';
+export * from './general/types';
 export * from './limit-with-current/types';
+export * from './product-discounts/types';
+export * from './shipping-methods/types';
+export * from './shopping-lists/types';
+export * from './stores/types';
+export * from './tax-categories/types';
+export * from './zones/types';
 
 // Export models
 export * as BusinessUnitLimitsProjection from './business-units';
@@ -12,4 +19,11 @@ export * as CartDiscountLimitsProjection from './cart-discounts';
 export * as CartLimitsProjection from './carts';
 export * as CustomerLimitsProjection from './customers';
 export * as CustomerGroupLimitsProjection from './customer-groups';
+export * as PlatformLimits from './general';
 export * as LimitWithCurrent from './limit-with-current';
+export * as ProductDiscountLimitsProjection from './product-discounts';
+export * as ShippingMethodLimitsProjection from './shipping-methods';
+export * as ShoppingListLimitsProjection from './shopping-lists';
+export * as StoreLimitsProjection from './stores';
+export * as TaxCategoryLimitsProjection from './tax-categories';
+export * as ZoneLimitsProjection from './zones';

--- a/models/platform-limits/src/product-discounts/builder.spec.ts
+++ b/models/platform-limits/src/product-discounts/builder.spec.ts
@@ -1,0 +1,50 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TProductDiscountLimitsProjection } from './types';
+import * as ProductDiscountLimitsProjection from './index';
+
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TProductDiscountLimitsProjection,
+      TProductDiscountLimitsProjection
+    >(
+      'default',
+      ProductDiscountLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        totalActive: expectedLimitWithCurrent,
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TProductDiscountLimitsProjection,
+      TProductDiscountLimitsProjection
+    >(
+      'rest',
+      ProductDiscountLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        totalActive: expectedLimitWithCurrent,
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TProductDiscountLimitsProjection,
+      TProductDiscountLimitsProjection
+    >(
+      'graphql',
+      ProductDiscountLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        totalActive: expectedLimitWithCurrent,
+        __typename: 'ProductDiscountLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/product-discounts/builder.ts
+++ b/models/platform-limits/src/product-discounts/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TProductDiscountLimitsProjection,
+  TCreateProductDiscountLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateProductDiscountLimitsProjectionBuilder = () =>
+  Builder<TProductDiscountLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/product-discounts/generator.ts
+++ b/models/platform-limits/src/product-discounts/generator.ts
@@ -1,0 +1,10 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TProductDiscountLimitsProjection } from './types';
+
+const generator = Generator<TProductDiscountLimitsProjection>({
+  fields: {
+    totalActive: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/product-discounts/index.ts
+++ b/models/platform-limits/src/product-discounts/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/product-discounts/presets/index.ts
+++ b/models/platform-limits/src/product-discounts/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/product-discounts/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/product-discounts/presets/with-limit-and-current.ts
@@ -1,0 +1,7 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import ProductDiscountsPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  ProductDiscountsPlatformLimits().totalActive(LimitWithCurrent.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/product-discounts/transformers.ts
+++ b/models/platform-limits/src/product-discounts/transformers.ts
@@ -1,0 +1,31 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TProductDiscountLimitsProjection,
+  TProductDiscountLimitsProjectionGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<
+    TProductDiscountLimitsProjection,
+    TProductDiscountLimitsProjection
+  >('default', {
+    buildFields: ['totalActive'],
+  }),
+  rest: Transformer<
+    TProductDiscountLimitsProjection,
+    TProductDiscountLimitsProjection
+  >('rest', {
+    buildFields: ['totalActive'],
+  }),
+  graphql: Transformer<
+    TProductDiscountLimitsProjection,
+    TProductDiscountLimitsProjectionGraphql
+  >('graphql', {
+    buildFields: ['totalActive'],
+    addFields: () => ({
+      __typename: 'ProductDiscountLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/product-discounts/types.ts
+++ b/models/platform-limits/src/product-discounts/types.ts
@@ -1,0 +1,16 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TProductDiscountLimitsProjection = {
+  totalActive: TLimitWithCurrent;
+};
+
+export type TProductDiscountLimitsProjectionGraphql =
+  TProductDiscountLimitsProjection & {
+    __typename: 'ProductDiscountLimitsProjection';
+  };
+
+export type TProductDiscountLimitsProjectionBuilder =
+  TBuilder<TProductDiscountLimitsProjection>;
+export type TCreateProductDiscountLimitsProjectionBuilder =
+  () => TProductDiscountLimitsProjectionBuilder;

--- a/models/platform-limits/src/shipping-methods/builder.spec.ts
+++ b/models/platform-limits/src/shipping-methods/builder.spec.ts
@@ -1,0 +1,50 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TShippingMethodLimitsProjection } from './types';
+import * as ShippingMethodLimitsProjection from './index';
+
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TShippingMethodLimitsProjection,
+      TShippingMethodLimitsProjection
+    >(
+      'default',
+      ShippingMethodLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        total: expectedLimitWithCurrent,
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TShippingMethodLimitsProjection,
+      TShippingMethodLimitsProjection
+    >(
+      'rest',
+      ShippingMethodLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        total: expectedLimitWithCurrent,
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TShippingMethodLimitsProjection,
+      TShippingMethodLimitsProjection
+    >(
+      'graphql',
+      ShippingMethodLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        total: expectedLimitWithCurrent,
+        __typename: 'ShippingMethodLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/shipping-methods/builder.ts
+++ b/models/platform-limits/src/shipping-methods/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TShippingMethodLimitsProjection,
+  TCreateShippingMethodLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateShippingMethodLimitsProjectionBuilder = () =>
+  Builder<TShippingMethodLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/shipping-methods/generator.ts
+++ b/models/platform-limits/src/shipping-methods/generator.ts
@@ -1,0 +1,10 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TShippingMethodLimitsProjection } from './types';
+
+const generator = Generator<TShippingMethodLimitsProjection>({
+  fields: {
+    total: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/shipping-methods/index.ts
+++ b/models/platform-limits/src/shipping-methods/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/shipping-methods/presets/index.ts
+++ b/models/platform-limits/src/shipping-methods/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/shipping-methods/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/shipping-methods/presets/with-limit-and-current.ts
@@ -1,0 +1,7 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import ShippingMethodsPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  ShippingMethodsPlatformLimits().total(LimitWithCurrent.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/shipping-methods/transformers.ts
+++ b/models/platform-limits/src/shipping-methods/transformers.ts
@@ -1,0 +1,31 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TShippingMethodLimitsProjection,
+  TShippingMethodLimitsProjectionGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<
+    TShippingMethodLimitsProjection,
+    TShippingMethodLimitsProjection
+  >('default', {
+    buildFields: ['total'],
+  }),
+  rest: Transformer<
+    TShippingMethodLimitsProjection,
+    TShippingMethodLimitsProjection
+  >('rest', {
+    buildFields: ['total'],
+  }),
+  graphql: Transformer<
+    TShippingMethodLimitsProjection,
+    TShippingMethodLimitsProjectionGraphql
+  >('graphql', {
+    buildFields: ['total'],
+    addFields: () => ({
+      __typename: 'ShippingMethodLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/shipping-methods/types.ts
+++ b/models/platform-limits/src/shipping-methods/types.ts
@@ -1,0 +1,16 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TShippingMethodLimitsProjection = {
+  total: TLimitWithCurrent;
+};
+
+export type TShippingMethodLimitsProjectionGraphql =
+  TShippingMethodLimitsProjection & {
+    __typename: 'ShippingMethodLimitsProjection';
+  };
+
+export type TShippingMethodLimitsProjectionBuilder =
+  TBuilder<TShippingMethodLimitsProjection>;
+export type TCreateShippingMethodLimitsProjectionBuilder =
+  () => TShippingMethodLimitsProjectionBuilder;

--- a/models/platform-limits/src/shopping-lists/builder.spec.ts
+++ b/models/platform-limits/src/shopping-lists/builder.spec.ts
@@ -1,0 +1,56 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TShoppingListLimitsProjection } from './types';
+import * as ShoppingListLimitsProjection from './index';
+
+const expectedLimit = expect.objectContaining({
+  limit: expect.any(Number),
+});
+
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
+const expectedResult = {
+  total: expectedLimitWithCurrent,
+  lineItems: expectedLimit,
+  textLineItems: expectedLimit,
+};
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TShoppingListLimitsProjection,
+      TShoppingListLimitsProjection
+    >(
+      'default',
+      ShoppingListLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining(expectedResult)
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TShoppingListLimitsProjection,
+      TShoppingListLimitsProjection
+    >(
+      'rest',
+      ShoppingListLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining(expectedResult)
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TShoppingListLimitsProjection,
+      TShoppingListLimitsProjection
+    >(
+      'graphql',
+      ShoppingListLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        ...expectedResult,
+        __typename: 'ShoppingListLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/shopping-lists/builder.ts
+++ b/models/platform-limits/src/shopping-lists/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TShoppingListLimitsProjection,
+  TCreateShoppingListLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateShoppingListLimitsProjectionBuilder = () =>
+  Builder<TShoppingListLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/shopping-lists/generator.ts
+++ b/models/platform-limits/src/shopping-lists/generator.ts
@@ -1,0 +1,12 @@
+import { Generator } from '@commercetools-test-data/core';
+import type { TShoppingListLimitsProjection } from './types';
+
+const generator = Generator<TShoppingListLimitsProjection>({
+  fields: {
+    total: null,
+    lineItems: null,
+    textLineItems: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/shopping-lists/index.ts
+++ b/models/platform-limits/src/shopping-lists/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/shopping-lists/presets/index.ts
+++ b/models/platform-limits/src/shopping-lists/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/shopping-lists/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/shopping-lists/presets/with-limit-and-current.ts
@@ -1,0 +1,11 @@
+import * as Limit from '../../limit';
+import * as LimitWithCurrent from '../../limit-with-current';
+import ShoppingListsPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  ShoppingListsPlatformLimits()
+    .total(LimitWithCurrent.random())
+    .lineItems(Limit.random())
+    .textLineItems(Limit.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/shopping-lists/transformers.ts
+++ b/models/platform-limits/src/shopping-lists/transformers.ts
@@ -1,0 +1,37 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TShoppingListLimitsProjection,
+  TShoppingListLimitsProjectionGraphql,
+} from './types';
+
+const buildFields: (keyof TShoppingListLimitsProjection)[] = [
+  'total',
+  'lineItems',
+  'textLineItems',
+];
+
+const transformers = {
+  default: Transformer<
+    TShoppingListLimitsProjection,
+    TShoppingListLimitsProjection
+  >('default', {
+    buildFields,
+  }),
+  rest: Transformer<
+    TShoppingListLimitsProjection,
+    TShoppingListLimitsProjection
+  >('rest', {
+    buildFields,
+  }),
+  graphql: Transformer<
+    TShoppingListLimitsProjection,
+    TShoppingListLimitsProjectionGraphql
+  >('graphql', {
+    buildFields,
+    addFields: () => ({
+      __typename: 'ShoppingListLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/shopping-lists/types.ts
+++ b/models/platform-limits/src/shopping-lists/types.ts
@@ -1,0 +1,19 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimit } from '../limit';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TShoppingListLimitsProjection = {
+  total: TLimitWithCurrent;
+  lineItems: TLimit;
+  textLineItems: TLimit;
+};
+
+export type TShoppingListLimitsProjectionGraphql =
+  TShoppingListLimitsProjection & {
+    __typename: 'ShoppingListLimitsProjection';
+  };
+
+export type TShoppingListLimitsProjectionBuilder =
+  TBuilder<TShoppingListLimitsProjection>;
+export type TCreateShoppingListLimitsProjectionBuilder =
+  () => TShoppingListLimitsProjectionBuilder;

--- a/models/platform-limits/src/stores/builder.spec.ts
+++ b/models/platform-limits/src/stores/builder.spec.ts
@@ -1,0 +1,47 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TStoreLimitsProjection } from './types';
+import * as StoreLimitsProjection from './index';
+
+const expectedLimit = expect.objectContaining({
+  limit: expect.any(Number),
+});
+
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
+const expectedResult = {
+  total: expectedLimitWithCurrent,
+  inventorySupplyChannels: expectedLimit,
+  productDistributionChannels: expectedLimit,
+};
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<TStoreLimitsProjection, TStoreLimitsProjection>(
+      'default',
+      StoreLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining(expectedResult)
+    )
+  );
+  it(
+    ...createBuilderSpec<TStoreLimitsProjection, TStoreLimitsProjection>(
+      'rest',
+      StoreLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining(expectedResult)
+    )
+  );
+  it(
+    ...createBuilderSpec<TStoreLimitsProjection, TStoreLimitsProjection>(
+      'graphql',
+      StoreLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        ...expectedResult,
+        __typename: 'StoreLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/stores/builder.ts
+++ b/models/platform-limits/src/stores/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TStoreLimitsProjection,
+  TCreateStoreLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateStoreLimitsProjectionBuilder = () =>
+  Builder<TStoreLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/stores/generator.ts
+++ b/models/platform-limits/src/stores/generator.ts
@@ -1,0 +1,12 @@
+import { Generator } from '@commercetools-test-data/core';
+import type { TStoreLimitsProjection } from './types';
+
+const generator = Generator<TStoreLimitsProjection>({
+  fields: {
+    total: null,
+    inventorySupplyChannels: null,
+    productDistributionChannels: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/stores/index.ts
+++ b/models/platform-limits/src/stores/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/stores/presets/index.ts
+++ b/models/platform-limits/src/stores/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/stores/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/stores/presets/with-limit-and-current.ts
@@ -1,0 +1,11 @@
+import * as Limit from '../../limit';
+import * as LimitWithCurrent from '../../limit-with-current';
+import StoresPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  StoresPlatformLimits()
+    .total(LimitWithCurrent.random())
+    .inventorySupplyChannels(Limit.random())
+    .productDistributionChannels(Limit.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/stores/transformers.ts
+++ b/models/platform-limits/src/stores/transformers.ts
@@ -1,0 +1,29 @@
+import { Transformer } from '@commercetools-test-data/core';
+import { TStoreLimitsProjection, TStoreLimitsProjectionGraphql } from './types';
+
+const buildFields: (keyof TStoreLimitsProjection)[] = [
+  'total',
+  'inventorySupplyChannels',
+  'productDistributionChannels',
+];
+
+const transformers = {
+  default: Transformer<TStoreLimitsProjection, TStoreLimitsProjection>(
+    'default',
+    { buildFields }
+  ),
+  rest: Transformer<TStoreLimitsProjection, TStoreLimitsProjection>('rest', {
+    buildFields,
+  }),
+  graphql: Transformer<TStoreLimitsProjection, TStoreLimitsProjectionGraphql>(
+    'graphql',
+    {
+      buildFields,
+      addFields: () => ({
+        __typename: 'StoreLimitsProjection',
+      }),
+    }
+  ),
+};
+
+export default transformers;

--- a/models/platform-limits/src/stores/types.ts
+++ b/models/platform-limits/src/stores/types.ts
@@ -1,0 +1,17 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimit } from '../limit';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TStoreLimitsProjection = {
+  inventorySupplyChannels: TLimit;
+  productDistributionChannels: TLimit;
+  total: TLimitWithCurrent;
+};
+
+export type TStoreLimitsProjectionGraphql = TStoreLimitsProjection & {
+  __typename: 'StoreLimitsProjection';
+};
+
+export type TStoreLimitsProjectionBuilder = TBuilder<TStoreLimitsProjection>;
+export type TCreateStoreLimitsProjectionBuilder =
+  () => TStoreLimitsProjectionBuilder;

--- a/models/platform-limits/src/tax-categories/builder.spec.ts
+++ b/models/platform-limits/src/tax-categories/builder.spec.ts
@@ -1,0 +1,50 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TTaxCategoryLimitsProjection } from './types';
+import * as TaxCategoryLimitsProjection from './index';
+
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TTaxCategoryLimitsProjection,
+      TTaxCategoryLimitsProjection
+    >(
+      'default',
+      TaxCategoryLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        total: expectedLimitWithCurrent,
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TTaxCategoryLimitsProjection,
+      TTaxCategoryLimitsProjection
+    >(
+      'rest',
+      TaxCategoryLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        total: expectedLimitWithCurrent,
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TTaxCategoryLimitsProjection,
+      TTaxCategoryLimitsProjection
+    >(
+      'graphql',
+      TaxCategoryLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        total: expectedLimitWithCurrent,
+        __typename: 'TaxCategoryLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/tax-categories/builder.ts
+++ b/models/platform-limits/src/tax-categories/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TTaxCategoryLimitsProjection,
+  TCreateTaxCategoryLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateTaxCategoryLimitsProjectionBuilder = () =>
+  Builder<TTaxCategoryLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/tax-categories/generator.ts
+++ b/models/platform-limits/src/tax-categories/generator.ts
@@ -1,0 +1,10 @@
+import { Generator } from '@commercetools-test-data/core';
+import type { TTaxCategoryLimitsProjection } from './types';
+
+const generator = Generator<TTaxCategoryLimitsProjection>({
+  fields: {
+    total: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/tax-categories/index.ts
+++ b/models/platform-limits/src/tax-categories/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/tax-categories/presets/index.ts
+++ b/models/platform-limits/src/tax-categories/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/tax-categories/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/tax-categories/presets/with-limit-and-current.ts
@@ -1,0 +1,7 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import TaxCategoriesPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  TaxCategoriesPlatformLimits().total(LimitWithCurrent.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/tax-categories/transformers.ts
+++ b/models/platform-limits/src/tax-categories/transformers.ts
@@ -1,0 +1,31 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TTaxCategoryLimitsProjection,
+  TTaxCategoryLimitsProjectionGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<
+    TTaxCategoryLimitsProjection,
+    TTaxCategoryLimitsProjection
+  >('default', {
+    buildFields: ['total'],
+  }),
+  rest: Transformer<TTaxCategoryLimitsProjection, TTaxCategoryLimitsProjection>(
+    'rest',
+    {
+      buildFields: ['total'],
+    }
+  ),
+  graphql: Transformer<
+    TTaxCategoryLimitsProjection,
+    TTaxCategoryLimitsProjectionGraphql
+  >('graphql', {
+    buildFields: ['total'],
+    addFields: () => ({
+      __typename: 'TaxCategoryLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/tax-categories/types.ts
+++ b/models/platform-limits/src/tax-categories/types.ts
@@ -1,0 +1,16 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TTaxCategoryLimitsProjection = {
+  total: TLimitWithCurrent;
+};
+
+export type TTaxCategoryLimitsProjectionGraphql =
+  TTaxCategoryLimitsProjection & {
+    __typename: 'TaxCategoryLimitsProjection';
+  };
+
+export type TTaxCategoryLimitsProjectionBuilder =
+  TBuilder<TTaxCategoryLimitsProjection>;
+export type TCreateTaxCategoryLimitsProjectionBuilder =
+  () => TTaxCategoryLimitsProjectionBuilder;

--- a/models/platform-limits/src/zones/builder.spec.ts
+++ b/models/platform-limits/src/zones/builder.spec.ts
@@ -1,0 +1,42 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TZoneLimitsProjection } from './types';
+import * as ZoneLimitsProjection from './index';
+
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<TZoneLimitsProjection, TZoneLimitsProjection>(
+      'default',
+      ZoneLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        total: expectedLimitWithCurrent,
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TZoneLimitsProjection, TZoneLimitsProjection>(
+      'rest',
+      ZoneLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        total: expectedLimitWithCurrent,
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TZoneLimitsProjection, TZoneLimitsProjection>(
+      'graphql',
+      ZoneLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining({
+        total: expectedLimitWithCurrent,
+
+        __typename: 'ZoneLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/zones/builder.ts
+++ b/models/platform-limits/src/zones/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TZoneLimitsProjection,
+  TCreateZoneLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateZoneLimitsProjectionBuilder = () =>
+  Builder<TZoneLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/zones/generator.ts
+++ b/models/platform-limits/src/zones/generator.ts
@@ -1,0 +1,10 @@
+import { Generator } from '@commercetools-test-data/core';
+import type { TZoneLimitsProjection } from './types';
+
+const generator = Generator<TZoneLimitsProjection>({
+  fields: {
+    total: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/zones/index.ts
+++ b/models/platform-limits/src/zones/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/zones/presets/index.ts
+++ b/models/platform-limits/src/zones/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/zones/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/zones/presets/with-limit-and-current.ts
@@ -1,0 +1,7 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import ZonesPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  ZonesPlatformLimits().total(LimitWithCurrent.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/zones/transformers.ts
+++ b/models/platform-limits/src/zones/transformers.ts
@@ -1,0 +1,25 @@
+import { Transformer } from '@commercetools-test-data/core';
+import { TZoneLimitsProjection, TZoneLimitsProjectionGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TZoneLimitsProjection, TZoneLimitsProjection>(
+    'default',
+    {
+      buildFields: ['total'],
+    }
+  ),
+  rest: Transformer<TZoneLimitsProjection, TZoneLimitsProjection>('rest', {
+    buildFields: ['total'],
+  }),
+  graphql: Transformer<TZoneLimitsProjection, TZoneLimitsProjectionGraphql>(
+    'graphql',
+    {
+      buildFields: ['total'],
+      addFields: () => ({
+        __typename: 'ZoneLimitsProjection',
+      }),
+    }
+  ),
+};
+
+export default transformers;

--- a/models/platform-limits/src/zones/types.ts
+++ b/models/platform-limits/src/zones/types.ts
@@ -1,0 +1,14 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TZoneLimitsProjection = {
+  total: TLimitWithCurrent;
+};
+
+export type TZoneLimitsProjectionGraphql = TZoneLimitsProjection & {
+  __typename: 'ZoneLimitsProjection';
+};
+
+export type TZoneLimitsProjectionBuilder = TBuilder<TZoneLimitsProjection>;
+export type TCreateZoneLimitsProjectionBuilder =
+  () => TZoneLimitsProjectionBuilder;


### PR DESCRIPTION
### Summary

This is the 2nd PR in this series to add the `platform-limits` model. 

The models are copied from FE repo and few adjustment to `spec` file and `typescript` are done. The model covered in this PR are referred from this below code
- [cart-discounts](https://github.com/commercetools/merchant-center-frontend/tree/main/packages-shared/test-data/src/platform-limits/cart-discounts)
- [carts](https://github.com/commercetools/merchant-center-frontend/tree/main/packages-shared/test-data/src/platform-limits/carts) 
- [customers](https://github.com/commercetools/merchant-center-frontend/tree/main/packages-shared/test-data/src/platform-limits/customers)
- [customer-groups](https://github.com/commercetools/merchant-center-frontend/tree/main/packages-shared/test-data/src/platform-limits/customer-groups)