### PR TITLE
FEC-57: Add platform-limits model (Part 3)

### DIFF
--- a/.changeset/strong-eagles-smell.md
+++ b/.changeset/strong-eagles-smell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/platform-limits': minor
+---
+
+Add `PlatformLimit` test data model

--- a/models/platform-limits/README.md
+++ b/models/platform-limits/README.md
@@ -12,6 +12,251 @@ $ pnpm add -D @commercetools-test-data/platform-limits
 
 # Usage
 
-```ts
+- [BusinessUnitLimitsProjection](#businessunitlimitsprojection)<br>
+- [CartDiscountLimitsProjection](#cartdiscountlimitsprojection)<br>
+- [CartLimitsProjection](#cartlimitsprojection)<br>
+- [CustomerLimitsProjection](#customerlimitsprojection)<br>
+- [CustomerGroupLimitsProjection](#customergrouplimitsprojection)<br>
+- [PlatformLimits](#platformlimits)<br>
+- [LimitWithCurrent](#limitwithcurrent)<br>
+- [ProductDiscountLimitsProjection](#productdiscountlimitsprojection)<br>
+- [ShippingMethodLimitsProjection](#shippingmethodlimitsprojection)<br>
+- [ShoppingListLimitsProjection](#shoppinglistlimitsprojection)<br>
+- [StoreLimitsProjection](#storelimitsprojection)<br><br>
+- [TaxCategoryLimitsProjection](#taxcategorylimitsprojection)<br>
+- [ZoneLimitsProjection](#zonelimitsprojection)
 
+## `BusinessUnitLimitsProjection`
+
+```ts
+import {
+  BusinessUnitLimitsProjection,
+  type TBusinessUnitLimitsProjection,
+} from '@commercetools-test-data/product-type';
+
+const businessUnitLimitsProjection =
+  BusinessUnitLimitsProjection.random().build<TBusinessUnitLimitsProjection>();
+
+// Presets
+const BusinessUnitWithLimit = businessUnitLimitsProjection.presets
+  .withLimit()
+  .build<TBusinessUnitLimitsProjection>();
+```
+
+## `CartDiscountLimitsProjection`
+
+```ts
+import {
+  CartDiscountLimitsProjection,
+  type TCartDiscountLimitsProjection,
+} from '@commercetools-test-data/product-type';
+
+const cartDiscountLimitsProjection =
+  CartDiscountLimitsProjection.random().build<TCartDiscountLimitsProjection>();
+
+// Presets
+const cartDiscountLimitsProjectionWithLimitAndCurrent =
+  CartDiscountLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TCartDiscountLimitsProjection>();
+```
+
+## `CartLimitsProjection`
+
+```ts
+import {
+  CartLimitsProjection,
+  type TCartLimitsProjection,
+} from '@commercetools-test-data/product-type';
+
+const cartLimitsProjection =
+  CartLimitsProjection.random().build<TCartLimitsProjection>();
+
+// Presets
+const cartLimitsProjectionWithLimitAndCurrent = CartLimitsProjection.presets
+  .withLimitAndCurrent()
+  .build<TCartLimitsProjection>();
+```
+
+## `CustomerLimitsProjection`
+
+```ts
+import {
+  CustomerLimitsProjection,
+  type TCustomerLimitsProjection,
+} from '@commercetools-test-data/product-type';
+
+const customerLimitsProjection =
+  CustomerLimitsProjection.random().build<TCustomerLimitsProjection>();
+
+// Presets
+const customerLimitsProjectionWithLimitAndCurrent =
+  CustomerLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TCustomerLimitsProjection>();
+```
+
+## `CustomerGroupLimitsProjection`
+
+```ts
+import {
+  CustomerGroupLimitsProjection,
+  type TCustomerGroupLimitsProjection,
+} from '@commercetools-test-data/product-type';
+
+const customerGroupLimitsProjection =
+  CustomerGroupLimitsProjection.random().build<TCustomerGroupLimitsProjection>();
+
+// Presets
+const customerGroupLimitsProjectionWithLimitAndCurrent =
+  CustomerGroupLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TCustomerGroupLimitsProjection>();
+```
+
+## `PlatformLimits`
+
+```ts
+import {
+  PlatformLimits,
+  type TPlatformLimits,
+} from '@commercetools-test-data/product-type';
+
+const PlatformLimits = PlatformLimits.random().build<TPlatformLimits>();
+
+// Presets
+const PlatformLimitsWithLimitAndCurrent = PlatformLimits.presets
+  .withAllPlatformLimits()
+  .build<TPlatformLimits>();
+```
+
+## `LimitWithCurrent`
+
+```ts
+import {
+  LimitWithCurrent,
+  type TLimitWithCurrent,
+} from '@commercetools-test-data/product-type';
+
+const limitWithCurrent = LimitWithCurrent.random().build<TLimitWithCurrent>();
+
+// Presets
+const limitWithCurrentWithExceeded = LimitWithCurrent.presets
+  .withExceeded()
+  .build<TLimitWithCurrent>();
+const limitWithCurrentWithNonExceeded = LimitWithCurrent.presets
+  .withNonExceeded()
+  .build<TLimitWithCurrent>();
+const limitWithCurrentWithUndefined = LimitWithCurrent.presets
+  .withUndefined()
+  .build<TLimitWithCurrent>();
+const limitWithCurrentWithWarningExceeded = LimitWithCurrent.presets
+  .withWarningExceeded()
+  .build<TLimitWithCurrent>();
+```
+
+## `ProductDiscountLimitsProjection`
+
+```ts
+import {
+  ProductDiscountLimitsProjection,
+  type TProductDiscountLimitsProjection,
+} from '@commercetools-test-data/product-type';
+
+const productDiscountLimitsProjection =
+  ProductDiscountLimitsProjection.random().build<TProductDiscountLimitsProjection>();
+
+// Presets
+const productDiscountLimitsProjectionWithLimitAndCurrent =
+  ProductDiscountLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TProductDiscountLimitsProjection>();
+```
+
+## `ShippingMethodLimitsProjection`
+
+```ts
+import {
+  ShippingMethodLimitsProjection,
+  type TShippingMethodLimitsProjection,
+} from '@commercetools-test-data/product-type';
+
+const shippingMethodLimitsProjection =
+  ShippingMethodLimitsProjection.random().build<TShippingMethodLimitsProjection>();
+
+// Presets
+const shippingMethodLimitsProjectionWithLimitAndCurrent =
+  ShippingMethodLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TShippingMethodLimitsProjection>();
+```
+
+## `ShoppingListLimitsProjection`
+
+```ts
+import {
+  ShoppingListLimitsProjection,
+  type TShoppingListLimitsProjection,
+} from '@commercetools-test-data/product-type';
+
+const ShoppingListLimitsProjection =
+  ShoppingListLimitsProjection.random().build<TShoppingListLimitsProjection>();
+
+// Presets
+const ShoppingListLimitsProjectionWithLimitAndCurrent =
+  ShoppingListLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TShoppingListLimitsProjection>();
+```
+
+## `StoreLimitsProjection`
+
+```ts
+import {
+  StoreLimitsProjection,
+  type TStoreLimitsProjection,
+} from '@commercetools-test-data/product-type';
+
+const StoreLimitsProjection =
+  StoreLimitsProjection.random().build<TStoreLimitsProjection>();
+
+// Presets
+const StoreLimitsProjectionWithLimitAndCurrent = StoreLimitsProjection.presets
+  .withLimitAndCurrent()
+  .build<TStoreLimitsProjection>();
+```
+
+## `TaxCategoryLimitsProjection`
+
+```ts
+import {
+  TaxCategoryLimitsProjection,
+  type TTaxCategoryLimitsProjection,
+} from '@commercetools-test-data/product-type';
+
+const taxCategoryLimitsProjection =
+  TaxCategoryLimitsProjection.random().build<TTaxCategoryLimitsProjection>();
+
+// Presets
+const taxCategoryLimitsProjectionWithLimitAndCurrent =
+  TaxCategoryLimitsProjection.presets
+    .withLimitAndCurrent()
+    .build<TTaxCategoryLimitsProjection>();
+```
+
+## `ZoneLimitsProjection`
+
+```ts
+import {
+  ZoneLimitsProjection,
+  type TZoneLimitsProjection,
+} from '@commercetools-test-data/product-type';
+
+const zoneLimitsProjection =
+  ZoneLimitsProjection.random().build<TZoneLimitsProjection>();
+
+// Presets
+const zoneLimitsProjectionWithLimitAndCurrent = ZoneLimitsProjection.presets
+  .withLimitAndCurrent()
+  .build<TZoneLimitsProjection>();
 ```

--- a/models/platform-limits/README.md
+++ b/models/platform-limits/README.md
@@ -32,7 +32,7 @@ $ pnpm add -D @commercetools-test-data/platform-limits
 import {
   BusinessUnitLimitsProjection,
   type TBusinessUnitLimitsProjection,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const businessUnitLimitsProjection =
   BusinessUnitLimitsProjection.random().build<TBusinessUnitLimitsProjection>();
@@ -49,7 +49,7 @@ const BusinessUnitWithLimit = businessUnitLimitsProjection.presets
 import {
   CartDiscountLimitsProjection,
   type TCartDiscountLimitsProjection,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const cartDiscountLimitsProjection =
   CartDiscountLimitsProjection.random().build<TCartDiscountLimitsProjection>();
@@ -67,7 +67,7 @@ const cartDiscountLimitsProjectionWithLimitAndCurrent =
 import {
   CartLimitsProjection,
   type TCartLimitsProjection,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const cartLimitsProjection =
   CartLimitsProjection.random().build<TCartLimitsProjection>();
@@ -84,7 +84,7 @@ const cartLimitsProjectionWithLimitAndCurrent = CartLimitsProjection.presets
 import {
   CustomerLimitsProjection,
   type TCustomerLimitsProjection,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const customerLimitsProjection =
   CustomerLimitsProjection.random().build<TCustomerLimitsProjection>();
@@ -102,7 +102,7 @@ const customerLimitsProjectionWithLimitAndCurrent =
 import {
   CustomerGroupLimitsProjection,
   type TCustomerGroupLimitsProjection,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const customerGroupLimitsProjection =
   CustomerGroupLimitsProjection.random().build<TCustomerGroupLimitsProjection>();
@@ -120,7 +120,7 @@ const customerGroupLimitsProjectionWithLimitAndCurrent =
 import {
   PlatformLimits,
   type TPlatformLimits,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const PlatformLimits = PlatformLimits.random().build<TPlatformLimits>();
 
@@ -136,7 +136,7 @@ const PlatformLimitsWithLimitAndCurrent = PlatformLimits.presets
 import {
   LimitWithCurrent,
   type TLimitWithCurrent,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const limitWithCurrent = LimitWithCurrent.random().build<TLimitWithCurrent>();
 
@@ -161,7 +161,7 @@ const limitWithCurrentWithWarningExceeded = LimitWithCurrent.presets
 import {
   ProductDiscountLimitsProjection,
   type TProductDiscountLimitsProjection,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const productDiscountLimitsProjection =
   ProductDiscountLimitsProjection.random().build<TProductDiscountLimitsProjection>();
@@ -179,7 +179,7 @@ const productDiscountLimitsProjectionWithLimitAndCurrent =
 import {
   ShippingMethodLimitsProjection,
   type TShippingMethodLimitsProjection,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const shippingMethodLimitsProjection =
   ShippingMethodLimitsProjection.random().build<TShippingMethodLimitsProjection>();
@@ -197,7 +197,7 @@ const shippingMethodLimitsProjectionWithLimitAndCurrent =
 import {
   ShoppingListLimitsProjection,
   type TShoppingListLimitsProjection,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const ShoppingListLimitsProjection =
   ShoppingListLimitsProjection.random().build<TShoppingListLimitsProjection>();
@@ -215,7 +215,7 @@ const ShoppingListLimitsProjectionWithLimitAndCurrent =
 import {
   StoreLimitsProjection,
   type TStoreLimitsProjection,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const StoreLimitsProjection =
   StoreLimitsProjection.random().build<TStoreLimitsProjection>();
@@ -232,7 +232,7 @@ const StoreLimitsProjectionWithLimitAndCurrent = StoreLimitsProjection.presets
 import {
   TaxCategoryLimitsProjection,
   type TTaxCategoryLimitsProjection,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const taxCategoryLimitsProjection =
   TaxCategoryLimitsProjection.random().build<TTaxCategoryLimitsProjection>();
@@ -250,7 +250,7 @@ const taxCategoryLimitsProjectionWithLimitAndCurrent =
 import {
   ZoneLimitsProjection,
   type TZoneLimitsProjection,
-} from '@commercetools-test-data/product-type';
+} from '@commercetools-test-data/platform-limits';
 
 const zoneLimitsProjection =
   ZoneLimitsProjection.random().build<TZoneLimitsProjection>();

--- a/models/platform-limits/src/general/builder.spec.ts
+++ b/models/platform-limits/src/general/builder.spec.ts
@@ -1,0 +1,75 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TProjectCustomLimitsProjection } from './types';
+import * as ProjectCustomLimitsProjection from './index';
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TProjectCustomLimitsProjection,
+      TProjectCustomLimitsProjection
+    >(
+      'default',
+      ProjectCustomLimitsProjection.random(),
+      expect.objectContaining({
+        customers: expect.any(Object),
+        customerGroups: expect.any(Object),
+        zones: expect.any(Object),
+        taxCategories: expect.any(Object),
+        shippingMethods: expect.any(Object),
+        productDiscounts: expect.any(Object),
+        cartDiscounts: expect.any(Object),
+        stores: expect.any(Object),
+        carts: expect.any(Object),
+        shoppingLists: expect.any(Object),
+        businessUnits: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TProjectCustomLimitsProjection,
+      TProjectCustomLimitsProjection
+    >(
+      'rest',
+      ProjectCustomLimitsProjection.random(),
+      expect.objectContaining({
+        customers: expect.any(Object),
+        customerGroups: expect.any(Object),
+        zones: expect.any(Object),
+        taxCategories: expect.any(Object),
+        shippingMethods: expect.any(Object),
+        productDiscounts: expect.any(Object),
+        cartDiscounts: expect.any(Object),
+        stores: expect.any(Object),
+        carts: expect.any(Object),
+        shoppingLists: expect.any(Object),
+        businessUnits: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TProjectCustomLimitsProjection,
+      TProjectCustomLimitsProjection
+    >(
+      'graphql',
+      ProjectCustomLimitsProjection.random(),
+      expect.objectContaining({
+        customers: expect.any(Object),
+        customerGroups: expect.any(Object),
+        zones: expect.any(Object),
+        taxCategories: expect.any(Object),
+        shippingMethods: expect.any(Object),
+        productDiscounts: expect.any(Object),
+        cartDiscounts: expect.any(Object),
+        stores: expect.any(Object),
+        carts: expect.any(Object),
+        shoppingLists: expect.any(Object),
+        businessUnits: expect.any(Object),
+        __typename: 'ProjectCustomLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/general/builder.spec.ts
+++ b/models/platform-limits/src/general/builder.spec.ts
@@ -4,6 +4,57 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TProjectCustomLimitsProjection } from './types';
 import * as ProjectCustomLimitsProjection from './index';
 
+const expectedLimit = expect.objectContaining({
+  limit: expect.any(Number),
+});
+
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
+const expectedResult = {
+  customers: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  customerGroups: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  zones: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  taxCategories: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  shippingMethods: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  productDiscounts: expect.objectContaining({
+    totalActive: expectedLimitWithCurrent,
+  }),
+  cartDiscounts: expect.objectContaining({
+    totalActiveWithoutDiscountCodes: expectedLimitWithCurrent,
+  }),
+  stores: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+    inventorySupplyChannels: expectedLimit,
+    productDistributionChannels: expectedLimit,
+  }),
+  carts: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+  }),
+  shoppingLists: expect.objectContaining({
+    total: expectedLimitWithCurrent,
+    lineItems: expectedLimit,
+    textLineItems: expectedLimit,
+  }),
+  businessUnits: expect.objectContaining({
+    maxDivisions: expectedLimit,
+    maxDepthLimit: expectedLimit,
+    maxAssociates: expectedLimit,
+    maxAssociateRoles: expectedLimit,
+  }),
+};
 describe('building', () => {
   it(
     ...createBuilderSpec<
@@ -11,20 +62,8 @@ describe('building', () => {
       TProjectCustomLimitsProjection
     >(
       'default',
-      ProjectCustomLimitsProjection.random(),
-      expect.objectContaining({
-        customers: expect.any(Object),
-        customerGroups: expect.any(Object),
-        zones: expect.any(Object),
-        taxCategories: expect.any(Object),
-        shippingMethods: expect.any(Object),
-        productDiscounts: expect.any(Object),
-        cartDiscounts: expect.any(Object),
-        stores: expect.any(Object),
-        carts: expect.any(Object),
-        shoppingLists: expect.any(Object),
-        businessUnits: expect.any(Object),
-      })
+      ProjectCustomLimitsProjection.presets.withAllPlatformLimits(),
+      expect.objectContaining(expectedResult)
     )
   );
   it(
@@ -33,20 +72,8 @@ describe('building', () => {
       TProjectCustomLimitsProjection
     >(
       'rest',
-      ProjectCustomLimitsProjection.random(),
-      expect.objectContaining({
-        customers: expect.any(Object),
-        customerGroups: expect.any(Object),
-        zones: expect.any(Object),
-        taxCategories: expect.any(Object),
-        shippingMethods: expect.any(Object),
-        productDiscounts: expect.any(Object),
-        cartDiscounts: expect.any(Object),
-        stores: expect.any(Object),
-        carts: expect.any(Object),
-        shoppingLists: expect.any(Object),
-        businessUnits: expect.any(Object),
-      })
+      ProjectCustomLimitsProjection.presets.withAllPlatformLimits(),
+      expect.objectContaining(expectedResult)
     )
   );
   it(
@@ -55,19 +82,9 @@ describe('building', () => {
       TProjectCustomLimitsProjection
     >(
       'graphql',
-      ProjectCustomLimitsProjection.random(),
+      ProjectCustomLimitsProjection.presets.withAllPlatformLimits(),
       expect.objectContaining({
-        customers: expect.any(Object),
-        customerGroups: expect.any(Object),
-        zones: expect.any(Object),
-        taxCategories: expect.any(Object),
-        shippingMethods: expect.any(Object),
-        productDiscounts: expect.any(Object),
-        cartDiscounts: expect.any(Object),
-        stores: expect.any(Object),
-        carts: expect.any(Object),
-        shoppingLists: expect.any(Object),
-        businessUnits: expect.any(Object),
+        ...expectedResult,
         __typename: 'ProjectCustomLimitsProjection',
       })
     )

--- a/models/platform-limits/src/general/builder.ts
+++ b/models/platform-limits/src/general/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TProjectCustomLimitsProjection,
+  TCreateProjectCustomLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateProjectCustomLimitsProjectionBuilder = () =>
+  Builder<TProjectCustomLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/general/generator.ts
+++ b/models/platform-limits/src/general/generator.ts
@@ -1,0 +1,33 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TProjectCustomLimitsProjection } from './types';
+
+/**
+ * customers -  reference to customersPlatformLimits ,
+ * customerGroups -  reference to customerGroupsPlatformLimits ,
+ * zones -  reference to zonesPlatformLimits ,
+ * taxCategories -  reference to taxCategoriesPlatformLimits ,
+ * shippingMethods -  reference to shippingMethodsPlatformLimits ,
+ * productDiscounts -  reference to productDiscountsPlatformLimits ,
+ * cartDiscounts -  reference to cartDiscountsPlatformLimits ,
+ * stores -  reference to storesPlatformLimits ,
+ * shoppingLists -  reference to shoppingListsPlatformLimits ,
+ * carts -  reference to cartsPlatformLimits ,
+ * businessUnits -  reference to businessUnitsPlatformLimits ,
+ */
+const generator = Generator<TProjectCustomLimitsProjection>({
+  fields: {
+    customers: null,
+    customerGroups: null,
+    zones: null,
+    taxCategories: null,
+    shippingMethods: null,
+    productDiscounts: null,
+    cartDiscounts: null,
+    stores: null,
+    shoppingLists: null,
+    carts: null,
+    businessUnits: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/general/generator.ts
+++ b/models/platform-limits/src/general/generator.ts
@@ -1,19 +1,6 @@
 import { Generator } from '@commercetools-test-data/core';
 import { TProjectCustomLimitsProjection } from './types';
 
-/**
- * customers -  reference to customersPlatformLimits ,
- * customerGroups -  reference to customerGroupsPlatformLimits ,
- * zones -  reference to zonesPlatformLimits ,
- * taxCategories -  reference to taxCategoriesPlatformLimits ,
- * shippingMethods -  reference to shippingMethodsPlatformLimits ,
- * productDiscounts -  reference to productDiscountsPlatformLimits ,
- * cartDiscounts -  reference to cartDiscountsPlatformLimits ,
- * stores -  reference to storesPlatformLimits ,
- * shoppingLists -  reference to shoppingListsPlatformLimits ,
- * carts -  reference to cartsPlatformLimits ,
- * businessUnits -  reference to businessUnitsPlatformLimits ,
- */
 const generator = Generator<TProjectCustomLimitsProjection>({
   fields: {
     customers: null,

--- a/models/platform-limits/src/general/index.ts
+++ b/models/platform-limits/src/general/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/general/presets/index.ts
+++ b/models/platform-limits/src/general/presets/index.ts
@@ -1,0 +1,5 @@
+import withAllPlatformLimits from './with-all-platform-limits';
+
+export default {
+  withAllPlatformLimits,
+};

--- a/models/platform-limits/src/general/presets/with-all-platform-limits.ts
+++ b/models/platform-limits/src/general/presets/with-all-platform-limits.ts
@@ -1,0 +1,78 @@
+import * as BusinessUnitsPlatformLimits from '../../business-units';
+import * as CartDiscountsPlatformLimits from '../../cart-discounts';
+import * as CartsPlatformLimits from '../../carts';
+import * as CustomerGroupsPlatformLimits from '../../customer-groups';
+import * as CustomersPlatformLimits from '../../customers';
+import * as Limit from '../../limit';
+import * as LimitWithCurrent from '../../limit-with-current';
+import * as ProductDiscountsPlatformLimits from '../../product-discounts';
+import * as ShippingMethodsPlatformLimits from '../../shipping-methods';
+import * as ShoppingListsPlatformLimits from '../../shopping-lists';
+import * as StoresPlatformLimits from '../../stores';
+import * as TaxCategoriesPlatformLimits from '../../tax-categories';
+import * as ZonesPlatformLimits from '../../zones';
+import PlatformLimits from '../builder';
+
+const withAllPlatformLimits = () =>
+  PlatformLimits()
+    .businessUnits(
+      BusinessUnitsPlatformLimits.random()
+        .maxAssociateRoles(Limit.random().limit(5))
+        .maxAssociates(Limit.random().limit(2000))
+        .maxDepthLimit(Limit.random().limit(5))
+        .maxDivisions(Limit.random().limit(4000))
+    )
+    .customers(
+      CustomersPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .customerGroups(
+      CustomerGroupsPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .zones(
+      ZonesPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .taxCategories(
+      TaxCategoriesPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .shippingMethods(
+      ShippingMethodsPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .productDiscounts(
+      ProductDiscountsPlatformLimits.random().totalActive(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .cartDiscounts(
+      CartDiscountsPlatformLimits.random().totalActiveWithoutDiscountCodes(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .stores(
+      StoresPlatformLimits.random()
+        .total(LimitWithCurrent.presets.withNonExceeded())
+        .inventorySupplyChannels(Limit.random())
+        .productDistributionChannels(Limit.random())
+    )
+    .carts(
+      CartsPlatformLimits.random().total(
+        LimitWithCurrent.presets.withNonExceeded()
+      )
+    )
+    .shoppingLists(
+      ShoppingListsPlatformLimits.random()
+        .total(LimitWithCurrent.presets.withNonExceeded())
+        .lineItems(Limit.random().limit(10))
+        .textLineItems(Limit.random().limit(10))
+    );
+
+export default withAllPlatformLimits;

--- a/models/platform-limits/src/general/transformers.ts
+++ b/models/platform-limits/src/general/transformers.ts
@@ -4,60 +4,38 @@ import {
   TProjectCustomLimitsProjectionGraphql,
 } from './types';
 
+const buildFields: (keyof TProjectCustomLimitsProjection)[] = [
+  'customers',
+  'customerGroups',
+  'zones',
+  'taxCategories',
+  'shippingMethods',
+  'productDiscounts',
+  'cartDiscounts',
+  'stores',
+  'shoppingLists',
+  'carts',
+  'businessUnits',
+];
+
 const transformers = {
   default: Transformer<
     TProjectCustomLimitsProjection,
     TProjectCustomLimitsProjection
   >('default', {
-    buildFields: [
-      'customers',
-      'customerGroups',
-      'zones',
-      'taxCategories',
-      'shippingMethods',
-      'productDiscounts',
-      'cartDiscounts',
-      'stores',
-      'shoppingLists',
-      'carts',
-      'businessUnits',
-    ],
+    buildFields,
   }),
   rest: Transformer<
     TProjectCustomLimitsProjection,
     TProjectCustomLimitsProjection
   >('rest', {
-    buildFields: [
-      'customers',
-      'customerGroups',
-      'zones',
-      'taxCategories',
-      'shippingMethods',
-      'productDiscounts',
-      'cartDiscounts',
-      'stores',
-      'shoppingLists',
-      'carts',
-      'businessUnits',
-    ],
+    buildFields,
   }),
   graphql: Transformer<
     TProjectCustomLimitsProjection,
     TProjectCustomLimitsProjectionGraphql
   >('graphql', {
-    buildFields: [
-      'customers',
-      'customerGroups',
-      'zones',
-      'taxCategories',
-      'shippingMethods',
-      'productDiscounts',
-      'cartDiscounts',
-      'stores',
-      'shoppingLists',
-      'carts',
-      'businessUnits',
-    ],
+    buildFields,
     addFields: () => ({
       __typename: 'ProjectCustomLimitsProjection',
     }),

--- a/models/platform-limits/src/general/transformers.ts
+++ b/models/platform-limits/src/general/transformers.ts
@@ -1,0 +1,67 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TProjectCustomLimitsProjection,
+  TProjectCustomLimitsProjectionGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<
+    TProjectCustomLimitsProjection,
+    TProjectCustomLimitsProjection
+  >('default', {
+    buildFields: [
+      'customers',
+      'customerGroups',
+      'zones',
+      'taxCategories',
+      'shippingMethods',
+      'productDiscounts',
+      'cartDiscounts',
+      'stores',
+      'shoppingLists',
+      'carts',
+      'businessUnits',
+    ],
+  }),
+  rest: Transformer<
+    TProjectCustomLimitsProjection,
+    TProjectCustomLimitsProjection
+  >('rest', {
+    buildFields: [
+      'customers',
+      'customerGroups',
+      'zones',
+      'taxCategories',
+      'shippingMethods',
+      'productDiscounts',
+      'cartDiscounts',
+      'stores',
+      'shoppingLists',
+      'carts',
+      'businessUnits',
+    ],
+  }),
+  graphql: Transformer<
+    TProjectCustomLimitsProjection,
+    TProjectCustomLimitsProjectionGraphql
+  >('graphql', {
+    buildFields: [
+      'customers',
+      'customerGroups',
+      'zones',
+      'taxCategories',
+      'shippingMethods',
+      'productDiscounts',
+      'cartDiscounts',
+      'stores',
+      'shoppingLists',
+      'carts',
+      'businessUnits',
+    ],
+    addFields: () => ({
+      __typename: 'ProjectCustomLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/general/types.ts
+++ b/models/platform-limits/src/general/types.ts
@@ -1,0 +1,38 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type {
+  TCustomerLimitsProjection,
+  TCustomerGroupLimitsProjection,
+  TZoneLimitsProjection,
+  TTaxCategoryLimitsProjection,
+  TShippingMethodLimitsProjection,
+  TProductDiscountLimitsProjection,
+  TCartDiscountLimitsProjection,
+  TStoreLimitsProjection,
+  TShoppingListLimitsProjection,
+  TCartLimitsProjection,
+  TBusinessUnitLimitsProjection,
+} from '../index';
+
+export type TProjectCustomLimitsProjection = {
+  customers: TCustomerLimitsProjection;
+  customerGroups: TCustomerGroupLimitsProjection;
+  zones: TZoneLimitsProjection;
+  taxCategories: TTaxCategoryLimitsProjection;
+  shippingMethods: TShippingMethodLimitsProjection;
+  productDiscounts: TProductDiscountLimitsProjection;
+  cartDiscounts: TCartDiscountLimitsProjection;
+  stores: TStoreLimitsProjection;
+  shoppingLists: TShoppingListLimitsProjection;
+  carts: TCartLimitsProjection;
+  businessUnits: TBusinessUnitLimitsProjection;
+};
+
+export type TProjectCustomLimitsProjectionGraphql =
+  TProjectCustomLimitsProjection & {
+    __typename: 'ProjectCustomLimitsProjection';
+  };
+
+export type TProjectCustomLimitsProjectionBuilder =
+  TBuilder<TProjectCustomLimitsProjection>;
+export type TCreateProjectCustomLimitsProjectionBuilder =
+  () => TProjectCustomLimitsProjectionBuilder;

--- a/models/platform-limits/src/index.ts
+++ b/models/platform-limits/src/index.ts
@@ -4,7 +4,14 @@ export * from './cart-discounts/types';
 export * from './carts/types';
 export * from './customers/types';
 export * from './customer-groups/types';
+export * from './general/types';
 export * from './limit-with-current/types';
+export * from './product-discounts/types';
+export * from './shipping-methods/types';
+export * from './shopping-lists/types';
+export * from './stores/types';
+export * from './tax-categories/types';
+export * from './zones/types';
 
 // Export models
 export * as BusinessUnitLimitsProjection from './business-units';
@@ -12,4 +19,11 @@ export * as CartDiscountLimitsProjection from './cart-discounts';
 export * as CartLimitsProjection from './carts';
 export * as CustomerLimitsProjection from './customers';
 export * as CustomerGroupLimitsProjection from './customer-groups';
+export * as PlatformLimits from './general';
 export * as LimitWithCurrent from './limit-with-current';
+export * as ProductDiscountLimitsProjection from './product-discounts';
+export * as ShippingMethodLimitsProjection from './shipping-methods';
+export * as ShoppingListLimitsProjection from './shopping-lists';
+export * as StoreLimitsProjection from './stores';
+export * as TaxCategoryLimitsProjection from './tax-categories';
+export * as ZoneLimitsProjection from './zones';

--- a/models/platform-limits/src/product-discounts/builder.spec.ts
+++ b/models/platform-limits/src/product-discounts/builder.spec.ts
@@ -1,0 +1,45 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TProductDiscountLimitsProjection } from './types';
+import * as ProductDiscountLimitsProjection from './index';
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TProductDiscountLimitsProjection,
+      TProductDiscountLimitsProjection
+    >(
+      'default',
+      ProductDiscountLimitsProjection.random(),
+      expect.objectContaining({
+        totalActive: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TProductDiscountLimitsProjection,
+      TProductDiscountLimitsProjection
+    >(
+      'rest',
+      ProductDiscountLimitsProjection.random(),
+      expect.objectContaining({
+        totalActive: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TProductDiscountLimitsProjection,
+      TProductDiscountLimitsProjection
+    >(
+      'graphql',
+      ProductDiscountLimitsProjection.random(),
+      expect.objectContaining({
+        totalActive: expect.any(Object),
+        __typename: 'ProductDiscountLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/product-discounts/builder.spec.ts
+++ b/models/platform-limits/src/product-discounts/builder.spec.ts
@@ -4,6 +4,11 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TProductDiscountLimitsProjection } from './types';
 import * as ProductDiscountLimitsProjection from './index';
 
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
 describe('building', () => {
   it(
     ...createBuilderSpec<
@@ -11,9 +16,9 @@ describe('building', () => {
       TProductDiscountLimitsProjection
     >(
       'default',
-      ProductDiscountLimitsProjection.random(),
+      ProductDiscountLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        totalActive: expect.any(Object),
+        totalActive: expectedLimitWithCurrent,
       })
     )
   );
@@ -23,9 +28,9 @@ describe('building', () => {
       TProductDiscountLimitsProjection
     >(
       'rest',
-      ProductDiscountLimitsProjection.random(),
+      ProductDiscountLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        totalActive: expect.any(Object),
+        totalActive: expectedLimitWithCurrent,
       })
     )
   );
@@ -35,9 +40,9 @@ describe('building', () => {
       TProductDiscountLimitsProjection
     >(
       'graphql',
-      ProductDiscountLimitsProjection.random(),
+      ProductDiscountLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        totalActive: expect.any(Object),
+        totalActive: expectedLimitWithCurrent,
         __typename: 'ProductDiscountLimitsProjection',
       })
     )

--- a/models/platform-limits/src/product-discounts/builder.ts
+++ b/models/platform-limits/src/product-discounts/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TProductDiscountLimitsProjection,
+  TCreateProductDiscountLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateProductDiscountLimitsProjectionBuilder = () =>
+  Builder<TProductDiscountLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/product-discounts/generator.ts
+++ b/models/platform-limits/src/product-discounts/generator.ts
@@ -1,0 +1,13 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TProductDiscountLimitsProjection } from './types';
+
+/**
+ * total - reference to LimitWithCurrent
+ */
+const generator = Generator<TProductDiscountLimitsProjection>({
+  fields: {
+    totalActive: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/product-discounts/generator.ts
+++ b/models/platform-limits/src/product-discounts/generator.ts
@@ -1,9 +1,6 @@
 import { Generator } from '@commercetools-test-data/core';
 import { TProductDiscountLimitsProjection } from './types';
 
-/**
- * total - reference to LimitWithCurrent
- */
 const generator = Generator<TProductDiscountLimitsProjection>({
   fields: {
     totalActive: null,

--- a/models/platform-limits/src/product-discounts/index.ts
+++ b/models/platform-limits/src/product-discounts/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/product-discounts/presets/index.ts
+++ b/models/platform-limits/src/product-discounts/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/product-discounts/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/product-discounts/presets/with-limit-and-current.ts
@@ -1,0 +1,7 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import ProductDiscountsPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  ProductDiscountsPlatformLimits().totalActive(LimitWithCurrent.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/product-discounts/transformers.ts
+++ b/models/platform-limits/src/product-discounts/transformers.ts
@@ -1,0 +1,31 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TProductDiscountLimitsProjection,
+  TProductDiscountLimitsProjectionGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<
+    TProductDiscountLimitsProjection,
+    TProductDiscountLimitsProjection
+  >('default', {
+    buildFields: ['totalActive'],
+  }),
+  rest: Transformer<
+    TProductDiscountLimitsProjection,
+    TProductDiscountLimitsProjection
+  >('rest', {
+    buildFields: ['totalActive'],
+  }),
+  graphql: Transformer<
+    TProductDiscountLimitsProjection,
+    TProductDiscountLimitsProjectionGraphql
+  >('graphql', {
+    buildFields: ['totalActive'],
+    addFields: () => ({
+      __typename: 'ProductDiscountLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/product-discounts/types.ts
+++ b/models/platform-limits/src/product-discounts/types.ts
@@ -1,0 +1,16 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TProductDiscountLimitsProjection = {
+  totalActive: TLimitWithCurrent;
+};
+
+export type TProductDiscountLimitsProjectionGraphql =
+  TProductDiscountLimitsProjection & {
+    __typename: 'ProductDiscountLimitsProjection';
+  };
+
+export type TProductDiscountLimitsProjectionBuilder =
+  TBuilder<TProductDiscountLimitsProjection>;
+export type TCreateProductDiscountLimitsProjectionBuilder =
+  () => TProductDiscountLimitsProjectionBuilder;

--- a/models/platform-limits/src/shipping-methods/builder.spec.ts
+++ b/models/platform-limits/src/shipping-methods/builder.spec.ts
@@ -4,6 +4,11 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TShippingMethodLimitsProjection } from './types';
 import * as ShippingMethodLimitsProjection from './index';
 
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
 describe('building', () => {
   it(
     ...createBuilderSpec<
@@ -11,9 +16,9 @@ describe('building', () => {
       TShippingMethodLimitsProjection
     >(
       'default',
-      ShippingMethodLimitsProjection.random(),
+      ShippingMethodLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
@@ -23,9 +28,9 @@ describe('building', () => {
       TShippingMethodLimitsProjection
     >(
       'rest',
-      ShippingMethodLimitsProjection.random(),
+      ShippingMethodLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
@@ -35,9 +40,9 @@ describe('building', () => {
       TShippingMethodLimitsProjection
     >(
       'graphql',
-      ShippingMethodLimitsProjection.random(),
+      ShippingMethodLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
         __typename: 'ShippingMethodLimitsProjection',
       })
     )

--- a/models/platform-limits/src/shipping-methods/builder.spec.ts
+++ b/models/platform-limits/src/shipping-methods/builder.spec.ts
@@ -1,0 +1,45 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TShippingMethodLimitsProjection } from './types';
+import * as ShippingMethodLimitsProjection from './index';
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TShippingMethodLimitsProjection,
+      TShippingMethodLimitsProjection
+    >(
+      'default',
+      ShippingMethodLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TShippingMethodLimitsProjection,
+      TShippingMethodLimitsProjection
+    >(
+      'rest',
+      ShippingMethodLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TShippingMethodLimitsProjection,
+      TShippingMethodLimitsProjection
+    >(
+      'graphql',
+      ShippingMethodLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+        __typename: 'ShippingMethodLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/shipping-methods/builder.ts
+++ b/models/platform-limits/src/shipping-methods/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TShippingMethodLimitsProjection,
+  TCreateShippingMethodLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateShippingMethodLimitsProjectionBuilder = () =>
+  Builder<TShippingMethodLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/shipping-methods/generator.ts
+++ b/models/platform-limits/src/shipping-methods/generator.ts
@@ -1,9 +1,6 @@
 import { Generator } from '@commercetools-test-data/core';
 import { TShippingMethodLimitsProjection } from './types';
 
-/**
- * total - reference to LimitWithCurrent
- */
 const generator = Generator<TShippingMethodLimitsProjection>({
   fields: {
     total: null,

--- a/models/platform-limits/src/shipping-methods/generator.ts
+++ b/models/platform-limits/src/shipping-methods/generator.ts
@@ -1,0 +1,13 @@
+import { Generator } from '@commercetools-test-data/core';
+import { TShippingMethodLimitsProjection } from './types';
+
+/**
+ * total - reference to LimitWithCurrent
+ */
+const generator = Generator<TShippingMethodLimitsProjection>({
+  fields: {
+    total: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/shipping-methods/index.ts
+++ b/models/platform-limits/src/shipping-methods/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/shipping-methods/presets/index.ts
+++ b/models/platform-limits/src/shipping-methods/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/shipping-methods/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/shipping-methods/presets/with-limit-and-current.ts
@@ -1,0 +1,7 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import ShippingMethodsPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  ShippingMethodsPlatformLimits().total(LimitWithCurrent.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/shipping-methods/transformers.ts
+++ b/models/platform-limits/src/shipping-methods/transformers.ts
@@ -1,0 +1,31 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TShippingMethodLimitsProjection,
+  TShippingMethodLimitsProjectionGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<
+    TShippingMethodLimitsProjection,
+    TShippingMethodLimitsProjection
+  >('default', {
+    buildFields: ['total'],
+  }),
+  rest: Transformer<
+    TShippingMethodLimitsProjection,
+    TShippingMethodLimitsProjection
+  >('rest', {
+    buildFields: ['total'],
+  }),
+  graphql: Transformer<
+    TShippingMethodLimitsProjection,
+    TShippingMethodLimitsProjectionGraphql
+  >('graphql', {
+    buildFields: ['total'],
+    addFields: () => ({
+      __typename: 'ShippingMethodLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/shipping-methods/types.ts
+++ b/models/platform-limits/src/shipping-methods/types.ts
@@ -1,0 +1,16 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TShippingMethodLimitsProjection = {
+  total: TLimitWithCurrent;
+};
+
+export type TShippingMethodLimitsProjectionGraphql =
+  TShippingMethodLimitsProjection & {
+    __typename: 'ShippingMethodLimitsProjection';
+  };
+
+export type TShippingMethodLimitsProjectionBuilder =
+  TBuilder<TShippingMethodLimitsProjection>;
+export type TCreateShippingMethodLimitsProjectionBuilder =
+  () => TShippingMethodLimitsProjectionBuilder;

--- a/models/platform-limits/src/shopping-lists/builder.spec.ts
+++ b/models/platform-limits/src/shopping-lists/builder.spec.ts
@@ -1,0 +1,51 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TShoppingListLimitsProjection } from './types';
+import * as ShoppingListLimitsProjection from './index';
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TShoppingListLimitsProjection,
+      TShoppingListLimitsProjection
+    >(
+      'default',
+      ShoppingListLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+        lineItems: expect.any(Object),
+        textLineItems: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TShoppingListLimitsProjection,
+      TShoppingListLimitsProjection
+    >(
+      'rest',
+      ShoppingListLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+        lineItems: expect.any(Object),
+        textLineItems: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TShoppingListLimitsProjection,
+      TShoppingListLimitsProjection
+    >(
+      'graphql',
+      ShoppingListLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+        lineItems: expect.any(Object),
+        textLineItems: expect.any(Object),
+        __typename: 'ShoppingListLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/shopping-lists/builder.spec.ts
+++ b/models/platform-limits/src/shopping-lists/builder.spec.ts
@@ -4,6 +4,21 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TShoppingListLimitsProjection } from './types';
 import * as ShoppingListLimitsProjection from './index';
 
+const expectedLimit = expect.objectContaining({
+  limit: expect.any(Number),
+});
+
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
+const expectedResult = {
+  total: expectedLimitWithCurrent,
+  lineItems: expectedLimit,
+  textLineItems: expectedLimit,
+};
+
 describe('building', () => {
   it(
     ...createBuilderSpec<
@@ -11,12 +26,8 @@ describe('building', () => {
       TShoppingListLimitsProjection
     >(
       'default',
-      ShoppingListLimitsProjection.random(),
-      expect.objectContaining({
-        total: expect.any(Object),
-        lineItems: expect.any(Object),
-        textLineItems: expect.any(Object),
-      })
+      ShoppingListLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining(expectedResult)
     )
   );
   it(
@@ -25,12 +36,8 @@ describe('building', () => {
       TShoppingListLimitsProjection
     >(
       'rest',
-      ShoppingListLimitsProjection.random(),
-      expect.objectContaining({
-        total: expect.any(Object),
-        lineItems: expect.any(Object),
-        textLineItems: expect.any(Object),
-      })
+      ShoppingListLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining(expectedResult)
     )
   );
   it(
@@ -39,11 +46,9 @@ describe('building', () => {
       TShoppingListLimitsProjection
     >(
       'graphql',
-      ShoppingListLimitsProjection.random(),
+      ShoppingListLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
-        lineItems: expect.any(Object),
-        textLineItems: expect.any(Object),
+        ...expectedResult,
         __typename: 'ShoppingListLimitsProjection',
       })
     )

--- a/models/platform-limits/src/shopping-lists/builder.ts
+++ b/models/platform-limits/src/shopping-lists/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TShoppingListLimitsProjection,
+  TCreateShoppingListLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateShoppingListLimitsProjectionBuilder = () =>
+  Builder<TShoppingListLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/shopping-lists/generator.ts
+++ b/models/platform-limits/src/shopping-lists/generator.ts
@@ -1,0 +1,16 @@
+import { Generator } from '@commercetools-test-data/core';
+import type { TShoppingListLimitsProjection } from './types';
+/**
+ * total - reference to LimitWithCurrent
+ * lineItems - reference to Limit
+ * textLineItems - reference to Limit
+ */
+const generator = Generator<TShoppingListLimitsProjection>({
+  fields: {
+    total: null,
+    lineItems: null,
+    textLineItems: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/shopping-lists/generator.ts
+++ b/models/platform-limits/src/shopping-lists/generator.ts
@@ -1,10 +1,6 @@
 import { Generator } from '@commercetools-test-data/core';
 import type { TShoppingListLimitsProjection } from './types';
-/**
- * total - reference to LimitWithCurrent
- * lineItems - reference to Limit
- * textLineItems - reference to Limit
- */
+
 const generator = Generator<TShoppingListLimitsProjection>({
   fields: {
     total: null,

--- a/models/platform-limits/src/shopping-lists/index.ts
+++ b/models/platform-limits/src/shopping-lists/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/shopping-lists/presets/index.ts
+++ b/models/platform-limits/src/shopping-lists/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/shopping-lists/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/shopping-lists/presets/with-limit-and-current.ts
@@ -1,0 +1,11 @@
+import * as Limit from '../../limit';
+import * as LimitWithCurrent from '../../limit-with-current';
+import ShoppingListsPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  ShoppingListsPlatformLimits()
+    .total(LimitWithCurrent.random())
+    .lineItems(Limit.random())
+    .textLineItems(Limit.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/shopping-lists/transformers.ts
+++ b/models/platform-limits/src/shopping-lists/transformers.ts
@@ -4,24 +4,30 @@ import {
   TShoppingListLimitsProjectionGraphql,
 } from './types';
 
+const buildFields: (keyof TShoppingListLimitsProjection)[] = [
+  'total',
+  'lineItems',
+  'textLineItems',
+];
+
 const transformers = {
   default: Transformer<
     TShoppingListLimitsProjection,
     TShoppingListLimitsProjection
   >('default', {
-    buildFields: ['total', 'lineItems', 'textLineItems'],
+    buildFields,
   }),
   rest: Transformer<
     TShoppingListLimitsProjection,
     TShoppingListLimitsProjection
   >('rest', {
-    buildFields: ['total', 'lineItems', 'textLineItems'],
+    buildFields,
   }),
   graphql: Transformer<
     TShoppingListLimitsProjection,
     TShoppingListLimitsProjectionGraphql
   >('graphql', {
-    buildFields: ['total', 'lineItems', 'textLineItems'],
+    buildFields,
     addFields: () => ({
       __typename: 'ShoppingListLimitsProjection',
     }),

--- a/models/platform-limits/src/shopping-lists/transformers.ts
+++ b/models/platform-limits/src/shopping-lists/transformers.ts
@@ -1,0 +1,31 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TShoppingListLimitsProjection,
+  TShoppingListLimitsProjectionGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<
+    TShoppingListLimitsProjection,
+    TShoppingListLimitsProjection
+  >('default', {
+    buildFields: ['total', 'lineItems', 'textLineItems'],
+  }),
+  rest: Transformer<
+    TShoppingListLimitsProjection,
+    TShoppingListLimitsProjection
+  >('rest', {
+    buildFields: ['total', 'lineItems', 'textLineItems'],
+  }),
+  graphql: Transformer<
+    TShoppingListLimitsProjection,
+    TShoppingListLimitsProjectionGraphql
+  >('graphql', {
+    buildFields: ['total', 'lineItems', 'textLineItems'],
+    addFields: () => ({
+      __typename: 'ShoppingListLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/shopping-lists/types.ts
+++ b/models/platform-limits/src/shopping-lists/types.ts
@@ -1,0 +1,19 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimit } from '../limit';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TShoppingListLimitsProjection = {
+  total: TLimitWithCurrent;
+  lineItems: TLimit;
+  textLineItems: TLimit;
+};
+
+export type TShoppingListLimitsProjectionGraphql =
+  TShoppingListLimitsProjection & {
+    __typename: 'ShoppingListLimitsProjection';
+  };
+
+export type TShoppingListLimitsProjectionBuilder =
+  TBuilder<TShoppingListLimitsProjection>;
+export type TCreateShoppingListLimitsProjectionBuilder =
+  () => TShoppingListLimitsProjectionBuilder;

--- a/models/platform-limits/src/stores/builder.spec.ts
+++ b/models/platform-limits/src/stores/builder.spec.ts
@@ -4,37 +4,42 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TStoreLimitsProjection } from './types';
 import * as StoreLimitsProjection from './index';
 
+const expectedLimit = expect.objectContaining({
+  limit: expect.any(Number),
+});
+
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
+const expectedResult = {
+  total: expectedLimitWithCurrent,
+  inventorySupplyChannels: expectedLimit,
+  productDistributionChannels: expectedLimit,
+};
+
 describe('building', () => {
   it(
     ...createBuilderSpec<TStoreLimitsProjection, TStoreLimitsProjection>(
       'default',
-      StoreLimitsProjection.random(),
-      expect.objectContaining({
-        total: expect.any(Object),
-        inventorySupplyChannels: expect.any(Object),
-        productDistributionChannels: expect.any(Object),
-      })
+      StoreLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining(expectedResult)
     )
   );
   it(
     ...createBuilderSpec<TStoreLimitsProjection, TStoreLimitsProjection>(
       'rest',
-      StoreLimitsProjection.random(),
-      expect.objectContaining({
-        total: expect.any(Object),
-        inventorySupplyChannels: expect.any(Object),
-        productDistributionChannels: expect.any(Object),
-      })
+      StoreLimitsProjection.presets.withLimitAndCurrent(),
+      expect.objectContaining(expectedResult)
     )
   );
   it(
     ...createBuilderSpec<TStoreLimitsProjection, TStoreLimitsProjection>(
       'graphql',
-      StoreLimitsProjection.random(),
+      StoreLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
-        inventorySupplyChannels: expect.any(Object),
-        productDistributionChannels: expect.any(Object),
+        ...expectedResult,
         __typename: 'StoreLimitsProjection',
       })
     )

--- a/models/platform-limits/src/stores/builder.spec.ts
+++ b/models/platform-limits/src/stores/builder.spec.ts
@@ -1,0 +1,42 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TStoreLimitsProjection } from './types';
+import * as StoreLimitsProjection from './index';
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<TStoreLimitsProjection, TStoreLimitsProjection>(
+      'default',
+      StoreLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+        inventorySupplyChannels: expect.any(Object),
+        productDistributionChannels: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TStoreLimitsProjection, TStoreLimitsProjection>(
+      'rest',
+      StoreLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+        inventorySupplyChannels: expect.any(Object),
+        productDistributionChannels: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TStoreLimitsProjection, TStoreLimitsProjection>(
+      'graphql',
+      StoreLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+        inventorySupplyChannels: expect.any(Object),
+        productDistributionChannels: expect.any(Object),
+        __typename: 'StoreLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/stores/builder.ts
+++ b/models/platform-limits/src/stores/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TStoreLimitsProjection,
+  TCreateStoreLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateStoreLimitsProjectionBuilder = () =>
+  Builder<TStoreLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/stores/generator.ts
+++ b/models/platform-limits/src/stores/generator.ts
@@ -1,0 +1,14 @@
+import { Generator } from '@commercetools-test-data/core';
+import type { TStoreLimitsProjection } from './types';
+/**
+ * total - reference to LimitWithCurrent
+ */
+const generator = Generator<TStoreLimitsProjection>({
+  fields: {
+    total: null,
+    inventorySupplyChannels: null,
+    productDistributionChannels: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/stores/generator.ts
+++ b/models/platform-limits/src/stores/generator.ts
@@ -1,8 +1,6 @@
 import { Generator } from '@commercetools-test-data/core';
 import type { TStoreLimitsProjection } from './types';
-/**
- * total - reference to LimitWithCurrent
- */
+
 const generator = Generator<TStoreLimitsProjection>({
   fields: {
     total: null,

--- a/models/platform-limits/src/stores/index.ts
+++ b/models/platform-limits/src/stores/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/stores/presets/index.ts
+++ b/models/platform-limits/src/stores/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/stores/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/stores/presets/with-limit-and-current.ts
@@ -1,0 +1,11 @@
+import * as Limit from '../../limit';
+import * as LimitWithCurrent from '../../limit-with-current';
+import StoresPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  StoresPlatformLimits()
+    .total(LimitWithCurrent.random())
+    .inventorySupplyChannels(Limit.random())
+    .productDistributionChannels(Limit.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/stores/transformers.ts
+++ b/models/platform-limits/src/stores/transformers.ts
@@ -1,0 +1,37 @@
+import { Transformer } from '@commercetools-test-data/core';
+import { TStoreLimitsProjection, TStoreLimitsProjectionGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TStoreLimitsProjection, TStoreLimitsProjection>(
+    'default',
+    {
+      buildFields: [
+        'total',
+        'inventorySupplyChannels',
+        'productDistributionChannels',
+      ],
+    }
+  ),
+  rest: Transformer<TStoreLimitsProjection, TStoreLimitsProjection>('rest', {
+    buildFields: [
+      'total',
+      'inventorySupplyChannels',
+      'productDistributionChannels',
+    ],
+  }),
+  graphql: Transformer<TStoreLimitsProjection, TStoreLimitsProjectionGraphql>(
+    'graphql',
+    {
+      buildFields: [
+        'total',
+        'inventorySupplyChannels',
+        'productDistributionChannels',
+      ],
+      addFields: () => ({
+        __typename: 'StoreLimitsProjection',
+      }),
+    }
+  ),
+};
+
+export default transformers;

--- a/models/platform-limits/src/stores/transformers.ts
+++ b/models/platform-limits/src/stores/transformers.ts
@@ -1,32 +1,24 @@
 import { Transformer } from '@commercetools-test-data/core';
 import { TStoreLimitsProjection, TStoreLimitsProjectionGraphql } from './types';
 
+const buildFields: (keyof TStoreLimitsProjection)[] = [
+  'total',
+  'inventorySupplyChannels',
+  'productDistributionChannels',
+];
+
 const transformers = {
   default: Transformer<TStoreLimitsProjection, TStoreLimitsProjection>(
     'default',
-    {
-      buildFields: [
-        'total',
-        'inventorySupplyChannels',
-        'productDistributionChannels',
-      ],
-    }
+    { buildFields }
   ),
   rest: Transformer<TStoreLimitsProjection, TStoreLimitsProjection>('rest', {
-    buildFields: [
-      'total',
-      'inventorySupplyChannels',
-      'productDistributionChannels',
-    ],
+    buildFields,
   }),
   graphql: Transformer<TStoreLimitsProjection, TStoreLimitsProjectionGraphql>(
     'graphql',
     {
-      buildFields: [
-        'total',
-        'inventorySupplyChannels',
-        'productDistributionChannels',
-      ],
+      buildFields,
       addFields: () => ({
         __typename: 'StoreLimitsProjection',
       }),

--- a/models/platform-limits/src/stores/types.ts
+++ b/models/platform-limits/src/stores/types.ts
@@ -1,0 +1,17 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimit } from '../limit';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TStoreLimitsProjection = {
+  inventorySupplyChannels: TLimit;
+  productDistributionChannels: TLimit;
+  total: TLimitWithCurrent;
+};
+
+export type TStoreLimitsProjectionGraphql = TStoreLimitsProjection & {
+  __typename: 'StoreLimitsProjection';
+};
+
+export type TStoreLimitsProjectionBuilder = TBuilder<TStoreLimitsProjection>;
+export type TCreateStoreLimitsProjectionBuilder =
+  () => TStoreLimitsProjectionBuilder;

--- a/models/platform-limits/src/tax-categories/builder.spec.ts
+++ b/models/platform-limits/src/tax-categories/builder.spec.ts
@@ -4,6 +4,11 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TTaxCategoryLimitsProjection } from './types';
 import * as TaxCategoryLimitsProjection from './index';
 
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
 describe('building', () => {
   it(
     ...createBuilderSpec<
@@ -11,9 +16,9 @@ describe('building', () => {
       TTaxCategoryLimitsProjection
     >(
       'default',
-      TaxCategoryLimitsProjection.random(),
+      TaxCategoryLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
@@ -23,9 +28,9 @@ describe('building', () => {
       TTaxCategoryLimitsProjection
     >(
       'rest',
-      TaxCategoryLimitsProjection.random(),
+      TaxCategoryLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
@@ -35,10 +40,9 @@ describe('building', () => {
       TTaxCategoryLimitsProjection
     >(
       'graphql',
-      TaxCategoryLimitsProjection.random(),
+      TaxCategoryLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
-
+        total: expectedLimitWithCurrent,
         __typename: 'TaxCategoryLimitsProjection',
       })
     )

--- a/models/platform-limits/src/tax-categories/builder.spec.ts
+++ b/models/platform-limits/src/tax-categories/builder.spec.ts
@@ -1,0 +1,46 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TTaxCategoryLimitsProjection } from './types';
+import * as TaxCategoryLimitsProjection from './index';
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<
+      TTaxCategoryLimitsProjection,
+      TTaxCategoryLimitsProjection
+    >(
+      'default',
+      TaxCategoryLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TTaxCategoryLimitsProjection,
+      TTaxCategoryLimitsProjection
+    >(
+      'rest',
+      TaxCategoryLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TTaxCategoryLimitsProjection,
+      TTaxCategoryLimitsProjection
+    >(
+      'graphql',
+      TaxCategoryLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+
+        __typename: 'TaxCategoryLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/tax-categories/builder.ts
+++ b/models/platform-limits/src/tax-categories/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TTaxCategoryLimitsProjection,
+  TCreateTaxCategoryLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateTaxCategoryLimitsProjectionBuilder = () =>
+  Builder<TTaxCategoryLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/tax-categories/generator.ts
+++ b/models/platform-limits/src/tax-categories/generator.ts
@@ -1,8 +1,6 @@
 import { Generator } from '@commercetools-test-data/core';
 import type { TTaxCategoryLimitsProjection } from './types';
-/**
- * total - reference to LimitWithCurrent
- */
+
 const generator = Generator<TTaxCategoryLimitsProjection>({
   fields: {
     total: null,

--- a/models/platform-limits/src/tax-categories/generator.ts
+++ b/models/platform-limits/src/tax-categories/generator.ts
@@ -1,0 +1,12 @@
+import { Generator } from '@commercetools-test-data/core';
+import type { TTaxCategoryLimitsProjection } from './types';
+/**
+ * total - reference to LimitWithCurrent
+ */
+const generator = Generator<TTaxCategoryLimitsProjection>({
+  fields: {
+    total: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/tax-categories/index.ts
+++ b/models/platform-limits/src/tax-categories/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/tax-categories/presets/index.ts
+++ b/models/platform-limits/src/tax-categories/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/tax-categories/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/tax-categories/presets/with-limit-and-current.ts
@@ -1,0 +1,7 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import TaxCategoriesPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  TaxCategoriesPlatformLimits().total(LimitWithCurrent.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/tax-categories/transformers.ts
+++ b/models/platform-limits/src/tax-categories/transformers.ts
@@ -1,0 +1,31 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TTaxCategoryLimitsProjection,
+  TTaxCategoryLimitsProjectionGraphql,
+} from './types';
+
+const transformers = {
+  default: Transformer<
+    TTaxCategoryLimitsProjection,
+    TTaxCategoryLimitsProjection
+  >('default', {
+    buildFields: ['total'],
+  }),
+  rest: Transformer<TTaxCategoryLimitsProjection, TTaxCategoryLimitsProjection>(
+    'rest',
+    {
+      buildFields: ['total'],
+    }
+  ),
+  graphql: Transformer<
+    TTaxCategoryLimitsProjection,
+    TTaxCategoryLimitsProjectionGraphql
+  >('graphql', {
+    buildFields: ['total'],
+    addFields: () => ({
+      __typename: 'TaxCategoryLimitsProjection',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/platform-limits/src/tax-categories/types.ts
+++ b/models/platform-limits/src/tax-categories/types.ts
@@ -1,0 +1,16 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TTaxCategoryLimitsProjection = {
+  total: TLimitWithCurrent;
+};
+
+export type TTaxCategoryLimitsProjectionGraphql =
+  TTaxCategoryLimitsProjection & {
+    __typename: 'TaxCategoryLimitsProjection';
+  };
+
+export type TTaxCategoryLimitsProjectionBuilder =
+  TBuilder<TTaxCategoryLimitsProjection>;
+export type TCreateTaxCategoryLimitsProjectionBuilder =
+  () => TTaxCategoryLimitsProjectionBuilder;

--- a/models/platform-limits/src/zones/builder.spec.ts
+++ b/models/platform-limits/src/zones/builder.spec.ts
@@ -1,0 +1,37 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TZoneLimitsProjection } from './types';
+import * as ZoneLimitsProjection from './index';
+
+describe('building', () => {
+  it(
+    ...createBuilderSpec<TZoneLimitsProjection, TZoneLimitsProjection>(
+      'default',
+      ZoneLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TZoneLimitsProjection, TZoneLimitsProjection>(
+      'rest',
+      ZoneLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TZoneLimitsProjection, TZoneLimitsProjection>(
+      'graphql',
+      ZoneLimitsProjection.random(),
+      expect.objectContaining({
+        total: expect.any(Object),
+
+        __typename: 'ZoneLimitsProjection',
+      })
+    )
+  );
+});

--- a/models/platform-limits/src/zones/builder.spec.ts
+++ b/models/platform-limits/src/zones/builder.spec.ts
@@ -4,31 +4,36 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TZoneLimitsProjection } from './types';
 import * as ZoneLimitsProjection from './index';
 
+const expectedLimitWithCurrent = expect.objectContaining({
+  limit: expect.any(Number),
+  current: expect.any(Number),
+});
+
 describe('building', () => {
   it(
     ...createBuilderSpec<TZoneLimitsProjection, TZoneLimitsProjection>(
       'default',
-      ZoneLimitsProjection.random(),
+      ZoneLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
   it(
     ...createBuilderSpec<TZoneLimitsProjection, TZoneLimitsProjection>(
       'rest',
-      ZoneLimitsProjection.random(),
+      ZoneLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
       })
     )
   );
   it(
     ...createBuilderSpec<TZoneLimitsProjection, TZoneLimitsProjection>(
       'graphql',
-      ZoneLimitsProjection.random(),
+      ZoneLimitsProjection.presets.withLimitAndCurrent(),
       expect.objectContaining({
-        total: expect.any(Object),
+        total: expectedLimitWithCurrent,
 
         __typename: 'ZoneLimitsProjection',
       })

--- a/models/platform-limits/src/zones/builder.ts
+++ b/models/platform-limits/src/zones/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TZoneLimitsProjection,
+  TCreateZoneLimitsProjectionBuilder,
+} from './types';
+
+const Model: TCreateZoneLimitsProjectionBuilder = () =>
+  Builder<TZoneLimitsProjection>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/platform-limits/src/zones/generator.ts
+++ b/models/platform-limits/src/zones/generator.ts
@@ -1,8 +1,6 @@
 import { Generator } from '@commercetools-test-data/core';
 import type { TZoneLimitsProjection } from './types';
-/**
- * total - reference to LimitWithCurrent
- */
+
 const generator = Generator<TZoneLimitsProjection>({
   fields: {
     total: null,

--- a/models/platform-limits/src/zones/generator.ts
+++ b/models/platform-limits/src/zones/generator.ts
@@ -1,0 +1,12 @@
+import { Generator } from '@commercetools-test-data/core';
+import type { TZoneLimitsProjection } from './types';
+/**
+ * total - reference to LimitWithCurrent
+ */
+const generator = Generator<TZoneLimitsProjection>({
+  fields: {
+    total: null,
+  },
+});
+
+export default generator;

--- a/models/platform-limits/src/zones/index.ts
+++ b/models/platform-limits/src/zones/index.ts
@@ -1,0 +1,4 @@
+export { default as random } from './builder';
+export { default as presets } from './presets';
+
+export * from './types';

--- a/models/platform-limits/src/zones/presets/index.ts
+++ b/models/platform-limits/src/zones/presets/index.ts
@@ -1,0 +1,5 @@
+import withLimitAndCurrent from './with-limit-and-current';
+
+export default {
+  withLimitAndCurrent,
+};

--- a/models/platform-limits/src/zones/presets/with-limit-and-current.ts
+++ b/models/platform-limits/src/zones/presets/with-limit-and-current.ts
@@ -1,0 +1,7 @@
+import * as LimitWithCurrent from '../../limit-with-current';
+import ZonesPlatformLimits from '../builder';
+
+const withLimitAndCurrent = () =>
+  ZonesPlatformLimits().total(LimitWithCurrent.random());
+
+export default withLimitAndCurrent;

--- a/models/platform-limits/src/zones/transformers.ts
+++ b/models/platform-limits/src/zones/transformers.ts
@@ -1,0 +1,25 @@
+import { Transformer } from '@commercetools-test-data/core';
+import { TZoneLimitsProjection, TZoneLimitsProjectionGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TZoneLimitsProjection, TZoneLimitsProjection>(
+    'default',
+    {
+      buildFields: ['total'],
+    }
+  ),
+  rest: Transformer<TZoneLimitsProjection, TZoneLimitsProjection>('rest', {
+    buildFields: ['total'],
+  }),
+  graphql: Transformer<TZoneLimitsProjection, TZoneLimitsProjectionGraphql>(
+    'graphql',
+    {
+      buildFields: ['total'],
+      addFields: () => ({
+        __typename: 'ZoneLimitsProjection',
+      }),
+    }
+  ),
+};
+
+export default transformers;

--- a/models/platform-limits/src/zones/types.ts
+++ b/models/platform-limits/src/zones/types.ts
@@ -1,0 +1,14 @@
+import type { TBuilder } from '@commercetools-test-data/core';
+import type { TLimitWithCurrent } from '../limit-with-current';
+
+export type TZoneLimitsProjection = {
+  total: TLimitWithCurrent;
+};
+
+export type TZoneLimitsProjectionGraphql = TZoneLimitsProjection & {
+  __typename: 'ZoneLimitsProjection';
+};
+
+export type TZoneLimitsProjectionBuilder = TBuilder<TZoneLimitsProjection>;
+export type TCreateZoneLimitsProjectionBuilder =
+  () => TZoneLimitsProjectionBuilder;


### PR DESCRIPTION
### Summary

This is the 3rd (final) PR in this series to add the `platform-limits` model. 

The models are copied from FE repo and few adjustment to `spec` file and `typescript` are done. The model covered in this PR are referred from this below code
- [general](https://github.com/commercetools/merchant-center-frontend/tree/main/packages-shared/test-data/src/platform-limits/general)
- [product-discounts](https://github.com/commercetools/merchant-center-frontend/tree/main/packages-shared/test-data/src/platform-limits/product-discounts)
- [shipping-method](https://github.com/commercetools/merchant-center-frontend/tree/main/packages-shared/test-data/src/platform-limits/shipping-methods)
- [shopping-lists](https://github.com/commercetools/merchant-center-frontend/tree/main/packages-shared/test-data/src/platform-limits/shopping-lists)
- [stores](https://github.com/commercetools/merchant-center-frontend/tree/main/packages-shared/test-data/src/platform-limits/stores)
- [tax-categories](https://github.com/commercetools/merchant-center-frontend/tree/main/packages-shared/test-data/src/platform-limits/tax-categories)
- [zones](https://github.com/commercetools/merchant-center-frontend/tree/main/packages-shared/test-data/src/platform-limits/zones)