### PR TITLE
Update core helpers to support accurate typing for transformed models

### DIFF
--- a/.changeset/brown-spiders-impress.md
+++ b/.changeset/brown-spiders-impress.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/core': patch
+---
+
+Update core helpers to support accurate typing for transformed models

--- a/core/src/helpers.ts
+++ b/core/src/helpers.ts
@@ -115,17 +115,17 @@ const toGraphqlPaginatedQueryResult = <Model>(
   };
 };
 
-const buildField = <Model>(
+const buildField = <Model, TransformedModel = Model>(
   builder: Model | TBuilder<Model>,
   transformName: TTransformType = 'default',
   meta?: TBuildFieldMeta<Model>
-): Model => {
+): TransformedModel => {
   const buildName = convertTransformNameToBuildName(transformName);
   // @ts-ignore: TS does not know about the `Model` being an object.
   const builderField = builder?.[buildName];
   // We need to cast this to `() => Model` as otherwise the value is unknown.
   // We know it's a function because of the proxy builder.
-  const builderFn = builderField as (() => Model) | undefined;
+  const builderFn = builderField as (() => TransformedModel) | undefined;
   if (!builderFn) {
     throw new Error(
       `Builder with name '${buildName}' does not exist on field '${String(
@@ -136,19 +136,22 @@ const buildField = <Model>(
   return builderFn();
 };
 
-const buildFields = <Model>(
+const buildFields = <Model, TransformedModel = Model>(
   builders: (Model | TBuilder<Model>)[],
   transformName: TTransformType = 'default',
   meta?: TBuildFieldMeta<Model>
-): Model[] =>
-  builders.map((builder) => buildField(builder, transformName, meta));
+): TransformedModel[] => {
+  return builders.map((builder) =>
+    buildField<Model, TransformedModel>(builder, transformName, meta)
+  );
+};
 
-const buildGraphqlList = <Model>(
+const buildGraphqlList = <Model, GraphqlModel>(
   builders: TBuilder<Model>[],
   { name, total, offset, __typename }: TGraphqlPaginatedQueryResultOptions
-): TGraphqlPaginatedQueryResult<Model> => {
-  return toGraphqlPaginatedQueryResult<Model>(
-    buildFields<Model>(builders, 'graphql'),
+): TGraphqlPaginatedQueryResult<GraphqlModel> => {
+  return toGraphqlPaginatedQueryResult<GraphqlModel>(
+    buildFields<Model, GraphqlModel>(builders, 'graphql'),
     {
       name,
       __typename,

--- a/core/src/helpers.ts
+++ b/core/src/helpers.ts
@@ -146,7 +146,7 @@ const buildFields = <Model, TransformedModel = Model>(
   );
 };
 
-const buildGraphqlList = <Model, GraphqlModel>(
+const buildGraphqlList = <Model, GraphqlModel = Model>(
   builders: TBuilder<Model>[],
   { name, total, offset, __typename }: TGraphqlPaginatedQueryResultOptions
 ): TGraphqlPaginatedQueryResult<GraphqlModel> => {
@@ -161,14 +161,17 @@ const buildGraphqlList = <Model, GraphqlModel>(
   );
 };
 
-const buildRestList = <Model>(
+const buildRestList = <Model, RestModel = Model>(
   builders: TBuilder<Model>[],
   { total, offset }: TPaginatedQueryResultOptions
-): TPaginatedQueryResult<Model> => {
-  return toRestPaginatedQueryResult(buildFields(builders, 'rest'), {
-    total,
-    offset,
-  });
+): TPaginatedQueryResult<RestModel> => {
+  return toRestPaginatedQueryResult<RestModel>(
+    buildFields<Model, RestModel>(builders, 'rest'),
+    {
+      total,
+      offset,
+    }
+  );
 };
 
 export {


### PR DESCRIPTION
**Description**

This PR upgrades type accuracy for list builder helpers by introducing a second type parameter for the transformed output model (either GraphQL or REST).

- Previously, only the base model type was specified, representing the model from which the GraphQL or REST representations were derived. As a result, the returned data type did not accurately reflect the transformed output of these representations.

- Now, by specifying both the base model type and the transformed output type, the returned data type precisely matches the actual structure of the GraphQL and REST responses.

- For backward compatibility, the second type parameter will default to the base model (`Model`) if not provided.

- Users should now explicitly provide the `GraphqlModel` when needed:
```typescript
const graphqlList = buildGraphqlList<TDiscountCode, TDiscountCodeGraphql>(...)
```
