### PR TITLE
[FEC-49] - add type definition model

### DIFF
--- a/.changeset/witty-apes-trade.md
+++ b/.changeset/witty-apes-trade.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product-type': minor
+---
+
+Added `type-definition` test model

--- a/models/product-type/package.json
+++ b/models/product-type/package.json
@@ -8,20 +8,30 @@
     "url": "https://github.com/commercetools/test-data.git",
     "directory": "models/product-type"
   },
-  "keywords": ["javascript", "typescript", "test-data"],
+  "keywords": [
+    "javascript",
+    "typescript",
+    "test-data"
+  ],
   "license": "MIT",
   "publishConfig": {
     "access": "public"
   },
   "main": "dist/commercetools-test-data-product-type.cjs.js",
   "module": "dist/commercetools-test-data-product-type.esm.js",
-  "files": ["dist", "package.json", "LICENSE", "README.md"],
+  "files": [
+    "dist",
+    "package.json",
+    "LICENSE",
+    "README.md"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/commons": "10.5.0",
     "@commercetools-test-data/core": "10.5.0",
     "@commercetools-test-data/utils": "10.5.0",
+    "@commercetools-test-data/type": "10.5.0",
     "@commercetools/platform-sdk": "^7.0.0",
     "@faker-js/faker": "^8.0.0"
   }

--- a/models/product-type/src/index.ts
+++ b/models/product-type/src/index.ts
@@ -50,3 +50,4 @@ export * as AttributeDateTimeTypeDraft from './attribute-date-time-type/attribut
 
 export * as ProductType from './product-type';
 export * as ProductTypeDraft from './product-type/product-type-draft';
+export * as TypeDefinition from './type-definition';

--- a/models/product-type/src/type-definition/builder.spec.ts
+++ b/models/product-type/src/type-definition/builder.spec.ts
@@ -1,0 +1,83 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { FieldDefinition } from '@commercetools-test-data/type';
+import { TTypeDefinition, TTypeDefinitionGraphql } from './types';
+import { TypeDefinition } from '.';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TTypeDefinition, TTypeDefinition>(
+      'default',
+      TypeDefinition.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        key: expect.any(String),
+        name: expect.objectContaining({
+          en: expect.any(String),
+        }),
+        fieldDefinitions: expect.arrayContaining([
+          expect.objectContaining({
+            name: expect.any(String),
+            required: expect.any(Boolean),
+          }),
+        ]),
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TTypeDefinition, TTypeDefinitionGraphql>(
+      'graphql',
+      TypeDefinition.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        key: expect.any(String),
+        fieldDefinitions: expect.arrayContaining([
+          expect.objectContaining({
+            name: expect.any(String),
+            required: expect.any(Boolean),
+          }),
+        ]),
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            value: expect.any(String),
+          }),
+        ]),
+        __typename: 'TypeDefinition',
+      })
+    )
+  );
+
+  it('should allow customization', () => {
+    const id = 'test-id';
+    const key = 'test key';
+    const nameEn = 'name in english';
+    const required = true;
+
+    const name = LocalizedString.random().en(nameEn);
+    const fieldDefinitions = FieldDefinition.random().required(required);
+
+    const typeDefinitionMock = TypeDefinition.random()
+      .id(id)
+      .key(key)
+      .name(name)
+      // TODO: fix TS error
+      .fieldDefinitions(fieldDefinitions)
+      .buildGraphql();
+
+    expect(typeDefinitionMock).toEqual(
+      expect.objectContaining({
+        id,
+        key,
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            value: nameEn,
+          }),
+        ]),
+        fieldDefinitions: expect.objectContaining({ required }),
+        __typename: 'TypeDefinition',
+      })
+    );
+  });
+});

--- a/models/product-type/src/type-definition/builder.spec.ts
+++ b/models/product-type/src/type-definition/builder.spec.ts
@@ -1,8 +1,6 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
-import { LocalizedString } from '@commercetools-test-data/commons';
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import { FieldDefinition } from '@commercetools-test-data/type';
 import { TTypeDefinition, TTypeDefinitionGraphql } from './types';
 import { TypeDefinition } from '.';
 
@@ -48,36 +46,4 @@ describe('builder', () => {
       })
     )
   );
