### PR TITLE
FEC-60: Fix `state` model and add `CategorySearch` model

### DIFF
--- a/.changeset/rude-games-sin.md
+++ b/.changeset/rude-games-sin.md
@@ -1,0 +1,12 @@
+---
+'@commercetools-test-data/category': patch
+'@commercetools-test-data/state': patch
+---
+
+### Category Model (`category`)
+
+- Introduced a new model called `category-search`.
+
+### State Model (`state`)
+
+- Updated the transformer file to transform `name` and `description` for graphql

--- a/models/category/src/category-search/builder.spec.ts
+++ b/models/category/src/category-search/builder.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
 
+import { LocalizedString } from '@commercetools-test-data/commons';
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import type { TCategorySearch, TCategorySearchGraphql } from '../types';
 import * as CategorySearch from './index';
@@ -149,4 +150,29 @@ describe('builder', () => {
       })
     )
   );
+
+  it('should allow customization', () => {
+    const ancestors = [CategorySearch.random()];
+    const productTypeNames = ['product-type-1'];
+    const children = [CategorySearch.random()];
+    const name = LocalizedString.random().en('custom-name');
+    const category: TCategorySearchGraphql = CategorySearch.random()
+      .name(name)
+      .ancestors(ancestors)
+      .productTypeNames(productTypeNames)
+      .children(children)
+      .buildGraphql();
+
+    expect(category.nameAllLocales).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          locale: 'en',
+          value: 'custom-name',
+        }),
+      ])
+    );
+    expect(category.ancestors).toEqual([ancestors[0].buildGraphql()]);
+    expect(category.productTypeNames).toEqual(productTypeNames);
+    expect(category.children).toEqual([children[0].buildGraphql()]);
+  });
 });

--- a/models/category/src/category-search/builder.spec.ts
+++ b/models/category/src/category-search/builder.spec.ts
@@ -6,20 +6,36 @@ import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import type { TCategorySearch, TCategorySearchGraphql } from '../types';
 import * as CategorySearch from './index';
 
