### PR TITLE
Update Standalone price model

### DIFF
--- a/.changeset/great-pandas-run.md
+++ b/.changeset/great-pandas-run.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/standalone-price': minor
+---
+
+Improvments on the StandalonePrice model. Added currency sync between properties, limitations on price tiers, and alignments with GQL schemas

--- a/models/standalone-price/src/builder.spec.ts
+++ b/models/standalone-price/src/builder.spec.ts
@@ -7,6 +7,59 @@ import { StagedStandalonePrice, StandalonePrice } from '.';
 describe('builder', () => {
   it(
     ...createBuilderSpec<TStandalonePrice, TStandalonePrice>(
+      'default',
+      StandalonePrice.random(),
+      expect.objectContaining({
+        id: expect.any(String),
+        version: expect.any(Number),
+        createdAt: expect.any(String),
+        lastModifiedAt: expect.any(String),
+        lastModifiedBy: expect.objectContaining({
+          anonymousId: expect.any(String),
+        }),
+        createdBy: expect.objectContaining({
+          anonymousId: expect.any(String),
+        }),
+        key: expect.any(String),
+        sku: expect.any(String),
+        value: expect.objectContaining({
+          type: 'centPrecision',
+          currencyCode: expect.any(String),
+          centAmount: expect.any(Number),
+          fractionDigits: expect.any(Number),
+        }),
+        country: expect.any(String),
+        customerGroup: expect.objectContaining({
+          id: expect.any(String),
+          key: expect.any(String),
+        }),
+        channel: expect.objectContaining({
+          id: expect.any(String),
+          key: expect.any(String),
+        }),
+        validFrom: expect.any(String),
+        validUntil: expect.any(String),
+        tiers: expect.arrayContaining([
+          expect.objectContaining({
+            minimumQuantity: expect.any(Number),
+            value: expect.objectContaining({
+              type: 'centPrecision',
+              currencyCode: expect.any(String),
+              centAmount: expect.any(Number),
+              fractionDigits: expect.any(Number),
+            }),
+          }),
+        ]),
+        discounted: null,
+        staged: null,
+        active: expect.any(Boolean),
+        expiresAt: expect.any(String),
+      })
+    )
+  );
+
+  it(
+    ...createBuilderSpec<TStandalonePrice, TStandalonePrice>(
       'rest',
       StandalonePrice.random(),
       expect.objectContaining({
@@ -50,8 +103,8 @@ describe('builder', () => {
             }),
           }),
         ]),
-        discounted: undefined,
-        staged: undefined,
+        discounted: null,
+        staged: null,
         active: expect.any(Boolean),
       })
     )

--- a/models/standalone-price/src/builder.spec.ts
+++ b/models/standalone-price/src/builder.spec.ts
@@ -2,62 +2,9 @@
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
 import { TStandalonePrice, TStandalonePriceGraphql } from './types';
-import { StandalonePrice } from '.';
+import { StagedStandalonePrice, StandalonePrice } from '.';
 
 describe('builder', () => {
-  it(
-    ...createBuilderSpec<TStandalonePrice, TStandalonePrice>(
-      'default',
-      StandalonePrice.random(),
-      expect.objectContaining({
-        id: expect.any(String),
-        version: expect.any(Number),
-        createdAt: expect.any(String),
-        lastModifiedAt: expect.any(String),
-        lastModifiedBy: expect.objectContaining({
-          anonymousId: expect.any(String),
-        }),
-        createdBy: expect.objectContaining({
-          anonymousId: expect.any(String),
-        }),
-        key: expect.any(String),
-        sku: expect.any(String),
-        value: expect.objectContaining({
-          type: 'centPrecision',
-          currencyCode: expect.any(String),
-          centAmount: expect.any(Number),
-          fractionDigits: expect.any(Number),
-        }),
-        country: expect.any(String),
-        customerGroup: expect.objectContaining({
-          id: expect.any(String),
-          key: expect.any(String),
-        }),
-        channel: expect.objectContaining({
-          id: expect.any(String),
-          key: expect.any(String),
-        }),
-        validFrom: expect.any(String),
-        validUntil: expect.any(String),
-        tiers: expect.arrayContaining([
-          expect.objectContaining({
-            minimumQuantity: expect.any(Number),
-            value: expect.objectContaining({
-              type: 'centPrecision',
-              currencyCode: expect.any(String),
-              centAmount: expect.any(Number),
-              fractionDigits: expect.any(Number),
-            }),
-          }),
-        ]),
-        discounted: null,
-        staged: null,
-        active: expect.any(Boolean),
-        expiresAt: expect.any(String),
-      })
-    )
-  );
-
   it(
     ...createBuilderSpec<TStandalonePrice, TStandalonePrice>(
       'rest',
@@ -103,8 +50,8 @@ describe('builder', () => {
             }),
           }),
         ]),
