### PR TITLE
Refactor transformers behaviour for building nested models

### DIFF
--- a/.changeset/healthy-carrots-share.md
+++ b/.changeset/healthy-carrots-share.md
@@ -1,0 +1,18 @@
+---
+'@commercetools-test-data/core': patch
+---
+
+When creating Transformers, you can provide a `buildFields` property with the list of names of the nested models fields that should be transformed.
+
+In our latest version, we updated that behaviour so that, if you don't provide that property, the Transformer will automatically detect the nested models and build them.
+
+There were a few models where transformers where not providing the `buildFields` properties but they meant they didn't want any nested model to be build.
+In order to cover this use case, we modified the `buildFields` property to also accept `false` as a value, which was used as a signal to not build nested models and we updated those few models accordingly.
+
+However, we discovered one of our internal packages which relies on this one had many more models with the same use case and it's difficult to update all of them accordingly so we're updating the `buildFields` behaviour again to leave it as it was before.
+
+So now:
+
+- If the transformer configuration specifies a list of nested models, only those will be built
+- In the transformer configuration does not provide the `buildFields` property, no nested model will be built
+- [NEW] In the transformer configuration contains the `buildFields` property with the string value `all`, every nested model will be built (this is used in the new data models patterns)

--- a/.changeset/strange-months-hang.md
+++ b/.changeset/strange-months-hang.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/product-type': patch
+'@commercetools-test-data/commons': patch
+---
+
+Update transformers configuration to comply with the new `buildFields` behaviour.

--- a/core/src/helpers.ts
+++ b/core/src/helpers.ts
@@ -178,17 +178,14 @@ const buildRestList = <Model, RestModel = Model>(
   );
 };
 
-type TCreateSpecializedTransformersParams<TModel> = {
-  type: 'rest' | 'graphql';
-  buildFields?: (keyof TModel)[];
-};
 const createSpecializedTransformers = <TModel>({
   type,
-  buildFields,
-}: TCreateSpecializedTransformersParams<TModel>) => {
+}: {
+  type: 'rest' | 'graphql';
+}) => {
   return {
     [type]: Transformer<TModel, TModel>(type, {
-      buildFields: buildFields,
+      buildFields: 'all',
     }),
   };
 };