+const expectedResult = {
+  id: expect.any(String),
+  version: expect.any(Number),
+  key: expect.any(String),
+  externalId: expect.any(String),
+  orderHint: expect.any(String),
+  parent: expect.objectContaining({
+    typeId: 'category',
+  }),
+  createdAt: expect.any(String),
+  lastModifiedAt: expect.any(String),
+  parentRef: expect.objectContaining({
+    typeId: 'category',
+  }),
+  childCount: expect.any(Number),
+  stagedProductCount: expect.any(Number),
+  ancestorsRef: [],
+  ancestors: [],
+  productTypeNames: [],
+  children: [],
+  assets: [],
+  custom: [],
+};
 describe('builder', () => {
   it(
     ...createBuilderSpec<TCategorySearch, TCategorySearch>(
       'default',
       CategorySearch.random(),
       expect.objectContaining({
-        id: expect.any(String),
-        version: expect.any(Number),
-        key: expect.any(String),
-        externalId: expect.any(String),
-        orderHint: expect.any(String),
-        parent: expect.objectContaining({
-          typeId: 'category',
-        }),
+        ...expectedResult,
         name: expect.objectContaining({
           en: expect.any(String),
           de: expect.any(String),
@@ -35,19 +51,6 @@ describe('builder', () => {
           de: expect.any(String),
           fr: expect.any(String),
         }),
-        createdAt: expect.any(String),
-        lastModifiedAt: expect.any(String),
-        parentRef: expect.objectContaining({
-          typeId: 'category',
-        }),
-        childCount: expect.any(Number),
-        stagedProductCount: expect.any(Number),
-        ancestorsRef: [],
-        ancestors: [],
-        productTypeNames: [],
-        children: [],
-        assets: [],
-        custom: [],
       })
     )
   );
@@ -57,14 +60,7 @@ describe('builder', () => {
       'rest',
       CategorySearch.random(),
       expect.objectContaining({
-        id: expect.any(String),
-        version: expect.any(Number),
-        key: expect.any(String),
-        externalId: expect.any(String),
-        orderHint: expect.any(String),
-        parent: expect.objectContaining({
-          typeId: 'category',
-        }),
+        ...expectedResult,
         name: expect.objectContaining({
           en: expect.any(String),
           de: expect.any(String),
@@ -80,19 +76,6 @@ describe('builder', () => {
           de: expect.any(String),
           fr: expect.any(String),
         }),
-        createdAt: expect.any(String),
-        lastModifiedAt: expect.any(String),
-        parentRef: expect.objectContaining({
-          typeId: 'category',
-        }),
-        childCount: expect.any(Number),
-        stagedProductCount: expect.any(Number),
-        ancestorsRef: [],
-        ancestors: [],
-        productTypeNames: [],
-        children: [],
-        assets: [],
-        custom: [],
       })
     )
   );
@@ -101,22 +84,10 @@ describe('builder', () => {
       'graphql',
       CategorySearch.random(),
       expect.objectContaining({
-        id: expect.any(String),
-        version: expect.any(Number),
-        key: expect.any(String),
-        externalId: expect.any(String),
-        orderHint: expect.any(String),
-        parent: expect.objectContaining({
-          typeId: 'category',
-        }),
+        ...expectedResult,
         name: expect.any(String),
         description: expect.any(String),
         slug: expect.any(String),
-        createdAt: expect.any(String),
-        lastModifiedAt: expect.any(String),
-        parentRef: expect.objectContaining({
-          typeId: 'category',
-        }),
         nameAllLocales: expect.arrayContaining([
           expect.objectContaining({
             locale: 'en',
@@ -138,14 +109,6 @@ describe('builder', () => {
             __typename: 'LocalizedString',
           }),
         ]),
-        childCount: expect.any(Number),
-        stagedProductCount: expect.any(Number),
-        ancestorsRef: [],
-        ancestors: [],
-        productTypeNames: [],
-        children: [],
-        assets: [],
-        custom: [],
         __typename: 'CategorySearch',
       })
     )

--- a/models/category/src/category-search/builder.spec.ts
+++ b/models/category/src/category-search/builder.spec.ts
@@ -1,0 +1,152 @@
+/* eslint-disable jest/no-disabled-tests */
+/* eslint-disable jest/valid-title */
+
+import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import type { TCategorySearch, TCategorySearchGraphql } from '../types';
+import * as CategorySearch from './index';
+
+describe('builder', () => {
+  it(
+    ...createBuilderSpec<TCategorySearch, TCategorySearch>(
+      'default',
+      CategorySearch.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        key: expect.any(String),
+        externalId: expect.any(String),
+        orderHint: expect.any(String),
+        parent: expect.objectContaining({
+          typeId: 'category',
+        }),
+        name: expect.objectContaining({
+          en: expect.any(String),
+          de: expect.any(String),
+          fr: expect.any(String),
+        }),
+        description: expect.objectContaining({
+          en: expect.any(String),
+          de: expect.any(String),
+          fr: expect.any(String),
+        }),
+        slug: expect.objectContaining({
+          en: expect.any(String),
+          de: expect.any(String),
+          fr: expect.any(String),
+        }),
+        createdAt: expect.any(String),
+        lastModifiedAt: expect.any(String),
+        parentRef: expect.objectContaining({
+          typeId: 'category',
+        }),
+        childCount: expect.any(Number),
+        stagedProductCount: expect.any(Number),
+        ancestorsRef: [],
+        ancestors: [],
+        productTypeNames: [],
+        children: [],
+        assets: [],
+        custom: [],
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TCategorySearch, TCategorySearch>(
+      'rest',
+      CategorySearch.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        key: expect.any(String),
+        externalId: expect.any(String),
+        orderHint: expect.any(String),
+        parent: expect.objectContaining({
+          typeId: 'category',
+        }),
+        name: expect.objectContaining({
+          en: expect.any(String),
+          de: expect.any(String),
+          fr: expect.any(String),
+        }),
+        description: expect.objectContaining({
+          en: expect.any(String),
+          de: expect.any(String),
+          fr: expect.any(String),
+        }),
+        slug: expect.objectContaining({
+          en: expect.any(String),
+          de: expect.any(String),
+          fr: expect.any(String),
+        }),
+        createdAt: expect.any(String),
+        lastModifiedAt: expect.any(String),
+        parentRef: expect.objectContaining({
+          typeId: 'category',
+        }),
+        childCount: expect.any(Number),
+        stagedProductCount: expect.any(Number),
+        ancestorsRef: [],
+        ancestors: [],
+        productTypeNames: [],
+        children: [],
+        assets: [],
+        custom: [],
+      })
+    )
+  );
+  it(
+    ...createBuilderSpec<TCategorySearch, TCategorySearchGraphql>(
+      'graphql',
+      CategorySearch.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        key: expect.any(String),
+        externalId: expect.any(String),
+        orderHint: expect.any(String),
+        parent: expect.objectContaining({
+          typeId: 'category',
+        }),
+        name: expect.any(String),
+        description: expect.any(String),
+        slug: expect.any(String),
+        createdAt: expect.any(String),
+        lastModifiedAt: expect.any(String),
+        parentRef: expect.objectContaining({
+          typeId: 'category',
+        }),
+        nameAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        descriptionAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        slugAllLocales: expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: expect.any(String),
+            __typename: 'LocalizedString',
+          }),
+        ]),
+        childCount: expect.any(Number),
+        stagedProductCount: expect.any(Number),
+        ancestorsRef: [],
+        ancestors: [],
+        productTypeNames: [],
+        children: [],
+        assets: [],
+        custom: [],
+        __typename: 'CategorySearch',
+      })
+    )
+  );
+});

--- a/models/category/src/category-search/builder.ts
+++ b/models/category/src/category-search/builder.ts
@@ -1,0 +1,12 @@
+import { Builder } from '@commercetools-test-data/core';
+import type { TCreateCategorySearchBuilder, TCategorySearch } from '../types';
+import generator from './generator';
+import transformers from './transformers';
+
+const Model: TCreateCategorySearchBuilder = () =>
+  Builder<TCategorySearch>({
+    generator,
+    transformers,
+  });
+
+export default Model;

--- a/models/category/src/category-search/generator.ts
+++ b/models/category/src/category-search/generator.ts
@@ -1,0 +1,37 @@
+import {
+  KeyReferenceDraft,
+  LocalizedString,
+  Reference,
+} from '@commercetools-test-data/commons';
+import { fake, Generator, sequence } from '@commercetools-test-data/core';
+import { createRelatedDates } from '@commercetools-test-data/utils';
+import { TCategorySearch } from '../types';
+
+const [getOlderDate, getNewerDate] = createRelatedDates();
+
+const CategorySearch = Generator<TCategorySearch>({
+  fields: {
+    id: fake((f) => f.string.uuid()),
+    version: sequence(),
+    key: fake((f) => f.lorem.slug(2)),
+    name: fake(() => LocalizedString.random()),
+    slug: fake(() => LocalizedString.presets.ofSlugs()),
+    description: fake(() => LocalizedString.random()),
+    ancestorsRef: [],
+    ancestors: [],
+    parentRef: fake(() => Reference.random().typeId('category')),
+    parent: fake(() => KeyReferenceDraft.presets.category().key('key')),
+    externalId: fake((f) => f.string.uuid()),
+    stagedProductCount: fake((f) => f.number.int()),
+    childCount: fake((f) => f.number.int()),
+    productTypeNames: [],
+    children: [],
+    createdAt: fake(getOlderDate),
+    lastModifiedAt: fake(getNewerDate),
+    orderHint: fake((f) => f.number.float({ min: 0.01, max: 0.99 }).toString()),
+    assets: [],
+    custom: [],
+  },
+});
+
+export default CategorySearch;

--- a/models/category/src/category-search/index.ts
+++ b/models/category/src/category-search/index.ts
@@ -1,0 +1,2 @@
+export { default as random } from './builder';
+export * as presets from './presets';

--- a/models/category/src/category-search/presets/index.ts
+++ b/models/category/src/category-search/presets/index.ts
@@ -1,0 +1,2 @@
+export { default as withParent } from './with-parent';
+export { default as withParentAndAncestors } from './with-parent-and-ancestors';

--- a/models/category/src/category-search/presets/with-parent-and-ancestors.spec.ts
+++ b/models/category/src/category-search/presets/with-parent-and-ancestors.spec.ts
@@ -1,0 +1,29 @@
+import { TCategorySearch } from '../../types';
+import withParentAndAncestors from './with-parent-and-ancestors';
+
+it('should set the label only for en locale', () => {
+  const categoryWithParentAndAncestors: TCategorySearch =
+    withParentAndAncestors().build();
+  expect(categoryWithParentAndAncestors).toEqual(
+    expect.objectContaining({
+      parent: expect.objectContaining({
+        id: expect.any(String),
+        name: expect.objectContaining({
+          en: expect.any(String),
+          de: expect.any(String),
+          fr: expect.any(String),
+        }),
+      }),
+      ancestors: expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.any(String),
+          name: expect.objectContaining({
+            en: expect.any(String),
+            de: expect.any(String),
+            fr: expect.any(String),
+          }),
+        }),
+      ]),
+    })
+  );
+});