-        discounted: null,
-        staged: null,
+        discounted: undefined,
+        staged: undefined,
         active: expect.any(Boolean),
       })
     )
@@ -179,5 +126,33 @@ describe('builder', () => {
       standalonePrice.customerGroupRef?.id
     );
     expect(standalonePrice.channel?.id).toBe(standalonePrice.channelRef?.id);
+  });
+
+  describe('StandalonePrice builder currency code consistency', () => {
+    it('should have all currency codes tied to the main value currency code in REST', () => {
+      const standalonePrice = StandalonePrice.random()
+        .staged(StagedStandalonePrice.random())
+        .buildRest<TStandalonePrice>();
+
+      const mainCurrencyCode = standalonePrice.value.currencyCode;
+
+      standalonePrice.tiers?.forEach((tier) => {
+        expect(tier.value.currencyCode).toBe(mainCurrencyCode);
+      });
+      expect(standalonePrice.staged?.value.currencyCode).toBe(mainCurrencyCode);
+    });
+
+    it('should have all currency codes tied to the main value currency code in GraphQL', () => {
+      const standalonePrice = StandalonePrice.random()
+        .staged(StagedStandalonePrice.random())
+        .buildGraphql<TStandalonePriceGraphql>();
+
+      const mainCurrencyCode = standalonePrice.value.currencyCode;
+
+      standalonePrice.tiers?.forEach((tier) => {
+        expect(tier.value.currencyCode).toBe(mainCurrencyCode);
+      });
+      expect(standalonePrice.staged?.value.currencyCode).toBe(mainCurrencyCode);
+    });
   });
 });

--- a/models/standalone-price/src/builder.spec.ts
+++ b/models/standalone-price/src/builder.spec.ts
@@ -103,8 +103,8 @@ describe('builder', () => {
             }),
           }),
         ]),
-        discounted: null,
-        staged: null,
+        discounted: undefined,
+        staged: undefined,
         active: expect.any(Boolean),
       })
     )

