### PR TITLE
[B2B sample data]: set us standard vat not included in price

### DIFF
--- a/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-b2b/standard-tax.spec.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-b2b/standard-tax.spec.ts
@@ -49,7 +49,7 @@ describe(`with standardTax preset`, () => {
           {
             "amount": 0.2,
             "country": "US",
-            "includedInPrice": true,
+            "includedInPrice": false,
             "key": "vat-standard-us",
             "name": "Standard VAT for US",
             "state": undefined,
@@ -126,7 +126,7 @@ describe(`with standardTax preset`, () => {
           {
             "amount": 0.2,
             "country": "US",
-            "includedInPrice": true,
+            "includedInPrice": false,
             "key": "vat-standard-us",
             "name": "Standard VAT for US",
             "state": undefined,

--- a/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-b2b/standard-tax.ts
+++ b/models/tax-category/src/tax-category/tax-category-draft/presets/sample-data-b2b/standard-tax.ts
@@ -44,7 +44,7 @@ const standardTax = () =>
         .empty()
         .name('Standard VAT for US')
         .amount(0.2)
-        .includedInPrice(true)
+        .includedInPrice(false)
         .country('US')
         .key('vat-standard-us')
         .subRates([]),


### PR DESCRIPTION
## [B2B sample data]: set us standard vat not included in price

Small PR to update the standard VAT since all other US tax categories don't include the tax in the price. This change ensures consistency across the tax categories on the US and was requested by commercetools FE.
