### PR TITLE
chore: bump @commercetools/platform-sdk version

### DIFF
--- a/.changeset/purple-lizards-do.md
+++ b/.changeset/purple-lizards-do.md
@@ -1,0 +1,43 @@
+---
+'@commercetools-test-data/customers-search-list-my-view': patch
+'@commercetools-test-data/custom-application': patch
+'@commercetools-test-data/product-projection': patch
+'@commercetools-test-data/product-selection': patch
+'@commercetools-test-data/product-discount': patch
+'@commercetools-test-data/standalone-price': patch
+'@commercetools-test-data/attribute-group': patch
+'@commercetools-test-data/inventory-entry': patch
+'@commercetools-test-data/platform-limits': patch
+'@commercetools-test-data/shipping-method': patch
+'@commercetools-test-data/associate-role': patch
+'@commercetools-test-data/customer-group': patch
+'@commercetools-test-data/business-unit': patch
+'@commercetools-test-data/cart-discount': patch
+'@commercetools-test-data/custom-object': patch
+'@commercetools-test-data/discount-code': patch
+'@commercetools-test-data/quote-request': patch
+'@commercetools-test-data/shopping-list': patch
+'@commercetools-test-data/organization': patch
+'@commercetools-test-data/product-type': patch
+'@commercetools-test-data/staged-quote': patch
+'@commercetools-test-data/tax-category': patch
+'@commercetools-test-data/custom-view': patch
+'@commercetools-test-data/category': patch
+'@commercetools-test-data/customer': patch
+'@commercetools-test-data/channel': patch
+'@commercetools-test-data/commons': patch
+'@commercetools-test-data/payment': patch
+'@commercetools-test-data/product': patch
+'@commercetools-test-data/project': patch
+'@commercetools-test-data/review': patch
+'@commercetools-test-data/order': patch
+'@commercetools-test-data/quote': patch
+'@commercetools-test-data/state': patch
+'@commercetools-test-data/store': patch
+'@commercetools-test-data/cart': patch
+'@commercetools-test-data/type': patch
+'@commercetools-test-data/user': patch
+'@commercetools-test-data/zone': patch
+---
+
+Bump @commercetools/platform-sdk dependency version

--- a/models/associate-role/package.json
+++ b/models/associate-role/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/attribute-group/package.json
+++ b/models/attribute-group/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0",
     "omit-deep": "^0.3.0"
   }

--- a/models/business-unit/package.json
+++ b/models/business-unit/package.json
@@ -25,7 +25,7 @@
     "@commercetools-test-data/customer": "10.5.1",
     "@commercetools-test-data/store": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/business-unit/src/company/builder.spec.ts
