### PR TITLE
feat(changeset): adding missing changeset for shipping methods changes

### DIFF
--- a/.changeset/healthy-seahorses-sing.md
+++ b/.changeset/healthy-seahorses-sing.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/shipping-method': minor
+---
+
+Updating zone rates for b2b sample data presets


### PR DESCRIPTION
Missing changeset for [PR#740](https://github.com/commercetools/test-data/pull/740)

Changes the values for shipping rates:
- Standard should have value 100,00 and be free above 10.000,00
- Premium should have value 300,00 and be free above 15.000,00