-
-  it('should allow customization', () => {
-    const id = 'test-id';
-    const key = 'test key';
-    const nameEn = 'name in english';
-    const required = true;
-
-    const name = LocalizedString.random().en(nameEn);
-    const fieldDefinitions = FieldDefinition.random().required(required);
-
-    const typeDefinitionMock = TypeDefinition.random()
-      .id(id)
-      .key(key)
-      .name(name)
-      // TODO: fix TS error
-      .fieldDefinitions(fieldDefinitions)
-      .buildGraphql();
-
-    expect(typeDefinitionMock).toEqual(
-      expect.objectContaining({
-        id,
-        key,
-        nameAllLocales: expect.arrayContaining([
-          expect.objectContaining({
-            value: nameEn,
-          }),
-        ]),
-        fieldDefinitions: expect.objectContaining({ required }),
-        __typename: 'TypeDefinition',
-      })
-    );
-  });
 });

--- a/models/product-type/src/type-definition/builder.spec.ts
+++ b/models/product-type/src/type-definition/builder.spec.ts
@@ -1,49 +1,53 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
-import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import { TTypeDefinition, TTypeDefinitionGraphql } from './types';
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { FieldDefinition } from '@commercetools-test-data/type';
 import { TypeDefinition } from '.';
 
 describe('builder', () => {
-  it(
-    ...createBuilderSpec<TTypeDefinition, TTypeDefinition>(
-      'default',
-      TypeDefinition.random(),
+  it('should allow customization', () => {
+    const typeDefinitionMock = TypeDefinition.random()
+      .description(LocalizedString.random())
+      .resourceTypeIds(['string 1', 'string 2'])
+      .fieldDefinitions([FieldDefinition.random()])
+      .buildGraphql();
+
+    expect(typeDefinitionMock).toEqual(
       expect.objectContaining({
-        id: expect.any(String),
         key: expect.any(String),
-        name: expect.objectContaining({
-          en: expect.any(String),
-        }),
-        fieldDefinitions: expect.arrayContaining([
-          expect.objectContaining({
-            name: expect.any(String),
-            required: expect.any(Boolean),
-          }),
-        ]),
-      })
-    )
-  );
-  it(
-    ...createBuilderSpec<TTypeDefinition, TTypeDefinitionGraphql>(
-      'graphql',
-      TypeDefinition.random(),
-      expect.objectContaining({
-        id: expect.any(String),
-        key: expect.any(String),
-        fieldDefinitions: expect.arrayContaining([
-          expect.objectContaining({
-            name: expect.any(String),
-            required: expect.any(Boolean),
-          }),
-        ]),
+        name: expect.any(String),
         nameAllLocales: expect.arrayContaining([
           expect.objectContaining({
+            locale: expect.any(String),
             value: expect.any(String),
           }),
         ]),
+        description: expect.any(String),
+        descriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: expect.any(String),
+            value: expect.any(String),
+          }),
+        ]),
+        resourceTypeIds: expect.arrayContaining([expect.any(String)]),
+        fieldDefinitions: expect.arrayContaining([
+          expect.objectContaining({
+            inputHint: expect.any(String),
+            __typename: 'FieldDefinition',
+          }),
+        ]),
+        id: expect.any(String),
+        version: expect.any(Number),
+        createdAt: expect.any(String),
+        createdBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+        }),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          customerRef: expect.objectContaining({ typeId: 'customer' }),
+        }),
         __typename: 'TypeDefinition',
       })
-    )
-  );
+    );
+  });
 });

--- a/models/product-type/src/type-definition/builder.ts
+++ b/models/product-type/src/type-definition/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import generator from './generator';
+import transformers from './transformers';
+import type { TCreateTypeDefinitionBuilder, TTypeDefinition } from './types';
+
+const Model: TCreateTypeDefinitionBuilder = () =>
+  Builder<TTypeDefinition>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/product-type/src/type-definition/generator.ts
+++ b/models/product-type/src/type-definition/generator.ts
@@ -1,0 +1,18 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { fake, Generator } from '@commercetools-test-data/core';
+import { FieldDefinition } from '@commercetools-test-data/type';
+import type { TTypeDefinition } from './types';
+
+// https://docs.commercetools.com/api/projects/but where is this?
+// NOTE: SHould this be under type actually?
+
+const generator = Generator<TTypeDefinition>({
+  fields: {
+    id: fake((f) => f.string.uuid()),
+    key: fake((f) => f.lorem.words()),
+    name: fake(() => LocalizedString.random()),
+    fieldDefinitions: [fake(() => FieldDefinition.random())],
+  },
+});
+
+export default generator;