+++ b/models/business-unit/src/company/builder.spec.ts
@@ -31,6 +31,7 @@ describe('builder', () => {
         topLevelUnit: expect.objectContaining({
           typeId: 'business-unit',
         }),
+        approvalRuleMode: 'Explicit',
         custom: null,
         createdAt: expect.any(String),
         createdBy: expect.objectContaining({

--- a/models/business-unit/src/company/constants.ts
+++ b/models/business-unit/src/company/constants.ts
@@ -3,6 +3,11 @@ export const associateMode = {
   ExplicitAndFromParent: 'ExplicitAndFromParent',
 } as const;
 
+export const approvalRuleMode = {
+  Explicit: 'Explicit',
+  ExplicitAndFromParent: 'ExplicitAndFromParent',
+} as const;
+
 export const status = {
   Active: 'Active',
   Inactive: 'Inactive',

--- a/models/business-unit/src/company/generator.ts
+++ b/models/business-unit/src/company/generator.ts
@@ -10,7 +10,13 @@ import {
   sequence,
 } from '@commercetools-test-data/core';
 import { createRelatedDates } from '@commercetools-test-data/utils';
-import { status, storeMode, unitType, associateMode } from './constants';
+import {
+  status,
+  storeMode,
+  unitType,
+  associateMode,
+  approvalRuleMode,
+} from './constants';
 import type { TCompany } from './types';
 
 const [getOlderDate, getNewerDate] = createRelatedDates();
@@ -38,6 +44,7 @@ const generator = Generator<TCompany>({
     inheritedAssociates: [],
     parentUnit: null,
     topLevelUnit: fake(() => KeyReference.random().typeId('business-unit')),
+    approvalRuleMode: approvalRuleMode.Explicit,
     custom: null,
     createdAt: fake(getOlderDate),
     createdBy: fake(() => ClientLogging.random()),

--- a/models/business-unit/src/division/builder.spec.ts
+++ b/models/business-unit/src/division/builder.spec.ts
@@ -34,6 +34,7 @@ describe('builder', () => {
         topLevelUnit: expect.objectContaining({
           typeId: 'business-unit',
         }),
+        approvalRuleMode: 'Explicit',
         custom: null,
         createdAt: expect.any(String),
         createdBy: expect.objectContaining({

--- a/models/business-unit/src/division/constants.ts
+++ b/models/business-unit/src/division/constants.ts
@@ -3,6 +3,11 @@ export const associateMode = {
   ExplicitAndFromParent: 'ExplicitAndFromParent',
 } as const;
 
+export const approvalRuleMode = {
+  Explicit: 'Explicit',
+  ExplicitAndFromParent: 'ExplicitAndFromParent',
+} as const;
+
 export const status = {
   Active: 'Active',
   Inactive: 'Inactive',

--- a/models/business-unit/src/division/generator.ts
+++ b/models/business-unit/src/division/generator.ts
@@ -10,6 +10,7 @@ import {
   sequence,
 } from '@commercetools-test-data/core';
 import { createRelatedDates } from '@commercetools-test-data/utils';
+import { approvalRuleMode } from '../company/constants';
 import { status, storeMode, unitType, associateMode } from './constants';
 import type { TDivision } from './types';
 
@@ -38,6 +39,7 @@ const generator = Generator<TDivision>({
     inheritedAssociates: [],
     parentUnit: fake(() => KeyReference.random().typeId('business-unit')),
     topLevelUnit: fake(() => KeyReference.random().typeId('business-unit')),
+    approvalRuleMode: approvalRuleMode.Explicit,
     custom: null,
     createdAt: fake(getOlderDate),
     createdBy: fake(() => ClientLogging.random()),

--- a/models/cart-discount/package.json
+++ b/models/cart-discount/package.json
@@ -25,7 +25,7 @@
     "@commercetools-test-data/customer-group": "10.5.1",
     "@commercetools-test-data/product-type": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/cart/package.json
+++ b/models/cart/package.json
@@ -30,7 +30,7 @@
     "@commercetools-test-data/store": "10.5.1",
     "@commercetools-test-data/tax-category": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/category/package.json
+++ b/models/category/package.json
@@ -23,7 +23,7 @@
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/type": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/channel/package.json
+++ b/models/channel/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/commons/package.json
+++ b/models/commons/package.json
@@ -21,7 +21,7 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0",
     "@types/lodash": "^4.17.0",
     "lodash": "^4.17.21"

--- a/models/custom-application/package.json
+++ b/models/custom-application/package.json
@@ -25,7 +25,7 @@
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/graphql-types": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0",
     "@types/lodash": "^4.14.182",
     "lodash": "^4.17.21"

--- a/models/custom-object/package.json
+++ b/models/custom-object/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/custom-view/package.json
+++ b/models/custom-view/package.json
@@ -25,7 +25,7 @@
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/graphql-types": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0",
     "@types/lodash": "^4.17.0",
     "lodash": "^4.17.21"

--- a/models/customer-group/package.json
+++ b/models/customer-group/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/customer/package.json
+++ b/models/customer/package.json
@@ -23,7 +23,7 @@
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/customer-group": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/customers-search-list-my-view/package.json
+++ b/models/customers-search-list-my-view/package.json
@@ -24,7 +24,7 @@
     "@commercetools-test-data/filter-values": "10.5.1",
     "@commercetools-test-data/graphql-types": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/discount-code/package.json
+++ b/models/discount-code/package.json
@@ -23,7 +23,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/inventory-entry/package.json
+++ b/models/inventory-entry/package.json
@@ -24,7 +24,7 @@
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/product": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/order/package.json
+++ b/models/order/package.json
@@ -27,7 +27,7 @@
     "@commercetools-test-data/customer-group": "10.5.1",
     "@commercetools-test-data/quote": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0",
     "@types/lodash": "^4.17.0",
     "lodash": "^4.17.21"

--- a/models/organization/package.json
+++ b/models/organization/package.json
@@ -24,6 +24,6 @@
     "@commercetools-test-data/graphql-types": "10.5.1",
     "@commercetools-test-data/user": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0"
+    "@commercetools/platform-sdk": "7.12.0"
   }
 }

--- a/models/payment/package.json
+++ b/models/payment/package.json
@@ -24,7 +24,7 @@
     "@commercetools-test-data/customer": "10.5.1",
     "@commercetools-test-data/order": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/platform-limits/package.json
+++ b/models/platform-limits/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/product-discount/package.json
+++ b/models/product-discount/package.json
@@ -24,7 +24,7 @@
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/product-type": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/product-projection/package.json
+++ b/models/product-projection/package.json
@@ -27,7 +27,7 @@
     "@commercetools-test-data/state": "10.5.1",
     "@commercetools-test-data/tax-category": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/product-selection/package.json
+++ b/models/product-selection/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/product-type/package.json
+++ b/models/product-type/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/product/package.json
+++ b/models/product/package.json
@@ -26,7 +26,7 @@
     "@commercetools-test-data/product-type": "10.5.1",
     "@commercetools-test-data/tax-category": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/project/package.json
+++ b/models/project/package.json
@@ -21,6 +21,6 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0"
+    "@commercetools/platform-sdk": "7.12.0"
   }
 }

--- a/models/quote-request/package.json
+++ b/models/quote-request/package.json
@@ -27,7 +27,7 @@
     "@commercetools-test-data/customer-group": "10.5.1",
     "@commercetools-test-data/store": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/quote/package.json
+++ b/models/quote/package.json
@@ -29,7 +29,7 @@
     "@commercetools-test-data/staged-quote": "^10.5.1",
     "@commercetools-test-data/store": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/review/package.json
+++ b/models/review/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/shipping-method/package.json
+++ b/models/shipping-method/package.json
@@ -24,7 +24,7 @@
     "@commercetools-test-data/tax-category": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
     "@commercetools-test-data/zone": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/shipping-method/src/shipping-method/builder.spec.ts
+++ b/models/shipping-method/src/shipping-method/builder.spec.ts
@@ -26,6 +26,7 @@ describe('builder', () => {
         zoneRates: expect.any(Array),
         isDefault: expect.any(Boolean),
         predicate: expect.any(String),
+        active: false,
         custom: null,
         createdAt: expect.any(String),
         createdBy: expect.objectContaining({

--- a/models/shipping-method/src/shipping-method/generator.ts
+++ b/models/shipping-method/src/shipping-method/generator.ts
@@ -23,6 +23,7 @@ const generator = Generator<TShippingMethod>({
     zoneRates: fake(() => []),
     isDefault: fake((f) => f.datatype.boolean()),
     predicate: '1=1',
+    active: fake(() => false),
     custom: null,
     createdAt: fake(getOlderDate),
     createdBy: fake(() => ClientLogging.random()),

--- a/models/shopping-list/package.json
+++ b/models/shopping-list/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/staged-quote/package.json
+++ b/models/staged-quote/package.json
@@ -28,7 +28,7 @@
     "@commercetools-test-data/quote-request": "10.5.1",
     "@commercetools-test-data/store": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/standalone-price/package.json
+++ b/models/standalone-price/package.json
@@ -25,7 +25,7 @@
     "@commercetools-test-data/customer-group": "10.5.1",
     "@commercetools-test-data/product": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/state/package.json
+++ b/models/state/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/store/package.json
+++ b/models/store/package.json
@@ -24,7 +24,7 @@
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/product-selection": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/tax-category/package.json
+++ b/models/tax-category/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/type/package.json
+++ b/models/type/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/user/package.json
+++ b/models/user/package.json
@@ -24,7 +24,7 @@
     "@commercetools-test-data/graphql-types": "10.5.1",
     "@commercetools-test-data/project": "workspace:^",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/models/zone/package.json
+++ b/models/zone/package.json
@@ -22,7 +22,7 @@
     "@commercetools-test-data/commons": "10.5.1",
     "@commercetools-test-data/core": "10.5.1",
     "@commercetools-test-data/utils": "10.5.1",
-    "@commercetools/platform-sdk": "^7.0.0",
+    "@commercetools/platform-sdk": "7.12.0",
     "@faker-js/faker": "^8.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -173,8 +173,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -209,8 +209,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -257,8 +257,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -290,8 +290,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -317,8 +317,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -341,8 +341,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -362,8 +362,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -401,8 +401,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -431,8 +431,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -464,8 +464,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -497,8 +497,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -521,8 +521,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -551,8 +551,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -578,8 +578,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -656,8 +656,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -695,8 +695,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -731,8 +731,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
 
   models/organization-extension:
     dependencies:
@@ -782,8 +782,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -806,8 +806,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -842,8 +842,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -872,8 +872,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -911,8 +911,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -935,8 +935,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -959,8 +959,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -980,8 +980,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
 
   models/project-extension:
     dependencies:
@@ -1046,8 +1046,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1085,8 +1085,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1109,8 +1109,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1139,8 +1139,8 @@ importers:
         specifier: 10.5.1
         version: link:../zone
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1163,8 +1163,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1205,8 +1205,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1238,8 +1238,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1262,8 +1262,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1292,8 +1292,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1316,8 +1316,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1340,8 +1340,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1370,8 +1370,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -1394,8 +1394,8 @@ importers:
         specifier: 10.5.1
         version: link:../../utils
       '@commercetools/platform-sdk':
-        specifier: ^7.0.0
-        version: 7.8.0
+        specifier: 7.12.0
+        version: 7.12.0
       '@faker-js/faker':
         specifier: ^8.0.0
         version: 8.4.1
@@ -2217,8 +2217,8 @@ packages:
     peerDependencies:
       eslint: 8.x
 
-  '@commercetools/platform-sdk@7.8.0':
-    resolution: {integrity: sha512-7dpUG8kVULm286dyL1N5IZ6A+0iNwjHdeck7CZdUkVeJ697XN/YwPQkjQ2z62ZkaJRL0efPN5277TWttsU6uLA==}
+  '@commercetools/platform-sdk@7.12.0':
+    resolution: {integrity: sha512-fhO8kZgV1c1VuWe6pQ423dxat5E4y7uSyTjm5pO+yCO7EXdWT7IYkoP0xmnLay5kUuXxuD9GcTXobGxqkupESw==}
     engines: {node: '>=14'}
 
   '@commercetools/sdk-client-v2@2.5.0':
@@ -2237,8 +2237,8 @@ packages:
     resolution: {integrity: sha512-DhMXAA2yIch/AaGxy7st85Z1HFmeLtHWGkr9z5rX4xKjan4PHGB/IE5saAR+SNGHhs6+1Lp8vZEHDo3tFqVLmg==}
     engines: {node: '>=14'}
 
-  '@commercetools/ts-client@1.2.1':
-    resolution: {integrity: sha512-tgy78lQoEoqYoK0KeSj43/v1Mg17M1ouwXtDxKmjAqEW4RyiCGOPPjOiZT9adTyjbK4CcOcwDzJxUVziIerg5g==}
+  '@commercetools/ts-client@2.0.3':
+    resolution: {integrity: sha512-8S/wV56cyaXf5SbSdHtYqcFhZRFlM2N/nWgyD8wh84GuqYTJDKv5N1woKNOZVvajQZsnuy3DJDMSFzLG+EuDfw==}
     engines: {node: '>=14'}
 
   '@commitlint/cli@19.3.0':
@@ -3197,6 +3197,9 @@ packages:
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
+
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -6344,8 +6347,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
   v8-compile-cache@2.4.0:
@@ -7682,13 +7685,13 @@ snapshots:
       - jest
       - supports-color
 
-  '@commercetools/platform-sdk@7.8.0':
+  '@commercetools/platform-sdk@7.12.0':
     dependencies:
       '@commercetools/sdk-client-v2': 2.5.0
       '@commercetools/sdk-middleware-auth': 7.0.1
       '@commercetools/sdk-middleware-http': 7.0.4
       '@commercetools/sdk-middleware-logger': 3.0.0
-      '@commercetools/ts-client': 1.2.1
+      '@commercetools/ts-client': 2.0.3
     transitivePeerDependencies:
       - encoding
 
@@ -7709,12 +7712,13 @@ snapshots:
 
   '@commercetools/sdk-middleware-logger@3.0.0': {}
 
-  '@commercetools/ts-client@1.2.1':
+  '@commercetools/ts-client@2.0.3':
     dependencies:
       abort-controller: 3.0.0
+      async-mutex: 0.5.0
       buffer: 6.0.3
       node-fetch: 2.7.0
-      uuid: 9.0.1
+      uuid: 10.0.0
     transitivePeerDependencies:
       - encoding
 
@@ -9239,6 +9243,10 @@ snapshots:
   ast-types-flow@0.0.8: {}
 
   astral-regex@2.0.0: {}
+
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.6.3
 
   asynckit@0.4.0: {}
 
@@ -12860,7 +12868,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@9.0.1: {}
+  uuid@10.0.0: {}
 
   v8-compile-cache@2.4.0: {}
 


### PR DESCRIPTION
`CartDiscountValueAbsolute` and `CartDiscountValueAbsoluteDraft` types (from `@commercetools/platform-sdk`) provide a new field called `applicationMode` that we would like to start using in `CartDiscount` models.

That's why this PR bumps `@commercetools/platform-sdk` dependency version to `7.12.0`.

PS: renovate has not updated `@commercetools/platform-sdk` for 4 months. The caret and how `pnpm` resolves it seems to be the reason why the dependency was stale.