### PR TITLE
FEC-60: Adjust `state` model to send `null` as fallback

### DIFF
--- a/.changeset/dry-peas-return.md
+++ b/.changeset/dry-peas-return.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/state': patch
+---
+
+Make `name`,`description` as optional and send `null` as fallback

--- a/models/state/src/transformers.ts
+++ b/models/state/src/transformers.ts
@@ -35,10 +35,13 @@ const transformers = {
         __typename: 'State',
         nameAllLocales,
         descriptionAllLocales,
-        name: LocalizedString.resolveGraphqlDefaultLocaleValue(nameAllLocales)!,
-        description: LocalizedString.resolveGraphqlDefaultLocaleValue(
-          descriptionAllLocales
-        ),
+        name:
+          LocalizedString.resolveGraphqlDefaultLocaleValue(nameAllLocales) ??
+          null,
+        description:
+          LocalizedString.resolveGraphqlDefaultLocaleValue(
+            descriptionAllLocales
+          ) ?? null,
       };
     },
   }),

--- a/models/state/src/types.ts
+++ b/models/state/src/types.ts
@@ -6,8 +6,8 @@ export type TState = State;
 export type TStateDraft = StateDraft;
 
 export type TStateGraphql = Omit<TState, 'name' | 'description'> & {
-  name?: string;
-  description?: string;
+  name?: string | null;
+  description?: string | null;
   nameAllLocales?: TLocalizedStringGraphql | null;
   descriptionAllLocales?: TLocalizedStringGraphql | null;
   __typename: 'State';


### PR DESCRIPTION
### Summary

The `name` field should be `null` if the nameAllLocales is undefined. The jest throws error when the name is undefined.