### PR TITLE
Fix legacy ChannelDraft model presets

### DIFF
--- a/.changeset/tough-scissors-cheat.md
+++ b/.changeset/tough-scissors-cheat.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/channel': patch
+---
+
+There was an error with the legacy `ChannelDraft` model presets as it was always using the `GraphQL` ones instead of relying on the `build` method used (`buildRest` or `buildGraphql`).

--- a/models/channel/src/channel-draft/presets/index.ts
+++ b/models/channel/src/channel-draft/presets/index.ts
@@ -40,15 +40,15 @@ export const graphqlPresets = {
 
 export const compatPresets = {
   empty: empty.compatPreset,
-  withGeoLocationOnly: withGeoLocationOnly.graphqlPreset,
+  withGeoLocationOnly: withGeoLocationOnly.compatPreset,
   withInventorySupplyAndProductDistributionRoles:
-    withInventorySupplyAndProductDistributionRoles.graphqlPreset,
+    withInventorySupplyAndProductDistributionRoles.compatPreset,
   withInventorySupplyAndProductDistributionRolesNoAddress:
-    withInventorySupplyAndProductDistributionRolesNoAddress.graphqlPreset,
-  withInventorySupplyRole: withInventorySupplyRole.graphqlPreset,
+    withInventorySupplyAndProductDistributionRolesNoAddress.compatPreset,
+  withInventorySupplyRole: withInventorySupplyRole.compatPreset,
   withInventorySupplyRoleNoAddress:
-    withInventorySupplyRoleNoAddress.graphqlPreset,
-  withProductDistributionRole: withProductDistributionRole.graphqlPreset,
+    withInventorySupplyRoleNoAddress.compatPreset,
+  withProductDistributionRole: withProductDistributionRole.compatPreset,
   sampleDataB2B: sampleDataB2B.compatPresets,
   sampleDataB2CLifestyle: sampleDataB2C.compatPresets,
 };


### PR DESCRIPTION
We were exporting the GraphQL presets from the legacy `ChannelDraft` model when we must use the compatibility ones.