### PR TITLE
Update generators package to not publish to npm

### DIFF
--- a/generators/package.json
+++ b/generators/package.json
@@ -1,14 +1,21 @@
 {
   "name": "@commercetools-test-data/generators",
+  "private": true,
   "version": "1.0.0",
-  "description": "",
+  "description": "Data model generator CLI for commercetools APIs",
   "main": "dist/commercetools-test-data-generators.cjs.js",
   "module": "dist/commercetools-test-data-generators.esm.js",
   "scripts": {
     "generate": "tsx src/index.ts"
   },
-  "author": "",
-  "license": "ISC",
+  "bugs": "https://github.com/commercetools/test-data/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/test-data.git",
+    "directory": "generators"
+  },
+  "keywords": ["javascript", "typescript", "test-data"],
+  "license": "MIT",
   "dependencies": {
     "@babel/runtime": "7.17.9",
     "@babel/runtime-corejs3": "7.17.9",


### PR DESCRIPTION
With the current setup, we're trying to publish the new CLI package to NPM registry and getting this error:

![image](https://github.com/user-attachments/assets/25cea6ff-bec5-46c0-bcd6-8531fc6b0cf7)

I don't think we actually need to publish this package as it's usage is intended to be locally once a developer has cloned this repository so I'm updating the `package.json` to say this is a private package (no NPM publishing).