### PR TITLE
[FEC-49] - shipping info model

### DIFF
--- a/.changeset/olive-steaks-compete.md
+++ b/.changeset/olive-steaks-compete.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart': minor
+---
+
+Add `shipping-info` test data model

--- a/models/cart/package.json
+++ b/models/cart/package.json
@@ -21,6 +21,7 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/business-unit": "10.6.1",
     "@commercetools-test-data/channel": "10.6.1",
+    "@commercetools-test-data/cart-discount": "10.6.1",
     "@commercetools-test-data/commons": "10.6.1",
     "@commercetools-test-data/core": "10.6.1",
     "@commercetools-test-data/customer": "10.6.1",

--- a/models/cart/src/discounted-line-item-portion/builder.spec.ts
+++ b/models/cart/src/discounted-line-item-portion/builder.spec.ts
@@ -1,0 +1,56 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import {
+  TDiscountedLineItemPortion,
+  TDiscountedLineItemPortionGraphql,
+  TDiscountedLineItemPortionRest,
+} from './types';
+import { DiscountedLineItemPortion } from '.';
+
+describe('DiscountedLineItemPortion builder spec', () => {
+  const expectGenericCentPrecisionMoney = expect.objectContaining({
+    centAmount: expect.any(Number),
+    currencyCode: expect.any(String),
+    fractionDigits: expect.any(Number),
+  });
+
+  it(
+    ...createBuilderSpec<
+      TDiscountedLineItemPortion,
+      TDiscountedLineItemPortionRest
+    >(
+      'rest',
+      DiscountedLineItemPortion.random(),
+      expect.objectContaining({
+        discount: expect.objectContaining({
+          typeId: 'cart-discount',
+          id: expect.any(String),
+        }),
+        discountedAmount: expectGenericCentPrecisionMoney,
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TDiscountedLineItemPortion,
+      TDiscountedLineItemPortionGraphql
+    >(
+      'graphql',
+      DiscountedLineItemPortion.random(),
+      expect.objectContaining({
+        discount: expect.objectContaining({
+          key: expect.any(String),
+          __typename: 'CartDiscount',
+        }),
+        discountRef: expect.objectContaining({
+          typeId: 'cart-discount',
+          id: expect.any(String),
+          __typename: 'Reference',
+        }),
+        discountedAmount: expectGenericCentPrecisionMoney,
+      })
+    )
+  );
+});

--- a/models/cart/src/discounted-line-item-portion/builder.ts
+++ b/models/cart/src/discounted-line-item-portion/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TCreateDiscountedLineItemPortionBuilder,
+  TDiscountedLineItemPortion,
+} from './types';
+
+const Model: TCreateDiscountedLineItemPortionBuilder = () =>
+  Builder<TDiscountedLineItemPortion>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/cart/src/discounted-line-item-portion/generator.ts
+++ b/models/cart/src/discounted-line-item-portion/generator.ts
@@ -1,0 +1,17 @@
+import {
+  CentPrecisionMoney,
+  Reference,
+} from '@commercetools-test-data/commons';
+import { fake, Generator } from '@commercetools-test-data/core';
+import { TDiscountedLineItemPortion } from './types';
+
+// https://docs.commercetools.com/api/projects/carts#discountedlineitemportion
+
+const generator = Generator<TDiscountedLineItemPortion>({
+  fields: {
+    discount: fake(() => Reference.presets.cartDiscountReference()),
+    discountedAmount: fake(() => CentPrecisionMoney.random()),
+  },
+});
+
+export default generator;

--- a/models/cart/src/discounted-line-item-portion/index.ts
+++ b/models/cart/src/discounted-line-item-portion/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export * as DiscountedLineItemPortion from '.';

--- a/models/cart/src/discounted-line-item-portion/transformers.ts
+++ b/models/cart/src/discounted-line-item-portion/transformers.ts
@@ -1,0 +1,55 @@
+import {
+  CartDiscount,
+  TCartDiscountGraphql,
+} from '@commercetools-test-data/cart-discount';
+import { Reference, TReferenceGraphql } from '@commercetools-test-data/commons';
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TDiscountedLineItemPortion,
+  TDiscountedLineItemPortionRest,
+  TDiscountedLineItemPortionGraphql,
+} from './types';
+
+const buildFields: (keyof TDiscountedLineItemPortion)[] = [
+  'discount',
+  'discountedAmount',
+];
+
+const transformers = {
+  default: Transformer<TDiscountedLineItemPortion, TDiscountedLineItemPortion>(
+    'default',
+    {
+      buildFields,
+    }
+  ),
+  rest: Transformer<TDiscountedLineItemPortion, TDiscountedLineItemPortionRest>(
+    'rest',
+    {
+      buildFields,
+    }
+  ),
+  graphql: Transformer<
+    TDiscountedLineItemPortion,
+    TDiscountedLineItemPortionGraphql
+  >('graphql', {
+    buildFields,
+    replaceFields: ({ fields }) => {
+      const discount = CartDiscount.random()
+        .id(fields.discount.id)
+        .buildGraphql<TCartDiscountGraphql>();
+      const discountRef = Reference.presets
+        .cartDiscountReference()
+        .id(fields.discount.id)
+        .buildGraphql<TReferenceGraphql>();
+
+      return {
+        ...fields,
+        discount,
+        discountRef,
+        __typename: 'DiscountedLineItemPortion',
+      };
+    },
+  }),
+};
+
+export default transformers;

--- a/models/cart/src/discounted-line-item-portion/types.ts
+++ b/models/cart/src/discounted-line-item-portion/types.ts
@@ -1,0 +1,22 @@
+import type { DiscountedLineItemPortion } from '@commercetools/platform-sdk';
+import { TCartDiscountGraphql } from '@commercetools-test-data/cart-discount';
+import { TReferenceGraphql } from '@commercetools-test-data/commons';
+import { TBuilder } from '@commercetools-test-data/core';
+
+// https://docs.commercetools.com/api/projects/carts#discountedlineitemportion
+
+export type TDiscountedLineItemPortion = DiscountedLineItemPortion;
+export type TDiscountedLineItemPortionRest = DiscountedLineItemPortion;
+export type TDiscountedLineItemPortionGraphql = Omit<
+  DiscountedLineItemPortion,
+  'discount'
+> & {
+  discount?: TCartDiscountGraphql;
+  discountRef: TReferenceGraphql;
+  __typename: 'DiscountedLineItemPortion';
+};
+
+export type TDiscountedLineItemPortionBuilder =
+  TBuilder<TDiscountedLineItemPortion>;
+export type TCreateDiscountedLineItemPortionBuilder =
+  () => TDiscountedLineItemPortionBuilder;

--- a/models/cart/src/discounted-line-item-price/builder.spec.ts
+++ b/models/cart/src/discounted-line-item-price/builder.spec.ts
@@ -1,0 +1,68 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import {
+  TDiscountedLineItemPrice,
+  TDiscountedLineItemPriceGraphql,
+  TDiscountedLineItemPriceRest,
+} from './types';
+import { DiscountedLineItemPrice } from '.';
+
+describe('DiscountedLineItemPrice builder spec', () => {
+  const expectGenericCentPrecisionMoney = expect.objectContaining({
+    centAmount: expect.any(Number),
+    currencyCode: expect.any(String),
+    fractionDigits: expect.any(Number),
+  });
+
+  it(
+    ...createBuilderSpec<
+      TDiscountedLineItemPrice,
+      TDiscountedLineItemPriceRest
+    >(
+      'rest',
+      DiscountedLineItemPrice.random(),
+      expect.objectContaining({
+        value: expectGenericCentPrecisionMoney,
+        includedDiscounts: expect.arrayContaining([
+          expect.objectContaining({
+            discount: expect.objectContaining({
+              typeId: 'cart-discount',
+              id: expect.any(String),
+            }),
+            discountedAmount: expectGenericCentPrecisionMoney,
+          }),
+        ]),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<
+      TDiscountedLineItemPrice,
+      TDiscountedLineItemPriceGraphql
+    >(
+      'graphql',
+      DiscountedLineItemPrice.random(),
+      expect.objectContaining({
+        value: expect.objectContaining({
+          currencyCode: expect.any(String),
+          __typename: 'Money',
+        }),
+        includedDiscounts: expect.arrayContaining([
+          expect.objectContaining({
+            discount: expect.objectContaining({
+              key: expect.any(String),
+              __typename: 'CartDiscount',
+            }),
+            discountRef: expect.objectContaining({
+              typeId: 'cart-discount',
+              id: expect.any(String),
+            }),
+            discountedAmount: expectGenericCentPrecisionMoney,
+          }),
+        ]),
+      })
+    )
+  );
+});

--- a/models/cart/src/discounted-line-item-price/builder.ts
+++ b/models/cart/src/discounted-line-item-price/builder.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import {
+  TCreateDiscountedLineItemPriceBuilder,
+  TDiscountedLineItemPrice,
+} from './types';
+
+const Model: TCreateDiscountedLineItemPriceBuilder = () =>
+  Builder<TDiscountedLineItemPrice>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/cart/src/discounted-line-item-price/generator.ts
+++ b/models/cart/src/discounted-line-item-price/generator.ts
@@ -1,0 +1,15 @@
+import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import { fake, Generator } from '@commercetools-test-data/core';
+import { DiscountedLineItemPortion } from '../discounted-line-item-portion';
+import { TDiscountedLineItemPrice } from './types';
+
+// https://docs.commercetools.com/api/projects/carts#discountedlineitemprice
+
+const generator = Generator<TDiscountedLineItemPrice>({
+  fields: {
+    value: fake(() => CentPrecisionMoney.random()),
+    includedDiscounts: fake(() => [DiscountedLineItemPortion.random()]),
+  },
+});
+
+export default generator;

--- a/models/cart/src/discounted-line-item-price/index.ts
+++ b/models/cart/src/discounted-line-item-price/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export * as DiscountedLineItemPrice from '.';

--- a/models/cart/src/discounted-line-item-price/transformers.ts
+++ b/models/cart/src/discounted-line-item-price/transformers.ts
@@ -1,0 +1,37 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TDiscountedLineItemPrice,
+  TDiscountedLineItemPriceRest,
+  TDiscountedLineItemPriceGraphql,
+} from './types';
+
+const buildFields: (keyof TDiscountedLineItemPrice)[] = [
+  'value',
+  'includedDiscounts',
+];
+
+const transformers = {
+  default: Transformer<TDiscountedLineItemPrice, TDiscountedLineItemPrice>(
+    'default',
+    {
+      buildFields,
+    }
+  ),
+  rest: Transformer<TDiscountedLineItemPrice, TDiscountedLineItemPriceRest>(
+    'rest',
+    {
+      buildFields,
+    }
+  ),
+  graphql: Transformer<
+    TDiscountedLineItemPrice,
+    TDiscountedLineItemPriceGraphql
+  >('graphql', {
+    buildFields,
+    addFields: ({ fields }) => ({
+      __typename: 'DiscountedLineItemPrice',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/cart/src/discounted-line-item-price/types.ts
+++ b/models/cart/src/discounted-line-item-price/types.ts
@@ -1,0 +1,15 @@
+import type { DiscountedLineItemPrice } from '@commercetools/platform-sdk';
+import { TBuilder } from '@commercetools-test-data/core';
+
+// https://docs.commercetools.com/api/projects/carts#discountedlineitemprice
+
+export type TDiscountedLineItemPrice = DiscountedLineItemPrice;
+export type TDiscountedLineItemPriceRest = DiscountedLineItemPrice;
+export type TDiscountedLineItemPriceGraphql = DiscountedLineItemPrice & {
+  __typename: 'DiscountedLineItemPrice';
+};
+
+export type TDiscountedLineItemPriceBuilder =
+  TBuilder<TDiscountedLineItemPrice>;
+export type TCreateDiscountedLineItemPriceBuilder =
+  () => TDiscountedLineItemPriceBuilder;

--- a/models/cart/src/index.ts
+++ b/models/cart/src/index.ts
@@ -11,3 +11,7 @@ export * as CustomLineItemDraft from './custom-line-item/custom-line-item-draft'
 export * as LineItem from './line-item';
 export * as LineItemDraft from './line-item/line-item-draft';
 export * as ShippingInfo from './shipping-info';
+export * as DiscountedLineItemPortion from './discounted-line-item-portion';
+export * as DiscountedLineItemPrice from './discounted-line-item-price';
+export * as TaxPortion from './tax-portion';
+export * as TaxedItemPrice from './taxed-item-price';

--- a/models/cart/src/index.ts
+++ b/models/cart/src/index.ts
@@ -10,3 +10,4 @@ export * as CustomLineItem from './custom-line-item';
 export * as CustomLineItemDraft from './custom-line-item/custom-line-item-draft';
 export * as LineItem from './line-item';
 export * as LineItemDraft from './line-item/line-item-draft';
+export * as ShippingInfo from './shipping-info';

--- a/models/cart/src/shipping-info/builder.spec.ts
+++ b/models/cart/src/shipping-info/builder.spec.ts
@@ -1,11 +1,14 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
 
-import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import {
+  CentPrecisionMoney,
+  Reference,
+} from '@commercetools-test-data/commons';
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { ShippingMethod } from '@commercetools-test-data/shipping-method';
 import { TaxRate, TaxCategory } from '@commercetools-test-data/tax-category';
-import { Delivery } from '../../../order/src';
+// import { Delivery } from '../../../order/src';
 import { TShippingInfo, TShippingInfoGraphql } from './types';
 import * as ShippingInfo from '.';
 
@@ -53,33 +56,39 @@ describe('builder', () => {
       ShippingInfo.random(),
       expect.objectContaining({
         ...defaultShippingInfoSpec,
+        taxCategory: undefined,
+        taxCategoryRef: undefined,
+        shippingMethod: undefined,
+        shippingMethodRef: undefined,
         __typename: 'ShippingInfo',
       })
     )
   );
 
-  it('should allow customization', () => {
+  it.only('should allow customization', () => {
     const shippingMethodName = 'Test Shipping method name';
-    // const centAmount = 100;
+    const centAmount = 100;
     const currencyCode = 'EUR';
     const price = CentPrecisionMoney.random().currencyCode(currencyCode);
     const name = 'Test Name';
     const id = 'Test Id';
 
     const taxRate = TaxRate.random().name(name);
-    const taxCategory = TaxCategory.random().name(name);
-    const shippingMethod = ShippingMethod.random().name(name);
-    const deliveries = Delivery.random().id(id);
+    const taxCategory = Reference.presets.taxCategoryReference().id(id);
+    const shippingMethod = Reference.presets.shippingMethodReference().id(id);
+    // const taxedPrice = TaxedItemPrice.random().currencyCode(currencyCode);
+    const discountedPrice =
+      CentPrecisionMoney.random().currencyCode(currencyCode);
+    // const deliveries = Delivery.random().id(id);
 
     const shippingInfoMock = ShippingInfo.random()
       .shippingMethodName(shippingMethodName)
-      .price(price)
       // .taxedPrice(taxedPrice)
       .taxRate(taxRate)
       .taxCategory(taxCategory)
       .shippingMethod(shippingMethod)
-      .deliveries([deliveries])
-      // .discountedPrice(discountedPriceDummy)
+      // .deliveries([deliveries])
+      .discountedPrice(discountedPrice)
       .buildGraphql();
 
     expect(shippingInfoMock).toEqual(
@@ -88,19 +97,29 @@ describe('builder', () => {
         price: expect.objectContaining({
           currencyCode,
         }),
-        // taxedPrice: expect.objectContaining({
-        //   totalNet: expect.objectContaining({ centAmount, currencyCode }),
+        taxedPrice: expect.objectContaining({
+          totalNet: expect.objectContaining({
+            currencyCode,
+          }),
+        }),
+        // taxRate: expect.objectContaining({ name }),
+        // taxCategory: expect.objectContaining({ id }),
+        // taxCategoryRef: expect.objectContaining({
+        //   id,
+        //   typeId: 'tax-category',
         // }),
-        taxRate: expect.objectContaining({ name }),
-        taxCategory: expect.objectContaining({ name }),
-        shippingMethod: expect.objectContaining({ name }),
-        deliveries: expect.arrayContaining([expect.objectContaining({ id })]),
-        // discountedPrice: expect.objectContaining({
-        //   value: expect.objectContaining({ currencyCode, centAmount }),
+        // shippingMethod: expect.objectContaining({ id }),
+        // shippingMethodRef: expect.objectContaining({
+        //   id,
+        //   typeId: 'shipping-method',
         // }),
-        shippingMethodState: expect.stringMatching(
-          /^(MatchesCart|DoesNotMatchCart)$/
-        ),
+        // // deliveries: expect.arrayContaining([expect.objectContaining({ id })]),
+        // // discountedPrice: expect.objectContaining({
+        // //   value: expect.objectContaining({ currencyCode, centAmount }),
+        // // }),
+        // shippingMethodState: expect.stringMatching(
+        //   /^(MatchesCart|DoesNotMatchCart)$/
+        // ),
         __typename: 'ShippingInfo',
       })
     );

--- a/models/cart/src/shipping-info/builder.spec.ts
+++ b/models/cart/src/shipping-info/builder.spec.ts
@@ -6,122 +6,126 @@ import {
   Reference,
 } from '@commercetools-test-data/commons';
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import { ShippingMethod } from '@commercetools-test-data/shipping-method';
-import { TaxRate, TaxCategory } from '@commercetools-test-data/tax-category';
-// import { Delivery } from '../../../order/src';
+import { TaxRate } from '@commercetools-test-data/tax-category';
+import { DiscountedLineItemPrice } from '../discounted-line-item-price';
+import { TaxedItemPrice } from '../taxed-item-price';
 import { TShippingInfo, TShippingInfoGraphql } from './types';
 import * as ShippingInfo from '.';
 
 describe('builder', () => {
-  const defaultShippingInfoSpec = {
-    shippingMethodName: expect.any(String),
-    price: expect.objectContaining({
-      centAmount: expect.any(Number),
-      currencyCode: expect.any(String),
-      fractionDigits: expect.any(Number),
-      type: expect.any(String),
-    }),
+  const modelBuilder = ShippingInfo.random()
+    .taxedPrice(TaxedItemPrice.random())
+    .taxRate(TaxRate.random().key('test-tax-rate'))
+    .taxCategory(
+      Reference.presets.taxCategoryReference().id('test-tax-category')
+    )
+    .shippingMethod(
+      Reference.presets.shippingMethodReference().id('test-shipping-method')
+    )
+    .discountedPrice(
+      DiscountedLineItemPrice.random().value(
+        CentPrecisionMoney.random().currencyCode('EUR')
+      )
+    );
+  // TODO: Blocked by another PR
+  // .deliveries([]),
 
-    shippingRate: expect.objectContaining({
-      price: expect.objectContaining({
-        centAmount: expect.any(Number),
-        currencyCode: expect.any(String),
-      }),
-      freeAbove: expect.objectContaining({
-        centAmount: expect.any(Number),
-        currencyCode: expect.any(String),
-      }),
-      tiers: expect.any(Array),
-    }),
-    taxedPrice: null,
-    taxRate: null,
-    taxCategory: null,
-    shippingMethod: null,
-    deliveries: [],
-    discountedPrice: null,
-    shippingMethodState: expect.stringMatching(
-      /^(MatchesCart|DoesNotMatchCart)$/
-    ),
-  };
   it(
     ...createBuilderSpec<TShippingInfo, TShippingInfo>(
-      'default',
-      ShippingInfo.random(),
-      expect.objectContaining(defaultShippingInfoSpec)
+      'rest',
+      modelBuilder,
+      expect.objectContaining({
+        shippingMethodName: expect.any(String),
+        price: expect.objectContaining({
+          centAmount: expect.any(Number),
+          currencyCode: expect.any(String),
+        }),
+        shippingRate: expect.objectContaining({
+          price: expect.objectContaining({
+            currencyCode: expect.any(String),
+          }),
+          freeAbove: expect.objectContaining({
+            currencyCode: expect.any(String),
+          }),
+          tiers: expect.any(Array),
+        }),
+        taxedPrice: expect.objectContaining({
+          taxPortions: [],
+        }),
+        taxRate: expect.objectContaining({
+          key: 'test-tax-rate',
+        }),
+        taxCategory: expect.objectContaining({
+          id: 'test-tax-category',
+          typeId: 'tax-category',
+        }),
+        shippingMethod: expect.objectContaining({
+          id: 'test-shipping-method',
+          typeId: 'shipping-method',
+        }),
+        // TODO: Blocked by another PR
+        // deliveries: [],
+        discountedPrice: expect.objectContaining({
+          value: expect.objectContaining({
+            centAmount: expect.any(Number),
+            currencyCode: 'EUR',
+          }),
+        }),
+        shippingMethodState: expect.stringMatching(
+          /^(MatchesCart|DoesNotMatchCart)$/
+        ),
+      })
     )
   );
   it(
     ...createBuilderSpec<TShippingInfo, TShippingInfoGraphql>(
       'graphql',
-      ShippingInfo.random(),
+      modelBuilder,
       expect.objectContaining({
-        ...defaultShippingInfoSpec,
-        taxCategory: undefined,
-        taxCategoryRef: undefined,
-        shippingMethod: undefined,
-        shippingMethodRef: undefined,
-        __typename: 'ShippingInfo',
+        shippingMethodName: expect.any(String),
+        price: expect.objectContaining({
+          __typename: 'Money',
+        }),
+        shippingRate: expect.objectContaining({
+          __typename: 'ShippingRate',
+        }),
+        taxedPrice: expect.objectContaining({
+          taxPortions: [],
+          __typename: 'TaxedItemPrice',
+        }),
+        taxRate: expect.objectContaining({
+          key: 'test-tax-rate',
+          __typename: 'TaxRate',
+        }),
+        taxCategory: expect.objectContaining({
+          id: 'test-tax-category',
+          __typename: 'TaxCategory',
+        }),
+        taxCategoryRef: expect.objectContaining({
+          id: 'test-tax-category',
+          typeId: 'tax-category',
+        }),
+        shippingMethod: expect.objectContaining({
+          id: 'test-shipping-method',
+          __typename: 'ShippingMethod',
+        }),
+        shippingMethodRef: expect.objectContaining({
+          id: 'test-shipping-method',
+          typeId: 'shipping-method',
+        }),
+        // TODO: Blocked by another PR
+        // deliveries: [],
+        discountedPrice: expect.objectContaining({
+          value: expect.objectContaining({
+            centAmount: expect.any(Number),
+            currencyCode: 'EUR',
+          }),
+          __typename: 'DiscountedLineItemPrice',
+        }),
+        shippingMethodState: expect.stringMatching(
+          /^(MatchesCart|DoesNotMatchCart)$/
+        ),
       })
     )
   );
-
-  it.only('should allow customization', () => {
-    const shippingMethodName = 'Test Shipping method name';
-    const centAmount = 100;
-    const currencyCode = 'EUR';
-    const price = CentPrecisionMoney.random().currencyCode(currencyCode);
-    const name = 'Test Name';
-    const id = 'Test Id';
-
-    const taxRate = TaxRate.random().name(name);
-    const taxCategory = Reference.presets.taxCategoryReference().id(id);
-    const shippingMethod = Reference.presets.shippingMethodReference().id(id);
-    // const taxedPrice = TaxedItemPrice.random().currencyCode(currencyCode);
-    const discountedPrice =
-      CentPrecisionMoney.random().currencyCode(currencyCode);
-    // const deliveries = Delivery.random().id(id);
-
-    const shippingInfoMock = ShippingInfo.random()
-      .shippingMethodName(shippingMethodName)
-      // .taxedPrice(taxedPrice)
-      .taxRate(taxRate)
-      .taxCategory(taxCategory)
-      .shippingMethod(shippingMethod)
-      // .deliveries([deliveries])
-      .discountedPrice(discountedPrice)
-      .buildGraphql();
-
-    expect(shippingInfoMock).toEqual(
-      expect.objectContaining({
-        shippingMethodName: shippingMethodName,
-        price: expect.objectContaining({
-          currencyCode,
-        }),
-        taxedPrice: expect.objectContaining({
-          totalNet: expect.objectContaining({
-            currencyCode,
-          }),
-        }),
-        // taxRate: expect.objectContaining({ name }),
-        // taxCategory: expect.objectContaining({ id }),
-        // taxCategoryRef: expect.objectContaining({
-        //   id,
-        //   typeId: 'tax-category',
-        // }),
-        // shippingMethod: expect.objectContaining({ id }),
-        // shippingMethodRef: expect.objectContaining({
-        //   id,
-        //   typeId: 'shipping-method',
-        // }),
-        // // deliveries: expect.arrayContaining([expect.objectContaining({ id })]),
-        // // discountedPrice: expect.objectContaining({
-        // //   value: expect.objectContaining({ currencyCode, centAmount }),
-        // // }),
-        // shippingMethodState: expect.stringMatching(
-        //   /^(MatchesCart|DoesNotMatchCart)$/
-        // ),
-        __typename: 'ShippingInfo',
-      })
-    );
-  });
 });

--- a/models/cart/src/shipping-info/builder.spec.ts
+++ b/models/cart/src/shipping-info/builder.spec.ts
@@ -1,0 +1,108 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+
+import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { ShippingMethod } from '@commercetools-test-data/shipping-method';
+import { TaxRate, TaxCategory } from '@commercetools-test-data/tax-category';
+import { Delivery } from '../../../order/src';
+import { TShippingInfo, TShippingInfoGraphql } from './types';
+import * as ShippingInfo from '.';
+
+describe('builder', () => {
+  const defaultShippingInfoSpec = {
+    shippingMethodName: expect.any(String),
+    price: expect.objectContaining({
+      centAmount: expect.any(Number),
+      currencyCode: expect.any(String),
+      fractionDigits: expect.any(Number),
+      type: expect.any(String),
+    }),
+
+    shippingRate: expect.objectContaining({
+      price: expect.objectContaining({
+        centAmount: expect.any(Number),
+        currencyCode: expect.any(String),
+      }),
+      freeAbove: expect.objectContaining({
+        centAmount: expect.any(Number),
+        currencyCode: expect.any(String),
+      }),
+      tiers: expect.any(Array),
+    }),
+    taxedPrice: null,
+    taxRate: null,
+    taxCategory: null,
+    shippingMethod: null,
+    deliveries: [],
+    discountedPrice: null,
+    shippingMethodState: expect.stringMatching(
+      /^(MatchesCart|DoesNotMatchCart)$/
+    ),
+  };
+  it(
+    ...createBuilderSpec<TShippingInfo, TShippingInfo>(
+      'default',
+      ShippingInfo.random(),
+      expect.objectContaining(defaultShippingInfoSpec)
+    )
+  );
+  it(
+    ...createBuilderSpec<TShippingInfo, TShippingInfoGraphql>(
+      'graphql',
+      ShippingInfo.random(),
+      expect.objectContaining({
+        ...defaultShippingInfoSpec,
+        __typename: 'ShippingInfo',
+      })
+    )
+  );
+
+  it('should allow customization', () => {
+    const shippingMethodName = 'Test Shipping method name';
+    // const centAmount = 100;
+    const currencyCode = 'EUR';
+    const price = CentPrecisionMoney.random().currencyCode(currencyCode);
+    const name = 'Test Name';
+    const id = 'Test Id';
+
+    const taxRate = TaxRate.random().name(name);
+    const taxCategory = TaxCategory.random().name(name);
+    const shippingMethod = ShippingMethod.random().name(name);
+    const deliveries = Delivery.random().id(id);
+
+    const shippingInfoMock = ShippingInfo.random()
+      .shippingMethodName(shippingMethodName)
+      .price(price)
+      // .taxedPrice(taxedPrice)
+      .taxRate(taxRate)
+      .taxCategory(taxCategory)
+      .shippingMethod(shippingMethod)
+      .deliveries([deliveries])
+      // .discountedPrice(discountedPriceDummy)
+      .buildGraphql();
+
+    expect(shippingInfoMock).toEqual(
+      expect.objectContaining({
+        shippingMethodName: shippingMethodName,
+        price: expect.objectContaining({
+          currencyCode,
+        }),
+        // taxedPrice: expect.objectContaining({
+        //   totalNet: expect.objectContaining({ centAmount, currencyCode }),
+        // }),
+        taxRate: expect.objectContaining({ name }),
+        taxCategory: expect.objectContaining({ name }),
+        shippingMethod: expect.objectContaining({ name }),
+        deliveries: expect.arrayContaining([expect.objectContaining({ id })]),
+        // discountedPrice: expect.objectContaining({
+        //   value: expect.objectContaining({ currencyCode, centAmount }),
+        // }),
+        shippingMethodState: expect.stringMatching(
+          /^(MatchesCart|DoesNotMatchCart)$/
+        ),
+        __typename: 'ShippingInfo',
+      })
+    );
+  });
+});

--- a/models/cart/src/shipping-info/builder.ts
+++ b/models/cart/src/shipping-info/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type { TCreateShippingInfoBuilder, TShippingInfo } from './types';
+
+const Model: TCreateShippingInfoBuilder = () =>
+  Builder<TShippingInfo>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/cart/src/shipping-info/generator.ts
+++ b/models/cart/src/shipping-info/generator.ts
@@ -1,0 +1,25 @@
+import type { ShippingInfo } from '@commercetools/platform-sdk';
+import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import { fake, Generator } from '@commercetools-test-data/core';
+import { ShippingRate } from '@commercetools-test-data/shipping-method';
+
+// https://docs.commercetools.com/api/projects/carts#shippinginfo
+
+const generator = Generator<ShippingInfo>({
+  fields: {
+    shippingMethodName: fake((f) => f.lorem.words(2)),
+    price: fake(() => CentPrecisionMoney.random()),
+    shippingRate: fake(() => ShippingRate.random()),
+    taxedPrice: null,
+    taxRate: null,
+    taxCategory: null,
+    shippingMethod: null,
+    deliveries: [],
+    discountedPrice: null,
+    shippingMethodState: fake((f) =>
+      f.helpers.arrayElement(['MatchesCart', 'DoesNotMatchCart'])
+    ),
+  },
+});
+
+export default generator;

--- a/models/cart/src/shipping-info/index.ts
+++ b/models/cart/src/shipping-info/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export * as ShippingInfo from '.';

--- a/models/cart/src/shipping-info/transformers.ts
+++ b/models/cart/src/shipping-info/transformers.ts
@@ -8,6 +8,7 @@ import {
   TaxCategory,
   TTaxCategoryGraphql,
 } from '@commercetools-test-data/tax-category';
+import { TTaxedItemPriceGraphql } from '../taxed-item-price/types';
 import type { TShippingInfo, TShippingInfoGraphql } from './types';
 
 const buildFields: (keyof TShippingInfo)[] = [
@@ -61,6 +62,7 @@ const transformers = {
         shippingMethodRef,
         taxCategory,
         taxCategoryRef,
+        taxedPrice: fields.taxedPrice as TTaxedItemPriceGraphql,
         __typename: 'ShippingInfo',
       };
     },

--- a/models/cart/src/shipping-info/transformers.ts
+++ b/models/cart/src/shipping-info/transformers.ts
@@ -1,4 +1,13 @@
+import { Reference, TReferenceGraphql } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
+import {
+  ShippingMethod,
+  TShippingMethodGraphql,
+} from '@commercetools-test-data/shipping-method';
+import {
+  TaxCategory,
+  TTaxCategoryGraphql,
+} from '@commercetools-test-data/tax-category';
 import type { TShippingInfo, TShippingInfoGraphql } from './types';
 
 const buildFields: (keyof TShippingInfo)[] = [
@@ -21,9 +30,40 @@ const transformers = {
   }),
   graphql: Transformer<TShippingInfo, TShippingInfoGraphql>('graphql', {
     buildFields,
-    addFields: () => ({
-      __typename: 'ShippingInfo',
-    }),
+    replaceFields: ({ fields }) => {
+      const shippingMethod = fields.shippingMethod
+        ? ShippingMethod.random()
+            .id(fields.shippingMethod.id)
+            .buildGraphql<TShippingMethodGraphql>()
+        : undefined;
+
+      const shippingMethodRef = fields.shippingMethod
+        ? Reference.presets
+            .shippingMethodReference()
+            .id(fields.shippingMethod.id)
+            .buildGraphql<TReferenceGraphql>()
+        : undefined;
+
+      const taxCategory = fields.taxCategory
+        ? TaxCategory.random()
+            .id(fields.taxCategory.id)
+            .buildGraphql<TTaxCategoryGraphql>()
+        : undefined;
+      const taxCategoryRef = fields.taxCategory
+        ? Reference.presets
+            .taxCategoryReference()
+            .id(fields.taxCategory.id)
+            .buildGraphql<TReferenceGraphql>()
+        : undefined;
+      return {
+        ...fields,
+        shippingMethod,
+        shippingMethodRef,
+        taxCategory,
+        taxCategoryRef,
+        __typename: 'ShippingInfo',
+      };
+    },
   }),
 };
 

--- a/models/cart/src/shipping-info/transformers.ts
+++ b/models/cart/src/shipping-info/transformers.ts
@@ -1,42 +1,26 @@
 import { Transformer } from '@commercetools-test-data/core';
 import type { TShippingInfo, TShippingInfoGraphql } from './types';
 
+const buildFields: (keyof TShippingInfo)[] = [
+  'taxCategory',
+  'shippingMethod',
+  'price',
+  'shippingRate',
+  'taxedPrice',
+  'taxRate',
+  'deliveries',
+  'discountedPrice',
+];
+
 const transformers = {
   default: Transformer<TShippingInfo, TShippingInfo>('default', {
-    buildFields: [
-      'taxCategory',
-      'shippingMethod',
-      'price',
-      'shippingRate',
-      'taxedPrice',
-      'taxRate',
-      'deliveries',
-      'discountedPrice',
-    ],
+    buildFields,
   }),
   rest: Transformer<TShippingInfo, TShippingInfo>('rest', {
-    buildFields: [
-      'taxCategory',
-      'shippingMethod',
-      'price',
-      'shippingRate',
-      'taxedPrice',
-      'taxRate',
-      'deliveries',
-      'discountedPrice',
-    ],
+    buildFields,
   }),
   graphql: Transformer<TShippingInfo, TShippingInfoGraphql>('graphql', {
-    buildFields: [
-      'taxCategory',
-      'shippingMethod',
-      'price',
-      'shippingRate',
-      'taxedPrice',
-      'taxRate',
-      'deliveries',
-      'discountedPrice',
-    ],
+    buildFields,
     addFields: () => ({
       __typename: 'ShippingInfo',
     }),

--- a/models/cart/src/shipping-info/transformers.ts
+++ b/models/cart/src/shipping-info/transformers.ts
@@ -1,0 +1,46 @@
+import { Transformer } from '@commercetools-test-data/core';
+import type { TShippingInfo, TShippingInfoGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TShippingInfo, TShippingInfo>('default', {
+    buildFields: [
+      'taxCategory',
+      'shippingMethod',
+      'price',
+      'shippingRate',
+      'taxedPrice',
+      'taxRate',
+      'deliveries',
+      'discountedPrice',
+    ],
+  }),
+  rest: Transformer<TShippingInfo, TShippingInfo>('rest', {
+    buildFields: [
+      'taxCategory',
+      'shippingMethod',
+      'price',
+      'shippingRate',
+      'taxedPrice',
+      'taxRate',
+      'deliveries',
+      'discountedPrice',
+    ],
+  }),
+  graphql: Transformer<TShippingInfo, TShippingInfoGraphql>('graphql', {
+    buildFields: [
+      'taxCategory',
+      'shippingMethod',
+      'price',
+      'shippingRate',
+      'taxedPrice',
+      'taxRate',
+      'deliveries',
+      'discountedPrice',
+    ],
+    addFields: () => ({
+      __typename: 'ShippingInfo',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/cart/src/shipping-info/types.ts
+++ b/models/cart/src/shipping-info/types.ts
@@ -1,9 +1,19 @@
 import type { ShippingInfo } from '@commercetools/platform-sdk';
+import { TReferenceGraphql } from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TShippingMethodGraphql } from '@commercetools-test-data/shipping-method';
+import { TTaxCategoryGraphql } from '@commercetools-test-data/tax-category';
 
 export type TShippingInfo = ShippingInfo;
 
-export type TShippingInfoGraphql = TShippingInfo & {
+export type TShippingInfoGraphql = Omit<
+  TShippingInfo,
+  'taxCategory' | 'shippingMethod'
+> & {
+  taxCategory?: TTaxCategoryGraphql;
+  taxCategoryRef?: TReferenceGraphql;
+  shippingMethod?: TShippingMethodGraphql;
+  shippingMethodRef?: TReferenceGraphql;
   __typename: 'ShippingInfo';
 };
 

--- a/models/cart/src/shipping-info/types.ts
+++ b/models/cart/src/shipping-info/types.ts
@@ -3,13 +3,15 @@ import { TReferenceGraphql } from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
 import { TShippingMethodGraphql } from '@commercetools-test-data/shipping-method';
 import { TTaxCategoryGraphql } from '@commercetools-test-data/tax-category';
+import { TTaxedItemPriceGraphql } from '../taxed-item-price/types';
 
 export type TShippingInfo = ShippingInfo;
 
 export type TShippingInfoGraphql = Omit<
   TShippingInfo,
-  'taxCategory' | 'shippingMethod'
+  'taxedPrice' | 'taxCategory' | 'shippingMethod'
 > & {
+  taxedPrice?: TTaxedItemPriceGraphql;
   taxCategory?: TTaxCategoryGraphql;
   taxCategoryRef?: TReferenceGraphql;
   shippingMethod?: TShippingMethodGraphql;

--- a/models/cart/src/shipping-info/types.ts
+++ b/models/cart/src/shipping-info/types.ts
@@ -1,0 +1,11 @@
+import type { ShippingInfo } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@commercetools-test-data/core';
+
+export type TShippingInfo = ShippingInfo;
+
+export type TShippingInfoGraphql = TShippingInfo & {
+  __typename: 'ShippingInfo';
+};
+
+export type TShippingInfoBuilder = TBuilder<ShippingInfo>;
+export type TCreateShippingInfoBuilder = () => TShippingInfoBuilder;

--- a/models/cart/src/tax-portion/builder.spec.ts
+++ b/models/cart/src/tax-portion/builder.spec.ts
@@ -1,0 +1,37 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TTaxPortion, TTaxPortionGraphql, TTaxPortionRest } from './types';
+import { TaxPortion } from '.';
+
+describe('TaxPortion builder spec', () => {
+  const expectGenericCentPrecisionMoney = expect.objectContaining({
+    centAmount: expect.any(Number),
+    currencyCode: expect.any(String),
+    fractionDigits: expect.any(Number),
+  });
+
+  it(
+    ...createBuilderSpec<TTaxPortion, TTaxPortionRest>(
+      'rest',
+      TaxPortion.random().name('Tax Portion #1'),
+      expect.objectContaining({
+        name: 'Tax Portion #1',
+        rate: expect.any(Number),
+        amount: expectGenericCentPrecisionMoney,
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TTaxPortion, TTaxPortionGraphql>(
+      'graphql',
+      TaxPortion.random().name('Tax Portion #1'),
+      expect.objectContaining({
+        name: 'Tax Portion #1',
+        rate: expect.any(Number),
+        amount: expectGenericCentPrecisionMoney,
+      })
+    )
+  );
+});

--- a/models/cart/src/tax-portion/builder.ts
+++ b/models/cart/src/tax-portion/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import { TCreateTaxPortionBuilder, TTaxPortion } from './types';
+
+const Model: TCreateTaxPortionBuilder = () =>
+  Builder<TTaxPortion>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/cart/src/tax-portion/generator.ts
+++ b/models/cart/src/tax-portion/generator.ts
@@ -1,0 +1,15 @@
+import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import { fake, Generator } from '@commercetools-test-data/core';
+import { TTaxPortion } from './types';
+
+// https://docs.commercetools.com/api/projects/carts#taxportion
+
+const generator = Generator<TTaxPortion>({
+  fields: {
+    name: null,
+    rate: fake((f) => f.number.int()),
+    amount: fake(() => CentPrecisionMoney.random()),
+  },
+});
+
+export default generator;

--- a/models/cart/src/tax-portion/index.ts
+++ b/models/cart/src/tax-portion/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export * as TaxPortion from '.';

--- a/models/cart/src/tax-portion/transformers.ts
+++ b/models/cart/src/tax-portion/transformers.ts
@@ -1,0 +1,21 @@
+import { Transformer } from '@commercetools-test-data/core';
+import { TTaxPortion, TTaxPortionRest, TTaxPortionGraphql } from './types';
+
+const buildFields: (keyof TTaxPortion)[] = ['amount'];
+
+const transformers = {
+  default: Transformer<TTaxPortion, TTaxPortion>('default', {
+    buildFields,
+  }),
+  rest: Transformer<TTaxPortion, TTaxPortionRest>('rest', {
+    buildFields,
+  }),
+  graphql: Transformer<TTaxPortion, TTaxPortionGraphql>('graphql', {
+    buildFields,
+    addFields: () => ({
+      __typename: 'TaxPortion',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/cart/src/tax-portion/types.ts
+++ b/models/cart/src/tax-portion/types.ts
@@ -1,0 +1,13 @@
+import type { TaxPortion } from '@commercetools/platform-sdk';
+import { TBuilder } from '@commercetools-test-data/core';
+
+// https://docs.commercetools.com/api/projects/carts#taxportion
+
+export type TTaxPortion = TaxPortion;
+export type TTaxPortionRest = TTaxPortion;
+export type TTaxPortionGraphql = TTaxPortion & {
+  __typename: 'TaxPortion';
+};
+
+export type TTaxPortionBuilder = TBuilder<TTaxPortion>;
+export type TCreateTaxPortionBuilder = () => TTaxPortionBuilder;

--- a/models/cart/src/taxed-item-price/builder.spec.ts
+++ b/models/cart/src/taxed-item-price/builder.spec.ts
@@ -1,0 +1,74 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+
+import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { TaxPortion } from '../tax-portion';
+import {
+  TTaxedItemPrice,
+  TTaxedItemPriceGraphql,
+  TTaxedItemPriceRest,
+} from './types';
+import { TaxedItemPrice } from '.';
+
+describe('TaxedItemPrice builder spec', () => {
+  const modelBuilder = TaxedItemPrice.random()
+    .taxPortions([TaxPortion.random()])
+    .totalTax(
+      CentPrecisionMoney.random()
+        .centAmount(12345)
+        .currencyCode('EUR')
+        .fractionDigits(1)
+    );
+  const expectGenericCentPrecisionMoney = expect.objectContaining({
+    centAmount: expect.any(Number),
+    currencyCode: expect.any(String),
+    fractionDigits: expect.any(Number),
+  });
+
+  it(
+    ...createBuilderSpec<TTaxedItemPrice, TTaxedItemPriceRest>(
+      'rest',
+      modelBuilder,
+      expect.objectContaining({
+        totalNet: expectGenericCentPrecisionMoney,
+        totalGross: expectGenericCentPrecisionMoney,
+        taxPortions: expect.arrayContaining([
+          expect.objectContaining({
+            rate: expect.any(Number),
+            amount: expectGenericCentPrecisionMoney,
+          }),
+        ]),
+        totalTax: expect.objectContaining({
+          centAmount: 12345,
+          currencyCode: 'EUR',
+          fractionDigits: 1,
+        }),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TTaxedItemPrice, TTaxedItemPriceGraphql>(
+      'graphql',
+      modelBuilder,
+      expect.objectContaining({
+        totalNet: expectGenericCentPrecisionMoney,
+        totalGross: expectGenericCentPrecisionMoney,
+        taxPortions: expect.arrayContaining([
+          expect.objectContaining({
+            rate: expect.any(Number),
+            amount: expectGenericCentPrecisionMoney,
+            __typename: 'TaxPortion',
+          }),
+        ]),
+        totalTax: expect.objectContaining({
+          centAmount: 12345,
+          currencyCode: 'EUR',
+          fractionDigits: 1,
+          __typename: 'Money',
+        }),
+        __typename: 'TaxedItemPrice',
+      })
+    )
+  );
+});

--- a/models/cart/src/taxed-item-price/builder.ts
+++ b/models/cart/src/taxed-item-price/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import { TCreateTaxedItemPriceBuilder, TTaxedItemPrice } from './types';
+
+const Model: TCreateTaxedItemPriceBuilder = () =>
+  Builder<TTaxedItemPrice>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/cart/src/taxed-item-price/generator.ts
+++ b/models/cart/src/taxed-item-price/generator.ts
@@ -1,0 +1,16 @@
+import { CentPrecisionMoney } from '@commercetools-test-data/commons';
+import { fake, Generator } from '@commercetools-test-data/core';
+import { TTaxedItemPrice } from './types';
+
+// https://docs.commercetools.com/api/projects/carts#taxeditemprice
+
+const generator = Generator<TTaxedItemPrice>({
+  fields: {
+    totalNet: fake(() => CentPrecisionMoney.random()),
+    totalGross: fake(() => CentPrecisionMoney.random()),
+    taxPortions: [],
+    totalTax: null,
+  },
+});
+
+export default generator;

--- a/models/cart/src/taxed-item-price/index.ts
+++ b/models/cart/src/taxed-item-price/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export * as TaxedItemPrice from '.';

--- a/models/cart/src/taxed-item-price/transformers.ts
+++ b/models/cart/src/taxed-item-price/transformers.ts
@@ -1,0 +1,30 @@
+import { Transformer } from '@commercetools-test-data/core';
+import {
+  TTaxedItemPrice,
+  TTaxedItemPriceGraphql,
+  TTaxedItemPriceRest,
+} from './types';
+
+const buildFields: (keyof TTaxedItemPrice)[] = [
+  'totalNet',
+  'totalGross',
+  'taxPortions',
+  'totalTax',
+];
+
+const transformers = {
+  default: Transformer<TTaxedItemPrice, TTaxedItemPrice>('default', {
+    buildFields,
+  }),
+  rest: Transformer<TTaxedItemPrice, TTaxedItemPriceRest>('rest', {
+    buildFields,
+  }),
+  graphql: Transformer<TTaxedItemPrice, TTaxedItemPriceGraphql>('graphql', {
+    buildFields,
+    addFields: () => ({
+      __typename: 'TaxedItemPrice',
+    }),
+  }),
+};
+
+export default transformers;

--- a/models/cart/src/taxed-item-price/types.ts
+++ b/models/cart/src/taxed-item-price/types.ts
@@ -1,0 +1,13 @@
+import type { TaxedItemPrice } from '@commercetools/platform-sdk';
+import { TBuilder } from '@commercetools-test-data/core';
+
+// https://docs.commercetools.com/api/projects/carts#taxeditemprice
+
+export type TTaxedItemPrice = TaxedItemPrice;
+export type TTaxedItemPriceRest = TTaxedItemPrice;
+export type TTaxedItemPriceGraphql = TTaxedItemPrice & {
+  __typename: 'TaxedItemPrice';
+};
+
+export type TTaxedItemPriceBuilder = TBuilder<TTaxedItemPrice>;
+export type TCreateTaxedItemPriceBuilder = () => TTaxedItemPriceBuilder;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,9 @@ importers:
       '@commercetools-test-data/business-unit':
         specifier: 10.6.1
         version: link:../business-unit
+      '@commercetools-test-data/cart-discount':
+        specifier: 10.6.1
+        version: link:../cart-discount
       '@commercetools-test-data/channel':
         specifier: 10.6.1
         version: link:../channel

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "target": "ESNext",
     "module": "CommonJS",
     "moduleResolution": "Node",
+    "preserveSymlinks": true,
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
#### Summary

This PR creates shipping info model needed for this [migration PR](https://github.com/commercetools/merchant-center-frontend/pull/17434) which is based on [batch 12](https://commercetools.atlassian.net/browse/FEC-49) of the [chapter epic](https://commercetools.atlassian.net/browse/FEC-26) where we are migrating tests to use public test-data package 