--- a/models/product-type/src/type-definition/generator.ts
+++ b/models/product-type/src/type-definition/generator.ts
@@ -1,17 +1,27 @@
-import { LocalizedString } from '@commercetools-test-data/commons';
-import { fake, Generator } from '@commercetools-test-data/core';
+import {
+  LocalizedString,
+  ClientLogging,
+} from '@commercetools-test-data/commons';
+import { fake, Generator, sequence } from '@commercetools-test-data/core';
 import { FieldDefinition } from '@commercetools-test-data/type';
+import { createRelatedDates } from '@commercetools-test-data/utils';
 import type { TTypeDefinition } from './types';
 
-// https://docs.commercetools.com/api/projects/but where is this?
-// NOTE: SHould this be under type actually?
+const [getOlderDate, getNewerDate] = createRelatedDates();
 
 const generator = Generator<TTypeDefinition>({
   fields: {
-    id: fake((f) => f.string.uuid()),
     key: fake((f) => f.lorem.words()),
     name: fake(() => LocalizedString.random()),
+    description: undefined,
+    resourceTypeIds: [],
     fieldDefinitions: [fake(() => FieldDefinition.random())],
+    id: fake((f) => f.string.uuid()),
+    version: sequence(),
+    createdAt: fake(getOlderDate),
+    createdBy: fake(() => ClientLogging.random()),
+    lastModifiedAt: fake(getNewerDate),
+    lastModifiedBy: fake(() => ClientLogging.random()),
   },
 });
 

--- a/models/product-type/src/type-definition/index.ts
+++ b/models/product-type/src/type-definition/index.ts
@@ -1,0 +1,5 @@
+export * as TypeDefinition from '.';
+
+export { default as random } from './builder';
+
+export * from './types';

--- a/models/product-type/src/type-definition/transformers.ts
+++ b/models/product-type/src/type-definition/transformers.ts
@@ -1,0 +1,26 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { Transformer } from '@commercetools-test-data/core';
+import type { TTypeDefinition, TTypeDefinitionGraphql } from './types';
+
+const transformers = {
+  default: Transformer<TTypeDefinition, TTypeDefinition>('default', {
+    buildFields: ['fieldDefinitions', 'name'],
+  }),
+  rest: Transformer<TTypeDefinition, TTypeDefinition>('rest', {
+    buildFields: ['fieldDefinitions', 'name'],
+  }),
+  graphql: Transformer<TTypeDefinition, TTypeDefinitionGraphql>('graphql', {
+    buildFields: ['fieldDefinitions'],
+    replaceFields: ({ fields }) => {
+      const nameAllLocales = LocalizedString.toLocalizedField(fields.name);
+
+      return {
+        ...fields,
+        nameAllLocales,
+        __typename: 'TypeDefinition',
+      };
+    },
+  }),
+};
+
+export default transformers;

--- a/models/product-type/src/type-definition/transformers.ts
+++ b/models/product-type/src/type-definition/transformers.ts
@@ -2,21 +2,40 @@ import { LocalizedString } from '@commercetools-test-data/commons';
 import { Transformer } from '@commercetools-test-data/core';
 import type { TTypeDefinition, TTypeDefinitionGraphql } from './types';
 
