### PR TITLE
feat: add applicationMode field to `CartDiscountValueAbsolute` model

### DIFF
--- a/.changeset/many-ducks-study.md
+++ b/.changeset/many-ducks-study.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart-discount': minor
+---
+
+Add applicationMode field to CartDiscountValueAbsolute model

--- a/models/cart-discount/src/cart-discount-value-absolute/builder.spec.ts
+++ b/models/cart-discount/src/cart-discount-value-absolute/builder.spec.ts
@@ -1,8 +1,11 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
+import { faker } from '@faker-js/faker';
+import { applicationModes } from './constants';
 import type {
   TCartDiscountValueAbsolute,
+  TCartDiscountValueAbsoluteCartGraphql,
   TCartDiscountValueAbsoluteGraphql,
 } from './types';
 import * as CartDiscountValueAbsolute from './index';
@@ -45,7 +48,8 @@ describe('builder', () => {
   );
 
   it(
-    ...createBuilderSpec<
+    'should build properties for AbsoluteDiscountValue "graphql"',
+    createBuilderSpec<
       TCartDiscountValueAbsolute,
       TCartDiscountValueAbsoluteGraphql
     >(
@@ -60,6 +64,29 @@ describe('builder', () => {
         ]),
         __typename: 'AbsoluteDiscountValue',
       })
-    )
+    )[1]
+  );
+
+  it(
+    'should build properties for AbsoluteCartDiscountValue "graphql"',
+    createBuilderSpec<
+      TCartDiscountValueAbsolute,
+      TCartDiscountValueAbsoluteCartGraphql
+    >(
+      'graphql',
+      CartDiscountValueAbsolute.random().applicationMode(
+        faker.helpers.arrayElement(applicationModes)
+      ),
+      expect.objectContaining({
+        type: 'absolute',
+        money: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'centPrecision',
+          }),
+        ]),
+        applicationMode: expect.toBeOneOf(applicationModes),
+        __typename: 'AbsoluteCartDiscountValue',
+      })
+    )[1]
   );
 });

--- a/models/cart-discount/src/cart-discount-value-absolute/constants.ts
+++ b/models/cart-discount/src/cart-discount-value-absolute/constants.ts
@@ -1,0 +1,7 @@
+import type { DiscountApplicationMode } from '@commercetools/platform-sdk';
+
+export const applicationModes: DiscountApplicationMode[] = [
+  'EvenDistribution',
+  'IndividualApplication',
+  'ProportionateDistribution',
+];

--- a/models/cart-discount/src/cart-discount-value-absolute/transformers.ts
+++ b/models/cart-discount/src/cart-discount-value-absolute/transformers.ts
@@ -1,6 +1,7 @@
 import { Transformer } from '@commercetools-test-data/core';
 import type {
   TCartDiscountValueAbsolute,
+  TCartDiscountValueAbsoluteCartGraphql,
   TCartDiscountValueAbsoluteGraphql,
 } from './types';
 
@@ -19,11 +20,13 @@ const transformers = {
   ),
   graphql: Transformer<
     TCartDiscountValueAbsolute,
-    TCartDiscountValueAbsoluteGraphql
+    TCartDiscountValueAbsoluteGraphql | TCartDiscountValueAbsoluteCartGraphql
   >('graphql', {
     buildFields: ['money'],
-    addFields: () => ({
-      __typename: 'AbsoluteDiscountValue',
+    addFields: ({ fields }) => ({
+      __typename: fields.applicationMode
+        ? 'AbsoluteCartDiscountValue'
+        : 'AbsoluteDiscountValue',
     }),
   }),
 };

--- a/models/cart-discount/src/cart-discount-value-absolute/types.ts
+++ b/models/cart-discount/src/cart-discount-value-absolute/types.ts
@@ -7,12 +7,24 @@ import type { TBuilder } from '@commercetools-test-data/core';
 export type TCartDiscountValueAbsolute = CartDiscountValueAbsolute;
 export type TCartDiscountValueAbsoluteDraft = CartDiscountValueAbsoluteDraft;
 
-export type TCartDiscountValueAbsoluteGraphql = TCartDiscountValueAbsolute & {
+export type TCartDiscountValueAbsoluteGraphql = Omit<
+  TCartDiscountValueAbsolute,
+  'applicationMode'
+> & {
   __typename: 'AbsoluteDiscountValue';
 };
 
+export type TCartDiscountValueAbsoluteCartGraphql =
+  Required<TCartDiscountValueAbsolute> & {
+    __typename: 'AbsoluteCartDiscountValue';
+  };
+
 export type TCartDiscountValueAbsoluteDraftGraphql = {
-  absolute: Omit<TCartDiscountValueAbsoluteDraft, 'type'>;
+  absolute: Omit<TCartDiscountValueAbsoluteDraft, 'type' | 'applicationMode'>;
+};
+
+export type TCartDiscountValueAbsoluteCartDraftGraphql = {
+  absoluteCart: Required<Omit<TCartDiscountValueAbsoluteDraft, 'type'>>;
 };
 
 export type TCartDiscountValueAbsoluteBuilder =


### PR DESCRIPTION
To properly test Cart Discount Application Modes feature, the new field needs to be added to the `CartDiscountValueAbsolute` model.