--- a/models/category/src/category-search/presets/with-parent-and-ancestors.ts
+++ b/models/category/src/category-search/presets/with-parent-and-ancestors.ts
@@ -1,9 +1,10 @@
+import { TCategorySearchBuilder } from '../../types';
 import CategorySearch from '../builder';
 
-function withParentAndAncestors() {
+const withParentAndAncestors = (): TCategorySearchBuilder => {
   return CategorySearch()
     .parent(CategorySearch())
     .ancestors([CategorySearch()]);
-}
+};
 
 export default withParentAndAncestors;

--- a/models/category/src/category-search/presets/with-parent-and-ancestors.ts
+++ b/models/category/src/category-search/presets/with-parent-and-ancestors.ts
@@ -1,0 +1,9 @@
+import CategorySearch from '../builder';
+
+function withParentAndAncestors() {
+  return CategorySearch()
+    .parent(CategorySearch())
+    .ancestors([CategorySearch()]);
+}
+
+export default withParentAndAncestors;

--- a/models/category/src/category-search/presets/with-parent.spec.ts
+++ b/models/category/src/category-search/presets/with-parent.spec.ts
@@ -1,0 +1,18 @@
+import { TCategorySearch } from '../../types';
+import withParent from './with-parent-and-ancestors';
+
+it('should set the label only for en locale', () => {
+  const categoryWithParent: TCategorySearch = withParent().build();
+  expect(categoryWithParent).toEqual(
+    expect.objectContaining({
+      parent: expect.objectContaining({
+        id: expect.any(String),
+        name: expect.objectContaining({
+          en: expect.any(String),
+          de: expect.any(String),
+          fr: expect.any(String),
+        }),
+      }),
+    })
+  );
+});