--- a/core/src/transformer.ts
+++ b/core/src/transformer.ts
@@ -24,7 +24,7 @@ function Transformer<Model, TransformedModel>(
     const fieldsToRemove = transformOptions?.removeFields;
     const fieldsToBuild = transformOptions?.buildFields;
 
-    if (fieldsToBuild) {
+    if (fieldsToBuild && Array.isArray(fieldsToBuild)) {
       fieldsToBuild.forEach((fieldToBuild) => {
         const field = transformedFields[fieldToBuild] as unknown as
           | TBuilder<Model>
@@ -43,7 +43,7 @@ function Transformer<Model, TransformedModel>(
           };
         }
       });
-    } else if (fieldsToBuild !== false) {
+    } else if (fieldsToBuild === 'all') {
       for (const [key, value] of Object.entries(transformedFields as {})) {
         if (!value || !isBuilder(value)) continue;
         const fieldKey = key as keyof Model;

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -51,8 +51,8 @@ export type TTransformerOptions<Model, TransformedModel> = {
   addFields?: (args: { fields: Model }) => Partial<TransformedModel>;
   removeFields?: (keyof Model)[];
   replaceFields?: (args: { fields: Model }) => TransformedModel;
-  // The `false` value means that the transformer should not build any model's fields
-  buildFields?: (keyof Model)[] | false;
+  // The `all` value means that the transformer should build all nested models fields
+  buildFields?: (keyof Model)[] | 'all';
 };
 
 export type TTransformFnParams<Model> = {

--- a/models/commons/src/client-logging/transformers.ts
+++ b/models/commons/src/client-logging/transformers.ts
@@ -12,7 +12,6 @@ const transformers = {
     buildFields: ['customer'],
   }),
   graphql: Transformer<TClientLogging, TClientLoggingGraphql>('graphql', {
-    buildFields: false,
     replaceFields: ({ fields }) => {
       const customerRef = buildField(
         fields.customer,

--- a/models/commons/src/reference/transformers.ts
+++ b/models/commons/src/reference/transformers.ts
@@ -5,7 +5,6 @@ import type { TReference, TReferenceGraphql, TReferenceRest } from './types';
 const transformers = {
   default: Transformer<TReference, TReference>('default', {}),
   rest: Transformer<TReference, TReferenceRest>('rest', {
-    buildFields: false,
     replaceFields: ({ fields }) => ({
       ...fields,
       obj: omit(fields, ['typeId']),
@@ -15,7 +14,6 @@ const transformers = {
   // since some fields are pure `*Ref`, e.g `channelsRef`
   // with no option to expand.
   graphql: Transformer<TReference, TReferenceGraphql>('graphql', {
-    buildFields: false,
     addFields: () => ({
       __typename: 'Reference',
     }),

--- a/models/product-type/src/attribute-enum-type/transformers.ts
+++ b/models/product-type/src/attribute-enum-type/transformers.ts
@@ -11,7 +11,6 @@ const transformers = {
   graphql: Transformer<TAttributeEnumType, TAttributeEnumTypeGraphql>(
     'graphql',
     {
-      buildFields: false,
       replaceFields: ({ fields }) => ({
         ...fields,
         values: {

--- a/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/transformers.ts
+++ b/models/product-type/src/attribute-localized-enum-type/attribute-localized-enum-type-draft/transformers.ts
@@ -15,7 +15,6 @@ const transformers = {
     TAttributeLocalizedEnumTypeDraft,
     TAttributeLocalizedEnumTypeDraftGraphql
   >('graphql', {
-    buildFields: false,
     replaceFields: ({ fields }) => {
       return {
         [fields.name]: {

--- a/models/product-type/src/attribute-set-type/attribute-set-type-draft/transformers.ts
+++ b/models/product-type/src/attribute-set-type/attribute-set-type-draft/transformers.ts
@@ -14,7 +14,6 @@ const transformers = {
   graphql: Transformer<TAttributeSetTypeDraft, TAttributeSetTypeDraftGraphql>(
     'graphql',
     {
-      buildFields: false,
       replaceFields: ({ fields }) => {
         return {
           [fields.name]: {

--- a/models/product-type/src/product-type/product-type-draft/transformers.ts
+++ b/models/product-type/src/product-type/product-type-draft/transformers.ts
@@ -10,7 +10,6 @@ const transformers = {
     buildFields: ['attributes'],
   }),
   graphql: Transformer<TProductTypeDraft, TProductTypeDraftGraphql>('graphql', {
-    buildFields: false,
     addFields: ({ fields }) => {
       return {
         attributeDefinitions: fields.attributes!.map((attribute) =>


### PR DESCRIPTION
When creating Transformers, you can provide a `buildFields` property with the list of names of the nested models fields that should be transformed.

In our latest version, we updated that behaviour so that, if you don't provide that property, the Transformer will automatically detect the nested models and build them.

There were a few models where transformers where not providing the `buildFields` properties but they meant they didn't want any nested model to be build.
In order to cover this use case, we modified the `buildFields` property to also accept `false` as a value, which was used as a signal to not build nested models and we updated those few models accordingly.

However, we discovered one of our internal packages which relies on this one had many more models with the same use case and it's difficult to update all of them accordingly so we're updating the `buildFields` behaviour again to leave it as it was before.

So now:

- If the transformer configuration specifies a list of nested models, only those will be built
- In the transformer configuration does not provide the `buildFields` property, no nested model will be built
- [NEW] In the transformer configuration contains the `buildFields` property with the string value `all`, every nested model will be built (this is used in the new data models patterns)
