### PR TITLE
fix(CentPrecisionMoney): add max centAmount value to CentPrecisionMoney and CentPrecisioMoneyDraft

### DIFF
--- a/.changeset/funny-ties-jog.md
+++ b/.changeset/funny-ties-jog.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/commons': patch
+---
+
+Add max centAmount value to CentPrecisionMoney and CentPrecisioMoneyDraft models to avoid rounding errors

--- a/models/commons/src/cent-precision-money/cent-precision-money-draft/generator.ts
+++ b/models/commons/src/cent-precision-money/cent-precision-money-draft/generator.ts
@@ -5,7 +5,7 @@ import { TCentPrecisionMoneyDraft } from '../types';
 
 const generator = Generator<TCentPrecisionMoneyDraft>({
   fields: {
-    centAmount: fake((f) => f.number.int({ min: 10 })),
+    centAmount: fake((f) => f.number.int({ min: 1, max: 9999999999 })),
     currencyCode: oneOf('EUR', 'USD'),
     type: 'centPrecision',
     // Default fraction digits for a currency for EUR and USD

--- a/models/commons/src/cent-precision-money/generator.ts
+++ b/models/commons/src/cent-precision-money/generator.ts
@@ -5,7 +5,7 @@ import { TCentPrecisionMoney } from './types';
 
 const generator = Generator<TCentPrecisionMoney>({
   fields: {
-    centAmount: fake((f) => f.number.int({ min: 10 })),
+    centAmount: fake((f) => f.number.int({ min: 1, max: 9999999999 })),
     currencyCode: oneOf('EUR', 'USD'),
     type: 'centPrecision',
     // Default fraction digits for a currency for EUR and USD


### PR DESCRIPTION
This PR adds a max value for the `centAmount` field in the `CentPrecisionMoney` and `CentPrecisionMoneyDraft` models. The reason is rounding errors can occur when the `centAmount` value is too large, so we want to limit the value to a reasonable range.

Uploading Screen Recording 2024-09-24 at 16.40.35.mov…

