### PR TITLE
[FEC-49] -fix dimension keys inside graphql representation

### DIFF
--- a/.changeset/hip-hairs-compare.md
+++ b/.changeset/hip-hairs-compare.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product': patch
+---
+
+Fix image dimension keys for graphQL response

--- a/models/product/src/image/builder.spec.ts
+++ b/models/product/src/image/builder.spec.ts
@@ -43,8 +43,8 @@ describe('builder', () => {
         label: expect.any(String),
         url: expect.any(String),
         dimensions: expect.objectContaining({
-          w: expect.any(Number),
-          h: expect.any(Number),
+          width: expect.any(Number),
+          height: expect.any(Number),
         }),
         __typename: 'Image',
       })

--- a/models/product/src/image/transformers.ts
+++ b/models/product/src/image/transformers.ts
@@ -10,7 +10,12 @@ const transformers = {
   }),
   graphql: Transformer<TImage, TImageGraphql>('graphql', {
     buildFields: [],
-    addFields: () => ({
+    replaceFields: ({ fields }) => ({
+      ...fields,
+      dimensions: {
+        width: fields.dimensions.w,
+        height: fields.dimensions.h,
+      },
       __typename: 'Image',
     }),
   }),

--- a/models/product/src/image/types.ts
+++ b/models/product/src/image/types.ts
@@ -4,7 +4,11 @@ import type { TBuilder } from '@commercetools-test-data/core';
 export type TImage = Image;
 export type TImageDraft = Image;
 
-export type TImageGraphql = TImage & {
+export type TImageGraphql = Omit<TImage, 'dimensions'> & {
+  dimensions: {
+    width: number;
+    height: number;
+  };
   __typename: 'Image';
 };
 

--- a/models/product/src/product-variant/builder.spec.ts
+++ b/models/product/src/product-variant/builder.spec.ts
@@ -21,6 +21,10 @@ describe('builder', () => {
         images: expect.arrayContaining([
           expect.objectContaining({
             url: expect.any(String),
+            dimensions: expect.objectContaining({
+              w: expect.any(Number),
+              h: expect.any(Number),
+            }),
           }),
         ]),
         attributes: expect.arrayContaining([
@@ -53,6 +57,10 @@ describe('builder', () => {
         images: expect.arrayContaining([
           expect.objectContaining({
             url: expect.any(String),
+            dimensions: expect.objectContaining({
+              w: expect.any(Number),
+              h: expect.any(Number),
+            }),
           }),
         ]),
         attributes: expect.arrayContaining([
@@ -87,6 +95,10 @@ describe('builder', () => {
         images: expect.arrayContaining([
           expect.objectContaining({
             url: expect.any(String),
+            dimensions: expect.objectContaining({
+              width: expect.any(Number),
+              height: expect.any(Number),
+            }),
             __typename: 'Image',
           }),
         ]),


### PR DESCRIPTION
#### Summary

This PR fixes `image` model image dimension graphQL keys needed for this [migration PR](https://github.com/commercetools/merchant-center-frontend/pull/17434) which is based on [batch 12](https://commercetools.atlassian.net/browse/FEC-49) of the [chapter epic](https://commercetools.atlassian.net/browse/FEC-26) where we are migrating tests to use public test-data package