### PR TITLE
chore(test-data): fix InventoryEntry export formatting

### DIFF
--- a/.changeset/spotty-onions-grab.md
+++ b/.changeset/spotty-onions-grab.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/inventory-entry': patch
+---
+
+Fix export formatting

--- a/models/inventory-entry/src/index.ts
+++ b/models/inventory-entry/src/index.ts
@@ -5,7 +5,7 @@ import {
 } from './builders';
 import * as modelPresets from './presets';
 
-export * as InventoryEntryDraft from './inventory-entry-draft';
+export * from './inventory-entry-draft';
 export * as InventoryEntry from '.';
 
 export * from './types';


### PR DESCRIPTION
## Summary

Fixes `InventoryEntry` exports to make them symmetrical with `Channel`