+const buildFields: (keyof TTypeDefinition)[] = [
+  'name',
+  'description',
+  'fieldDefinitions',
+  'createdBy',
+  'lastModifiedBy',
+];
+
 const transformers = {
   default: Transformer<TTypeDefinition, TTypeDefinition>('default', {
-    buildFields: ['fieldDefinitions', 'name'],
+    buildFields,
   }),
   rest: Transformer<TTypeDefinition, TTypeDefinition>('rest', {
-    buildFields: ['fieldDefinitions', 'name'],
+    buildFields,
   }),
   graphql: Transformer<TTypeDefinition, TTypeDefinitionGraphql>('graphql', {
-    buildFields: ['fieldDefinitions'],
+    buildFields: ['fieldDefinitions', 'createdBy', 'lastModifiedBy'],
     replaceFields: ({ fields }) => {
-      const nameAllLocales = LocalizedString.toLocalizedField(fields.name);
+      const nameAllLocales = LocalizedString.toLocalizedField(fields.name)!;
+      const descriptionAllLocales = LocalizedString.toLocalizedField(
+        fields.description
+      );
+      const name =
+        LocalizedString.resolveGraphqlDefaultLocaleValue(nameAllLocales);
+      const description = LocalizedString.resolveGraphqlDefaultLocaleValue(
+        descriptionAllLocales
+      );
 
       return {
         ...fields,
         nameAllLocales,
+        descriptionAllLocales: descriptionAllLocales || undefined,
+        name,
+        description,
         __typename: 'TypeDefinition',
       };
     },

--- a/models/product-type/src/type-definition/types.ts
+++ b/models/product-type/src/type-definition/types.ts
@@ -1,19 +1,36 @@
-// import { TypeDefinition } from '@commercetools/platform-sdk'; shouldn't this come from here?
+import { CreatedBy, LastModifiedBy } from '@commercetools/platform-sdk';
+import type {
+  TLocalizedString,
+  TLocalizedStringGraphql,
+} from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
+import type { TFieldDefinition } from '@commercetools-test-data/type';
 
-export interface TypeDefinition {
-  id: string;
+export type TTypeDefinition = {
   key: string;
-  name: null;
-  fieldDefinitions: null;
-}
+  name: TLocalizedString;
+  description?: TLocalizedString;
+  resourceTypeIds: string[];
+  fieldDefinitions: TFieldDefinition[];
+  id: string;
+  version: number;
+  createdAt: string;
+  lastModifiedAt: string;
+  lastModifiedBy?: LastModifiedBy;
+  createdBy?: CreatedBy;
+};
 
-export type TTypeDefinitionGraphql = TTypeDefinition & {
+export type TTypeDefinitionGraphql = Omit<
+  TTypeDefinition,
+  'name' | 'description'
+> & {
+  nameAllLocales: TLocalizedStringGraphql;
+  descriptionAllLocales?: TLocalizedStringGraphql;
+  name?: string;
+  description?: string;
   __typename: 'TypeDefinition';
 };
 
-export type TTypeDefinitionBuilder = TBuilder<TypeDefinition>;
-
-export type TTypeDefinition = TypeDefinition;
+export type TTypeDefinitionBuilder = TBuilder<TTypeDefinition>;
 
 export type TCreateTypeDefinitionBuilder = () => TTypeDefinitionBuilder;

--- a/models/product-type/src/type-definition/types.ts
+++ b/models/product-type/src/type-definition/types.ts
@@ -1,0 +1,19 @@
+// import { TypeDefinition } from '@commercetools/platform-sdk'; shouldn't this come from here?
+import type { TBuilder } from '@commercetools-test-data/core';
+
+export interface TypeDefinition {
+  id: string;
+  key: string;
+  name: null;
+  fieldDefinitions: null;
+}
+
+export type TTypeDefinitionGraphql = TTypeDefinition & {
+  __typename: 'TypeDefinition';
+};
+
+export type TTypeDefinitionBuilder = TBuilder<TypeDefinition>;
+
+export type TTypeDefinition = TypeDefinition;
+
+export type TCreateTypeDefinitionBuilder = () => TTypeDefinitionBuilder;

--- a/models/type/src/index.ts
+++ b/models/type/src/index.ts
@@ -13,6 +13,7 @@ export * from './custom-field-reference-type/types';
 export * from './custom-field-set-type/types';
 export * from './custom-field-string-type/types';
 export * from './custom-field-time-type/types';
+export * from './field-definition/types';
 
 // Export models
 export * as CustomFieldBooleanType from './custom-field-boolean-type';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -955,6 +955,9 @@ importers:
       '@commercetools-test-data/core':
         specifier: 10.5.0
         version: link:../../core
+      '@commercetools-test-data/type':
+        specifier: 10.5.0
+        version: link:../type
       '@commercetools-test-data/utils':
         specifier: 10.5.0
         version: link:../../utils


### PR DESCRIPTION
#### Summary

This PR creates `type definition` model needed for this [migration PR](https://github.com/commercetools/merchant-center-frontend/pull/17434) which is based on [batch 12](https://commercetools.atlassian.net/browse/FEC-49) of the [chapter epic](https://commercetools.atlassian.net/browse/FEC-26) where we are migrating tests to use public test-data package