### PR TITLE
fix(product-types/b2c-lifestyle): furniture and decor color attribute is now searchable

### DIFF
--- a/.changeset/tidy-ravens-sort.md
+++ b/.changeset/tidy-ravens-sort.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product-type': patch
+---
+
+B2C Lifestyle Presets - Updated Furniture and Decor product type attribute `color` to be searchable.

--- a/models/product-type/src/product-type/product-type-draft/presets/sample-data-b2c-lifestyle/furniture-and-decor.spec.ts
+++ b/models/product-type/src/product-type/product-type-draft/presets/sample-data-b2c-lifestyle/furniture-and-decor.spec.ts
@@ -41,7 +41,7 @@ describe(`with furnitureAndDecor preset`, () => {
       "inputHint": "SingleLine",
       "inputTip": undefined,
       "isRequired": false,
-      "isSearchable": false,
+      "isSearchable": true,
       "label": {
         "de": undefined,
         "de-DE": "Farbe",
@@ -197,7 +197,7 @@ describe(`with furnitureAndDecor preset`, () => {
       "inputHint": "SingleLine",
       "inputTip": undefined,
       "isRequired": false,
-      "isSearchable": false,
+      "isSearchable": true,
       "label": [
         {
           "locale": "en-GB",

--- a/models/product-type/src/product-type/product-type-draft/presets/sample-data-b2c-lifestyle/furniture-and-decor.ts
+++ b/models/product-type/src/product-type/product-type-draft/presets/sample-data-b2c-lifestyle/furniture-and-decor.ts
@@ -59,7 +59,7 @@ const furnitureAndDecor = (): TProductTypeDraftBuilder =>
         )
         .isRequired(false)
         .attributeConstraint(attributeConstraints.None)
-        .isSearchable(false)
+        .isSearchable(true)
         .inputHint(inputHints.SingleLine),
 
       AttributeDefinitionDraft.presets


### PR DESCRIPTION
See title. Based on [this request](https://commercetools.slack.com/archives/C03B6NKTA83/p1730211019423229).