### PR TITLE
FEC-56: update model version

### DIFF
--- a/.changeset/sweet-walls-whisper.md
+++ b/.changeset/sweet-walls-whisper.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/customers-search-list-my-view': minor
+---
+
+Add `CustomersSearchListMyView` test data model

--- a/models/customers-search-list-my-view/package.json
+++ b/models/customers-search-list-my-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/customers-search-list-my-view",
-  "version": "1.0.0",
+  "version": "10.1.4",
   "description": "Data model for internal Merchan Center API CustomersSearchListMyView",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {

--- a/models/customers-search-list-my-view/package.json
+++ b/models/customers-search-list-my-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-test-data/customers-search-list-my-view",
-  "version": "10.1.4",
+  "version": "10.2.0",
   "description": "Data model for internal Merchan Center API CustomersSearchListMyView",
   "bugs": "https://github.com/commercetools/test-data/issues",
   "repository": {
@@ -19,11 +19,11 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-test-data/commons": "10.1.4",
-    "@commercetools-test-data/core": "10.1.4",
-    "@commercetools-test-data/filter-values": "10.1.4",
-    "@commercetools-test-data/graphql-types": "10.1.4",
-    "@commercetools-test-data/utils": "10.1.4",
+    "@commercetools-test-data/commons": "10.2.0",
+    "@commercetools-test-data/core": "10.2.0",
+    "@commercetools-test-data/filter-values": "10.2.0",
+    "@commercetools-test-data/graphql-types": "10.2.0",
+    "@commercetools-test-data/utils": "10.2.0",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,20 +509,20 @@ importers:
         specifier: ^7.17.9
         version: 7.24.6
       '@commercetools-test-data/commons':
-        specifier: 10.1.4
-        version: 10.1.4
+        specifier: 10.2.0
+        version: link:../commons
       '@commercetools-test-data/core':
-        specifier: 10.1.4
-        version: 10.1.4
+        specifier: 10.2.0
+        version: link:../../core
       '@commercetools-test-data/filter-values':
-        specifier: 10.1.4
-        version: 10.1.4
+        specifier: 10.2.0
+        version: link:../filter-values
       '@commercetools-test-data/graphql-types':
-        specifier: 10.1.4
-        version: 10.1.4
+        specifier: 10.2.0
+        version: link:../../graphql-types
       '@commercetools-test-data/utils':
-        specifier: 10.1.4
-        version: 10.1.4
+        specifier: 10.2.0
+        version: link:../../utils
       '@commercetools/platform-sdk':
         specifier: ^7.0.0
         version: 7.8.0
@@ -2165,21 +2165,6 @@ packages:
     engines: {node: 16.x || >=18.0.0}
     peerDependencies:
       eslint: 8.x
-
-  '@commercetools-test-data/commons@10.1.4':
-    resolution: {integrity: sha512-u9mlD5Xc87RHLRsftNV8Lnoz2rs9T4D5j1ygjGlBxuSEWhz2r3MR+wKKrwmj+mFCQBl0SO6Ws1Pp0l4cFUYZRA==}
-
-  '@commercetools-test-data/core@10.1.4':
-    resolution: {integrity: sha512-LNfTR35FM/X2aia47vGoJy6dyCbYhR0fNunkyMFn7lRE9uGScc5o4vTMaWjcmU8PfV5Df08AWwSqUAgrAaCPjA==}
-
-  '@commercetools-test-data/filter-values@10.1.4':
-    resolution: {integrity: sha512-axaajIUD6djniOrlOXR0xFMEv3u6/M0elneBp+Eu2Qfu5gG5xftbR2Aq7AmbtLYCDqbZYzcYHeU2ziwik5HZAQ==}
-
-  '@commercetools-test-data/graphql-types@10.1.4':
-    resolution: {integrity: sha512-QcBCXqCl3scatlsV+TOgK6ntSn9S+iqGsCTzlAiNoQzdIw6VIubZwtVM64115Dm4BazFYH6c9ARCjQ3a0DAu0Q==}
-
-  '@commercetools-test-data/utils@10.1.4':
-    resolution: {integrity: sha512-M9vcm38nbTDoKIygCwjtoRuKqI+vl3FxiVXm+35swiFrXPtfkzY5z3MUKiB/7Fqy6UkgEKw4v5flAGOoQdhHeQ==}
 
   '@commercetools/platform-sdk@7.8.0':
     resolution: {integrity: sha512-7dpUG8kVULm286dyL1N5IZ6A+0iNwjHdeck7CZdUkVeJ697XN/YwPQkjQ2z62ZkaJRL0efPN5277TWttsU6uLA==}
@@ -7618,44 +7603,6 @@ snapshots:
       - eslint-import-resolver-webpack
       - jest
       - supports-color
-
-  '@commercetools-test-data/commons@10.1.4':
-    dependencies:
-      '@babel/runtime': 7.24.6
-      '@babel/runtime-corejs3': 7.24.6
-      '@commercetools-test-data/core': 10.1.4
-      '@commercetools-test-data/utils': 10.1.4
-      '@commercetools/platform-sdk': 7.8.0
-      '@faker-js/faker': 8.4.1
-      '@types/lodash': 4.17.4
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - encoding
-
-  '@commercetools-test-data/core@10.1.4':
-    dependencies:
-      '@babel/runtime': 7.24.6
-      '@babel/runtime-corejs3': 7.24.6
-      '@faker-js/faker': 8.4.1
-      '@types/lodash': 4.17.4
-      lodash: 4.17.21
-
-  '@commercetools-test-data/filter-values@10.1.4':
-    dependencies:
-      '@babel/runtime': 7.24.6
-      '@babel/runtime-corejs3': 7.24.6
-      '@commercetools-test-data/core': 10.1.4
-      '@commercetools-test-data/graphql-types': 10.1.4
-      '@commercetools-test-data/utils': 10.1.4
-      '@faker-js/faker': 8.4.1
-
-  '@commercetools-test-data/graphql-types@10.1.4': {}
-
-  '@commercetools-test-data/utils@10.1.4':
-    dependencies:
-      '@babel/runtime': 7.24.6
-      '@babel/runtime-corejs3': 7.24.6
-      '@faker-js/faker': 8.4.1
 
   '@commercetools/platform-sdk@7.8.0':
     dependencies:


### PR DESCRIPTION
## Summary

In the previous PR, I kept the version as `1.0.0` which is fixed in this PR. I also created changeset for the release