### PR TITLE
Fix Channel data model compat mode presets

### DIFF
--- a/.changeset/giant-pans-fly.md
+++ b/.changeset/giant-pans-fly.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-test-data/channel': patch
+---
+
+Fixes the exported presets for the compatibility test data model.
+We were exporting the GraphQL ones so it was not possible to generate REST data models out of them.

--- a/models/channel/src/index.ts
+++ b/models/channel/src/index.ts
@@ -25,4 +25,4 @@ export const ChannelGraphql = {
  * @deprecated Use `ChannelRest` or `ChannelGraphql` exported models instead of `Channel`.
  */
 export const random = CompatChannelModelBuilder;
-export const presets = modelPresets.graphqlPresets;
+export const presets = modelPresets.compatPresets;

--- a/models/channel/src/presets/index.ts
+++ b/models/channel/src/presets/index.ts
@@ -9,3 +9,7 @@ export const graphqlPresets = {
   foodStore: foodStore.graphqlPreset,
   clothesStore: clothesStore.graphqlPreset,
 };
+export const compatPresets = {
+  foodStore: foodStore.compatPreset,
+  clothesStore: clothesStore.compatPreset,
+};


### PR DESCRIPTION
We had a missconfiguration in the compatibility test data model for `Channel`s.
We were exporting the GraphQL presets instead of the REST ones, which made it impossible to generate REST data models out of them.