### PR TITLE
Fix values for premium and standard

### DIFF
--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-b2b/premium-shipping-method.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-b2b/premium-shipping-method.spec.ts
@@ -47,22 +47,22 @@ describe(`with premiumShippingMethod preset`, () => {
             "shippingRates": [
               {
                 "freeAbove": {
-                  "centAmount": 1000000,
+                  "centAmount": 1500000,
                   "currencyCode": "EUR",
                 },
                 "price": {
-                  "centAmount": 10000,
+                  "centAmount": 30000,
                   "currencyCode": "EUR",
                 },
                 "tiers": [],
               },
               {
                 "freeAbove": {
-                  "centAmount": 1000000,
+                  "centAmount": 1500000,
                   "currencyCode": "GBP",
                 },
                 "price": {
-                  "centAmount": 10000,
+                  "centAmount": 30000,
                   "currencyCode": "GBP",
                 },
                 "tiers": [],
@@ -165,22 +165,22 @@ describe(`with premiumShippingMethod preset`, () => {
             "shippingRates": [
               {
                 "freeAbove": {
-                  "centAmount": 1000000,
+                  "centAmount": 1500000,
                   "currencyCode": "EUR",
                 },
                 "price": {
-                  "centAmount": 10000,
+                  "centAmount": 30000,
                   "currencyCode": "EUR",
                 },
                 "tiers": [],
               },
               {
                 "freeAbove": {
-                  "centAmount": 1000000,
+                  "centAmount": 1500000,
                   "currencyCode": "GBP",
                 },
                 "price": {
-                  "centAmount": 10000,
+                  "centAmount": 30000,
                   "currencyCode": "GBP",
                 },
                 "tiers": [],

--- a/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-b2b/standard-shipping-method.spec.ts
+++ b/models/shipping-method/src/shipping-method/shipping-method-draft/presets/sample-data-b2b/standard-shipping-method.spec.ts
@@ -47,22 +47,22 @@ describe(`with standardShippingMethod preset`, () => {
             "shippingRates": [
               {
                 "freeAbove": {
-                  "centAmount": 1500000,
+                  "centAmount": 1000000,
                   "currencyCode": "EUR",
                 },
                 "price": {
-                  "centAmount": 30000,
+                  "centAmount": 10000,
                   "currencyCode": "EUR",
                 },
                 "tiers": [],
               },
               {
                 "freeAbove": {
-                  "centAmount": 1500000,
+                  "centAmount": 1000000,
                   "currencyCode": "GBP",
                 },
                 "price": {
-                  "centAmount": 30000,
+                  "centAmount": 10000,
                   "currencyCode": "GBP",
                 },
                 "tiers": [],
@@ -184,22 +184,22 @@ describe(`with standardShippingMethod preset`, () => {
             "shippingRates": [
               {
                 "freeAbove": {
-                  "centAmount": 1500000,
+                  "centAmount": 1000000,
                   "currencyCode": "EUR",
                 },
                 "price": {
-                  "centAmount": 30000,
+                  "centAmount": 10000,
                   "currencyCode": "EUR",
                 },
                 "tiers": [],
               },
               {
                 "freeAbove": {
-                  "centAmount": 1500000,
+                  "centAmount": 1000000,
                   "currencyCode": "GBP",
                 },
                 "price": {
-                  "centAmount": 30000,
+                  "centAmount": 10000,
                   "currencyCode": "GBP",
                 },
                 "tiers": [],

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-b2b/europe-premium.spec.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-b2b/europe-premium.spec.ts
@@ -9,22 +9,22 @@ describe(`with europe preset`, () => {
         "shippingRates": [
           {
             "freeAbove": {
-              "centAmount": 1000000,
+              "centAmount": 1500000,
               "currencyCode": "EUR",
             },
             "price": {
-              "centAmount": 10000,
+              "centAmount": 30000,
               "currencyCode": "EUR",
             },
             "tiers": [],
           },
           {
             "freeAbove": {
-              "centAmount": 1000000,
+              "centAmount": 1500000,
               "currencyCode": "GBP",
             },
             "price": {
-              "centAmount": 10000,
+              "centAmount": 30000,
               "currencyCode": "GBP",
             },
             "tiers": [],
@@ -45,22 +45,22 @@ describe(`with europe preset`, () => {
         "shippingRates": [
           {
             "freeAbove": {
-              "centAmount": 1000000,
+              "centAmount": 1500000,
               "currencyCode": "EUR",
             },
             "price": {
-              "centAmount": 10000,
+              "centAmount": 30000,
               "currencyCode": "EUR",
             },
             "tiers": [],
           },
           {
             "freeAbove": {
-              "centAmount": 1000000,
+              "centAmount": 1500000,
               "currencyCode": "GBP",
             },
             "price": {
-              "centAmount": 10000,
+              "centAmount": 30000,
               "currencyCode": "GBP",
             },
             "tiers": [],

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-b2b/europe-premium.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-b2b/europe-premium.ts
@@ -10,8 +10,8 @@ const europe = (): TZoneRateDraftBuilder =>
   ZoneRateDraft.random()
     .zone(KeyReferenceDraft.presets.zone().key(europeZone.key!))
     .shippingRates([
-      ShippingRateDraft.presets.sampleDataB2B.eur10000(),
-      ShippingRateDraft.presets.sampleDataB2B.gbp10000(),
+      ShippingRateDraft.presets.sampleDataB2B.eur30000(),
+      ShippingRateDraft.presets.sampleDataB2B.gbp30000(),
     ]);
 
 export default europe;

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-b2b/europe-standard.spec.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-b2b/europe-standard.spec.ts
@@ -9,22 +9,22 @@ describe(`with europe preset`, () => {
         "shippingRates": [
           {
             "freeAbove": {
-              "centAmount": 1000000,
+              "centAmount": 1500000,
               "currencyCode": "EUR",
             },
             "price": {
-              "centAmount": 10000,
+              "centAmount": 30000,
               "currencyCode": "EUR",
             },
             "tiers": [],
           },
           {
             "freeAbove": {
-              "centAmount": 1000000,
+              "centAmount": 1500000,
               "currencyCode": "GBP",
             },
             "price": {
-              "centAmount": 10000,
+              "centAmount": 30000,
               "currencyCode": "GBP",
             },
             "tiers": [],
@@ -45,22 +45,22 @@ describe(`with europe preset`, () => {
         "shippingRates": [
           {
             "freeAbove": {
-              "centAmount": 1000000,
+              "centAmount": 1500000,
               "currencyCode": "EUR",
             },
             "price": {
-              "centAmount": 10000,
+              "centAmount": 30000,
               "currencyCode": "EUR",
             },
             "tiers": [],
           },
           {
             "freeAbove": {
-              "centAmount": 1000000,
+              "centAmount": 1500000,
               "currencyCode": "GBP",
             },
             "price": {
-              "centAmount": 10000,
+              "centAmount": 30000,
               "currencyCode": "GBP",
             },
             "tiers": [],

--- a/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-b2b/europe-standard.ts
+++ b/models/shipping-method/src/zone-rate/zone-rate-draft/presets/sample-data-b2b/europe-standard.ts
@@ -10,8 +10,8 @@ const europe = (): TZoneRateDraftBuilder =>
   ZoneRateDraft.random()
     .zone(KeyReferenceDraft.presets.zone().key(europeZone.key!))
     .shippingRates([
-      ShippingRateDraft.presets.sampleDataB2B.eur30000(),
-      ShippingRateDraft.presets.sampleDataB2B.gbp30000(),
+      ShippingRateDraft.presets.sampleDataB2B.eur10000(),
+      ShippingRateDraft.presets.sampleDataB2B.gbp10000(),
     ]);
 
 export default europe;


### PR DESCRIPTION
# B2B Sample data update fix
Fixing values after the latest change [PR#729](https://github.com/commercetools/test-data/pull/729/files):
- Standard should have value `100,00` and be free above `10.000,00`
- Premium should have value `300,00` and be free above `15.000,00`