### PR TITLE
Fix LocalizedString common model helper

### DIFF
--- a/.changeset/tasty-hats-joke.md
+++ b/.changeset/tasty-hats-joke.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/commons': patch
+---
+
+Fix an error in the `LocalizedString.resolveGraphqlDefaultLocaleValue` helper function when an empty array is passed as a parameter.

--- a/models/commons/src/localized-string/helpers.spec.ts
+++ b/models/commons/src/localized-string/helpers.spec.ts
@@ -1,0 +1,62 @@
+import { LocalizedString } from '..';
+import { toLocalizedField, resolveGraphqlDefaultLocaleValue } from './helpers';
+import { TLocalizedStringGraphql } from './types';
+
+describe('LocalizedString helpers', () => {
+  describe('toLocalizedField', () => {
+    it('should return null if no value is provided', () => {
+      const result = toLocalizedField(null);
+      expect(result).toBeNull();
+    });
+
+    it('should return a localized field if value is provided', () => {
+      const mockValue = LocalizedString.random().en('Hello').de('Hallo');
+      const result = toLocalizedField(mockValue);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            locale: 'en',
+            value: 'Hello',
+            __typename: 'LocalizedString',
+          }),
+          expect.objectContaining({
+            locale: 'de',
+            value: 'Hallo',
+            __typename: 'LocalizedString',
+          }),
+        ])
+      );
+    });
+  });
+
+  describe('resolveGraphqlDefaultLocaleValue', () => {
+    it('should return null if no locales are provided', () => {
+      const result = resolveGraphqlDefaultLocaleValue(null);
+      expect(result).toBeNull();
+    });
+
+    it('should return null if locales array is empty', () => {
+      const result = resolveGraphqlDefaultLocaleValue([]);
+      expect(result).toBeNull();
+    });
+
+    it('should return the value of the default locale if it exists', () => {
+      const mockLocales: TLocalizedStringGraphql = [
+        { locale: 'en', value: 'Hello', __typename: 'LocalizedString' },
+        { locale: 'de', value: 'Hallo', __typename: 'LocalizedString' },
+      ];
+      const result = resolveGraphqlDefaultLocaleValue(mockLocales);
+      expect(result).toBe('Hello');
+    });
+
+    it('should return the value of the first locale if default locale does not exist', () => {
+      const mockLocales: TLocalizedStringGraphql = [
+        { locale: 'fr', value: 'Bonjour', __typename: 'LocalizedString' },
+        { locale: 'de', value: 'Hallo', __typename: 'LocalizedString' },
+      ];
+      const result = resolveGraphqlDefaultLocaleValue(mockLocales);
+      expect(result).toBe('Bonjour');
+    });
+  });
+});

--- a/models/commons/src/localized-string/helpers.ts
+++ b/models/commons/src/localized-string/helpers.ts
@@ -18,7 +18,7 @@ const DEFAULT_LOCALE = 'en';
 const resolveGraphqlDefaultLocaleValue = (
   allLocales: TLocalizedStringGraphql | null
 ) => {
-  if (!allLocales) {
+  if (!allLocales || allLocales.length < 1) {
     return null;
   }
   const defaultLocaleName = allLocales.find(


### PR DESCRIPTION
The `resolveGraphqlDefaultLocaleValue` helper of the `LocalizedString` model breaks when it receives an empty array as a parameter.