--- a/models/category/src/category-search/presets/with-parent.ts
+++ b/models/category/src/category-search/presets/with-parent.ts
@@ -1,7 +1,8 @@
+import { TCategorySearchBuilder } from '../../types';
 import CategorySearch from '../builder';
 
-function withParent() {
+const withParent = (): TCategorySearchBuilder => {
   return CategorySearch().parent(CategorySearch());
-}
+};
 
 export default withParent;

--- a/models/category/src/category-search/presets/with-parent.ts
+++ b/models/category/src/category-search/presets/with-parent.ts
@@ -1,0 +1,7 @@
+import CategorySearch from '../builder';
+
+function withParent() {
+  return CategorySearch().parent(CategorySearch());
+}
+
+export default withParent;

--- a/models/category/src/category-search/transformers.ts
+++ b/models/category/src/category-search/transformers.ts
@@ -7,7 +7,6 @@ const buildFields: (keyof TCategorySearch)[] = [
   'ancestors',
   'parentRef',
   'parent',
-  'productTypeNames',
   'children',
   'assets',
   'custom',

--- a/models/category/src/category-search/transformers.ts
+++ b/models/category/src/category-search/transformers.ts
@@ -1,0 +1,52 @@
+import { LocalizedString } from '@commercetools-test-data/commons';
+import { Transformer } from '@commercetools-test-data/core';
+import { TCategorySearch, TCategorySearchGraphql } from '../types';
+
+const buildFields: (keyof TCategorySearch)[] = [
+  'ancestorsRef',
+  'ancestors',
+  'parentRef',
+  'parent',
+  'productTypeNames',
+  'children',
+  'assets',
+  'custom',
+];
+
+const transformers = {
+  default: Transformer<TCategorySearch, TCategorySearch>('default', {
+    buildFields: ['name', 'slug', 'description', ...buildFields],
+  }),
+  rest: Transformer<TCategorySearch, TCategorySearch>('rest', {
+    buildFields: ['name', 'slug', 'description', ...buildFields],
+  }),
+  graphql: Transformer<TCategorySearch, TCategorySearchGraphql>('graphql', {
+    buildFields,
+    replaceFields: ({ fields }) => {
+      const nameAllLocales = LocalizedString.toLocalizedField(fields.name);
+      const descriptionAllLocales = LocalizedString.toLocalizedField(
+        fields.description
+      );
+      const slugAllLocales = LocalizedString.toLocalizedField(fields.slug);
+      return {
+        ...fields,
+        name:
+          LocalizedString.resolveGraphqlDefaultLocaleValue(nameAllLocales) ??
+          null,
+        nameAllLocales,
+        description:
+          LocalizedString.resolveGraphqlDefaultLocaleValue(
+            descriptionAllLocales
+          ) ?? null,
+        descriptionAllLocales,
+        slug:
+          LocalizedString.resolveGraphqlDefaultLocaleValue(slugAllLocales) ??
+          null,
+        slugAllLocales,
+        __typename: 'CategorySearch',
+      };
+    },
+  }),
+};
+
+export default transformers;

--- a/models/category/src/index.ts
+++ b/models/category/src/index.ts
@@ -1,5 +1,6 @@
 export * as CategoryDraft from './category-draft';
 export * as Category from '.';
+export * as CategorySearch from './category-search';
 
 export { default as random } from './builder';
 export { default as presets } from './presets';

--- a/models/category/src/types.ts
+++ b/models/category/src/types.ts
@@ -1,4 +1,10 @@
-import type { Category, CategoryDraft } from '@commercetools/platform-sdk';
+import type {
+  Asset,
+  Category,
+  CategoryDraft,
+  CustomFields,
+  Reference,
+} from '@commercetools/platform-sdk';
 import type {
   TClientLoggingGraphql,
   TLocalizedStringDraftGraphql,
@@ -58,4 +64,36 @@ export type TCategoryGraphql = Omit<
   metaKeywordsAllLocales?: TLocalizedStringGraphql | null;
   metaDescription?: string;
   metaDescriptionAllLocales?: TLocalizedStringGraphql | null;
+};
+
+// CategorySearch
+export type TCategorySearch = {
+  id: string;
+  key: string;
+  version: number;
+  name?: string | null;
+  description?: string | null;
+  slug?: String | null;
+  ancestorsRef: Reference[];
+  ancestors: TCategorySearch[];
+  parentRef: Reference;
+  parent: TCategorySearch;
+  externalId: String;
+  stagedProductCount: number;
+  childCount: number;
+  productTypeNames: String[] | null;
+  children: TCategorySearch[] | null;
+  createdAt: string;
+  lastModifiedAt: string;
+  orderHint: string;
+  assets: Asset[];
+  custom: CustomFields[];
+};
+export type TCategorySearchBuilder = TBuilder<TCategorySearch>;
+export type TCreateCategorySearchBuilder = () => TCategorySearchBuilder;
+export type TCategorySearchGraphql = TCategorySearch & {
+  nameAllLocales: TLocalizedStringGraphql | null;
+  descriptionAllLocales: TLocalizedStringGraphql | null;
+  slugAllLocales: TLocalizedStringGraphql | null;
+  __typename: 'CategorySearch';
 };

--- a/models/state/src/builder.spec.ts
+++ b/models/state/src/builder.spec.ts
@@ -80,26 +80,8 @@ describe('builder', () => {
         version: expect.any(Number),
         key: expect.any(String),
         type: expect.any(String),
-        name: expect.arrayContaining([
-          expect.objectContaining({
-            locale: 'en',
-            value: expect.any(String),
-          }),
-          expect.objectContaining({
-            locale: 'de',
-            value: expect.any(String),
-          }),
-          expect.objectContaining({
-            locale: 'fr',
-            value: expect.any(String),
-          }),
-        ]),
-        description: expect.arrayContaining([
-          expect.objectContaining({
-            locale: 'en',
-            value: expect.any(String),
-          }),
-        ]),
+        name: expect.any(String),
+        description: expect.any(String),
         initial: expect.any(Boolean),
         builtIn: expect.any(Boolean),
         roles: expect.any(Array),

--- a/models/state/src/transformers.ts
+++ b/models/state/src/transformers.ts
@@ -23,23 +23,22 @@ const transformers = {
   }),
   // Note that the State graphql is provided as scaffolding only and may not be complete at this time.
   graphql: Transformer<TState, TStateGraphql>('graphql', {
-    buildFields: [
-      'name',
-      'description',
-      'createdBy',
-      'lastModifiedBy',
-      'transitions',
-    ],
-    addFields: ({ fields }) => {
+    buildFields: ['createdBy', 'lastModifiedBy', 'transitions'],
+    replaceFields: ({ fields }) => {
       const nameAllLocales = LocalizedString.toLocalizedField(fields.name);
       const descriptionAllLocales = LocalizedString.toLocalizedField(
         fields.description
       );
 
       return {
+        ...(fields as unknown as TStateGraphql),
         __typename: 'State',
         nameAllLocales,
         descriptionAllLocales,
+        name: LocalizedString.resolveGraphqlDefaultLocaleValue(nameAllLocales)!,
+        description: LocalizedString.resolveGraphqlDefaultLocaleValue(
+          descriptionAllLocales
+        ),
       };
     },
   }),

--- a/models/state/src/types.ts
+++ b/models/state/src/types.ts
@@ -1,10 +1,15 @@
 import type { State, StateDraft } from '@commercetools/platform-sdk';
+import { TLocalizedStringGraphql } from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
 
 export type TState = State;
 export type TStateDraft = StateDraft;
 
-export type TStateGraphql = TState & {
+export type TStateGraphql = Omit<TState, 'name' | 'description'> & {
+  name?: string;
+  description?: string;
+  nameAllLocales?: TLocalizedStringGraphql | null;
+  descriptionAllLocales?: TLocalizedStringGraphql | null;
   __typename: 'State';
 };
 export type TStateDraftGraphql = TStateDraft;


### PR DESCRIPTION
### Summary

The `name` field in state model is transformed for graphql. A new `CategorySearch` model is added under category.

Note: `CategorySearch` is a deprecated graphql service and it is used only in category search page which was developed long time ago.