--- a/models/standalone-price/src/generator.ts
+++ b/models/standalone-price/src/generator.ts
@@ -29,7 +29,13 @@ const generator = Generator<TStandalonePrice>({
     channel: fake(() => Channel.random()),
     validFrom: fake(getCreatedAt),
     validUntil: fake(getExpiresAt),
-    tiers: [fake(() => PriceTier.random())],
+    tiers: [
+      fake((f) =>
+        PriceTier.random().minimumQuantity(
+          f.number.int({ min: 1, max: 2000000000 })
+        )
+      ),
+    ],
     discounted: null,
     staged: null,
     custom: null,

--- a/models/standalone-price/src/staged-standalone-price/transformers.ts
+++ b/models/standalone-price/src/staged-standalone-price/transformers.ts
@@ -8,16 +8,16 @@ const transformers = {
   default: Transformer<TStagedStandalonePrice, TStagedStandalonePrice>(
     'default',
     {
-      buildFields: ['value'],
+      buildFields: ['value', 'discounted'],
     }
   ),
   rest: Transformer<TStagedStandalonePrice, TStagedStandalonePrice>('rest', {
-    buildFields: ['value'],
+    buildFields: ['value', 'discounted'],
   }),
   graphql: Transformer<TStagedStandalonePrice, TStagedStandalonePriceGraphql>(
     'graphql',
     {
-      buildFields: ['value'],
+      buildFields: ['value', 'discounted'],
     }
   ),
 };

--- a/models/standalone-price/src/transformers.ts
+++ b/models/standalone-price/src/transformers.ts
@@ -11,6 +11,19 @@ import type {
 } from './types';
 
 const transformers = {
+  default: Transformer<TStandalonePrice, TStandalonePrice>('default', {
+    buildFields: [
+      'lastModifiedBy',
+      'createdBy',
+      'value',
+      'customerGroup',
+      'channel',
+      'tiers',
+      'custom',
+      'discounted',
+      'staged',
+    ],
+  }),
   rest: Transformer<TStandalonePrice, TStandalonePriceRest>('rest', {
     buildFields: [
       'lastModifiedBy',

--- a/models/standalone-price/src/transformers.ts
+++ b/models/standalone-price/src/transformers.ts
@@ -11,19 +11,6 @@ import type {
 } from './types';
 
 const transformers = {
-  default: Transformer<TStandalonePrice, TStandalonePrice>('default', {
-    buildFields: [
-      'lastModifiedBy',
-      'createdBy',
-      'value',
-      'customerGroup',
-      'channel',
-      'tiers',
-      'custom',
-      'discounted',
-      'staged',
-    ],
-  }),
   rest: Transformer<TStandalonePrice, TStandalonePriceRest>('rest', {
     buildFields: [
       'lastModifiedBy',
@@ -54,6 +41,8 @@ const transformers = {
             .buildRest<TReference<'channel'>>()
         : undefined;
 
+      const mainCurrency = fields.value.currencyCode;
+
       const adjustedFields = {
         ...rest,
         customerGroup,
@@ -64,18 +53,20 @@ const transformers = {
               ...tier,
               value: {
                 ...tier.value,
-                currencyCode: fields.value.currencyCode,
+                currencyCode: mainCurrency,
               },
             }))
           : undefined,
         staged: fields.staged
           ? {
+              ...fields.staged,
               value: {
                 ...fields.staged.value,
-                currencyCode: fields.value.currencyCode,
+                currencyCode: mainCurrency,
               },
             }
           : undefined,
+        discounted: fields.discounted || undefined,
       };
 
       return adjustedFields;
@@ -108,29 +99,34 @@ const transformers = {
             .buildGraphql<TReferenceGraphql<'channel'>>()
         : null;
 
-      const adjustedFields = {
+      const mainCurrency = fields.value.currencyCode;
+
+      const adjustedFields: TStandalonePriceGraphql = {
         ...fields,
         __typename: 'StandalonePrice' as const,
         customerGroupRef,
         channelRef,
+        custom: fields.custom || null,
         // Currency sync
         tiers: fields.tiers
           ? fields.tiers.map((tier) => ({
               ...tier,
               value: {
                 ...tier.value,
-                currencyCode: fields.value.currencyCode,
+                currencyCode: mainCurrency,
               },
             }))
-          : undefined,
+          : null,
         staged: fields.staged
           ? {
+              ...fields.staged,
               value: {
                 ...fields.staged.value,
-                currencyCode: fields.value.currencyCode,
+                currencyCode: mainCurrency,
               },
             }
-          : undefined,
+          : null,
+        discounted: fields.discounted || null,
       };
 
       return adjustedFields;

--- a/models/standalone-price/src/transformers.ts
+++ b/models/standalone-price/src/transformers.ts
@@ -19,6 +19,9 @@ const transformers = {
       'customerGroup',
       'channel',
       'tiers',
+      'custom',
+      'discounted',
+      'staged',
     ],
   }),
   rest: Transformer<TStandalonePrice, TStandalonePriceRest>('rest', {
@@ -29,6 +32,9 @@ const transformers = {
       'customerGroup',
       'channel',
       'tiers',
+      'custom',
+      'discounted',
+      'staged',
     ],
     replaceFields: ({ fields }) => {
       // Remove `expiresAt` from the fields
@@ -63,6 +69,9 @@ const transformers = {
       'customerGroup',
       'channel',
       'tiers',
+      'custom',
+      'discounted',
+      'staged',
     ],
     replaceFields: ({ fields }) => {
       const customerGroupRef = fields.customerGroup

--- a/models/standalone-price/src/transformers.ts
+++ b/models/standalone-price/src/transformers.ts
@@ -54,11 +54,31 @@ const transformers = {
             .buildRest<TReference<'channel'>>()
         : undefined;
 
-      return {
+      const adjustedFields = {
         ...rest,
         customerGroup,
         channel,
+        // Currency sync
+        tiers: fields.tiers
+          ? fields.tiers.map((tier) => ({
+              ...tier,
+              value: {
+                ...tier.value,
+                currencyCode: fields.value.currencyCode,
+              },
+            }))
+          : undefined,
+        staged: fields.staged
+          ? {
+              value: {
+                ...fields.staged.value,
+                currencyCode: fields.value.currencyCode,
+              },
+            }
+          : undefined,
       };
+
+      return adjustedFields;
     },
   }),
   graphql: Transformer<TStandalonePrice, TStandalonePriceGraphql>('graphql', {
@@ -88,12 +108,32 @@ const transformers = {
             .buildGraphql<TReferenceGraphql<'channel'>>()
         : null;
 
-      return {
+      const adjustedFields = {
         ...fields,
-        __typename: 'StandalonePrice',
+        __typename: 'StandalonePrice' as const,
         customerGroupRef,
         channelRef,
+        // Currency sync
+        tiers: fields.tiers
+          ? fields.tiers.map((tier) => ({
+              ...tier,
+              value: {
+                ...tier.value,
+                currencyCode: fields.value.currencyCode,
+              },
+            }))
+          : undefined,
+        staged: fields.staged
+          ? {
+              value: {
+                ...fields.staged.value,
+                currencyCode: fields.value.currencyCode,
+              },
+            }
+          : undefined,
       };
+
+      return adjustedFields;
     },
   }),
 };

--- a/models/standalone-price/src/types.ts
+++ b/models/standalone-price/src/types.ts
@@ -3,6 +3,10 @@ import {
   StandalonePriceDraft,
   CustomerGroup,
   Channel,
+  StagedStandalonePrice,
+  PriceTier,
+  CustomFields,
+  DiscountedPrice,
 } from '@commercetools/platform-sdk';
 import {
   TMoneyGraphql,
@@ -25,7 +29,14 @@ export type TStandalonePriceRest = StandalonePrice;
 export type TStandalonePriceDraft = StandalonePriceDraft;
 
 // Graphql representation
-export type TStandalonePriceGraphql = TStandalonePrice & {
+export type TStandalonePriceGraphql = Omit<
+  TStandalonePrice,
+  'staged' | 'tiers' | 'custom' | 'discounted'
+> & {
+  tiers: PriceTier[] | null;
+  staged: StagedStandalonePrice | null;
+  custom: CustomFields | null;
+  discounted: DiscountedPrice | null;
   customerGroupRef: TReferenceGraphql | null;
   channelRef: TReferenceGraphql | null;
   __typename: 'StandalonePrice';


### PR DESCRIPTION
This PR updates the Standalone price model to improve consistency in our unit tests and provide a more realistic model that aligns with our GraphQL schema and form limitations.
Currencies are synced now with the main value currency code.

