### PR TITLE
fix(commons): Money and HighPrecisionMoney GraphQL models types

### DIFF
--- a/.changeset/kind-games-melt.md
+++ b/.changeset/kind-games-melt.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/commons': patch
+---
+
+Fix Money and HighPrecisionMoney GraphQL models

--- a/models/commons/src/high-precision-money/types.ts
+++ b/models/commons/src/high-precision-money/types.ts
@@ -3,14 +3,16 @@ import {
   HighPrecisionMoneyDraft,
 } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import {
+  TCtpHighPrecisionMoney,
+  TCtpHighPrecisionMoneyInput,
+} from '@commercetools-test-data/graphql-types';
 
 export type THighPrecisionMoney = HighPrecisionMoney;
 export type THighPrecisionMoneyDraft = HighPrecisionMoneyDraft;
 
-export type THighPrecisionMoneyGraphql = THighPrecisionMoney & {
-  __typename: 'HighPrecisionMoney';
-};
-export type THighPrecisionMoneyDraftGraphql = THighPrecisionMoneyDraft;
+export type THighPrecisionMoneyGraphql = TCtpHighPrecisionMoney;
+export type THighPrecisionMoneyDraftGraphql = TCtpHighPrecisionMoneyInput;
 
 export type THighPrecisionMoneyBuilder = TBuilder<THighPrecisionMoney>;
 export type THighPrecisionMoneyDraftBuilder =

--- a/models/commons/src/money/builder.spec.ts
+++ b/models/commons/src/money/builder.spec.ts
@@ -34,6 +34,8 @@ describe('builder', () => {
       expect.objectContaining({
         centAmount: expect.any(Number),
         currencyCode: expect.any(String),
+        type: 'centPrecision',
+        fractionDigits: expect.any(Number),
         __typename: 'Money',
       })
     )

--- a/models/commons/src/money/transformers.ts
+++ b/models/commons/src/money/transformers.ts
@@ -1,4 +1,5 @@
 import { Transformer } from '@commercetools-test-data/core';
+import { faker } from '@faker-js/faker';
 import type { TMoney, TMoneyGraphql } from './types';
 
 const transformers = {
@@ -11,6 +12,8 @@ const transformers = {
   graphql: Transformer<TMoney, TMoneyGraphql>('graphql', {
     buildFields: [],
     addFields: () => ({
+      type: 'centPrecision',
+      fractionDigits: faker.number.int({ min: 1, max: 3 }),
       __typename: 'Money',
     }),
   }),

--- a/models/commons/src/money/types.ts
+++ b/models/commons/src/money/types.ts
@@ -1,12 +1,11 @@
 import { Money } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpMoney, TCtpMoneyDraft } from '@commercetools-test-data/graphql-types';
 
 // Base model
 export type TMoney = Money;
 
-export type TMoneyGraphql = TMoney & {
-  __typename: 'Money';
-};
+export type TMoneyGraphql = TCtpMoney;
 
 export type TMoneyBuilder = TBuilder<TMoney>;
 export type TCreateMoneyBuilder = () => TMoneyBuilder;
@@ -14,9 +13,7 @@ export type TCreateMoneyBuilder = () => TMoneyBuilder;
 // Draft model
 export type TMoneyDraft = Money;
 
-export type TMoneyDraftGraphql = TMoneyDraft & {
-  __typename: 'Money';
-};
+export type TMoneyDraftGraphql = TCtpMoneyDraft;
 
 export type TMoneyDraftBuilder = TBuilder<TMoneyDraft>;
 export type TCreateMoneyDraftBuilder = () => TMoneyDraftBuilder;

--- a/models/commons/src/price/price-draft/transformers.ts
+++ b/models/commons/src/price/price-draft/transformers.ts
@@ -1,5 +1,5 @@
 import { Transformer } from '@commercetools-test-data/core';
-import { TMoneyDraftGraphql } from '../../money';
+import { MoneyDraft, TMoneyDraftGraphql } from '../../money';
 import type { TPriceDraft, TPriceDraftGraphql } from '../types';
 
 const transformers = {
@@ -32,12 +32,17 @@ const transformers = {
       'discounted',
       'custom',
     ],
-    replaceFields: ({ fields }) => ({
-      ...fields,
-      value: {
-        centPrecision: fields.value as TMoneyDraftGraphql,
-      },
-    }),
+    replaceFields: ({ fields }) => {
+      return {
+        ...fields,
+        value: {
+          centPrecision: MoneyDraft.random()
+            .centAmount(fields.value.centAmount ?? 0)
+            .currencyCode(fields.value.currencyCode)
+            .buildGraphql<TMoneyDraftGraphql>(),
+        },
+      } as TPriceDraftGraphql;
+    },
   }),
 };
 

--- a/models/commons/src/price/types.ts
+++ b/models/commons/src/price/types.ts
@@ -1,18 +1,15 @@
 import type { Price, PriceDraft } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TMoneyGraphql } from '../money';
+import {
+  TCtpProductPrice,
+  TCtpProductPriceDataInput,
+} from '@commercetools-test-data/graphql-types';
 
 export type TPrice = Price;
 export type TPriceDraft = PriceDraft;
 
-export type TPriceGraphql = TPrice & {
-  __typename: 'ProductPrice';
-};
-export type TPriceDraftGraphql = Omit<TPriceDraft, 'value'> & {
-  value: {
-    centPrecision: TMoneyGraphql;
-  };
-};
+export type TPriceGraphql = TCtpProductPrice;
+export type TPriceDraftGraphql = TCtpProductPriceDataInput;
 
 export type TPriceBuilder = TBuilder<Price>;
 export type TPriceDraftBuilder = TBuilder<PriceDraft>;

--- a/models/standalone-price/package.json
+++ b/models/standalone-price/package.json
@@ -23,6 +23,7 @@
     "@commercetools-test-data/commons": "10.13.0",
     "@commercetools-test-data/core": "10.13.0",
     "@commercetools-test-data/customer-group": "10.13.0",
+    "@commercetools-test-data/graphql-types": "10.13.0",
     "@commercetools-test-data/product": "10.13.0",
     "@commercetools-test-data/utils": "10.13.0",
     "@commercetools/platform-sdk": "7.25.1",

--- a/models/standalone-price/src/standalone-price-draft/transformers.ts
+++ b/models/standalone-price/src/standalone-price-draft/transformers.ts
@@ -70,7 +70,7 @@ const transformers = {
             },
           };
         }
-        return newFields;
+        return newFields as TStandalonePriceDraftGraphql;
       },
     }
   ),

--- a/models/standalone-price/src/transformers.ts
+++ b/models/standalone-price/src/transformers.ts
@@ -114,7 +114,7 @@ const transformers = {
 
       const mainCurrency = fields.value.currencyCode;
 
-      const adjustedFields: TStandalonePriceGraphql = {
+      const adjustedFields = {
         ...fields,
         __typename: 'StandalonePrice' as const,
         customerGroupRef,
@@ -140,7 +140,7 @@ const transformers = {
             }
           : null,
         discounted: fields.discounted || null,
-      };
+      } as TStandalonePriceGraphql;
 
       return adjustedFields;
     },

--- a/models/standalone-price/src/types.ts
+++ b/models/standalone-price/src/types.ts
@@ -3,16 +3,12 @@ import {
   StandalonePriceDraft,
   CustomerGroup,
   Channel,
-  StagedStandalonePrice,
-  PriceTier,
-  CustomFields,
-  DiscountedPrice,
 } from '@commercetools/platform-sdk';
-import {
-  TMoneyGraphql,
-  TReferenceGraphql,
-} from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
+import {
+  TCtpCreateStandalonePrice,
+  TCtpStandalonePrice,
+} from '@commercetools-test-data/graphql-types';
 
 // Base representation
 export type TStandalonePrice = Omit<
@@ -29,27 +25,8 @@ export type TStandalonePriceRest = StandalonePrice;
 export type TStandalonePriceDraft = StandalonePriceDraft;
 
 // Graphql representation
-export type TStandalonePriceGraphql = Omit<
-  TStandalonePrice,
-  'staged' | 'tiers' | 'custom' | 'discounted'
-> & {
-  tiers: PriceTier[] | null;
-  staged: StagedStandalonePrice | null;
-  custom: CustomFields | null;
-  discounted: DiscountedPrice | null;
-  customerGroupRef: TReferenceGraphql | null;
-  channelRef: TReferenceGraphql | null;
-  __typename: 'StandalonePrice';
-};
-
-export type TStandalonePriceDraftGraphql = Omit<
-  TStandalonePriceDraft,
-  'value'
-> & {
-  value: {
-    centPrecision: TMoneyGraphql;
-  };
-};
+export type TStandalonePriceGraphql = TCtpStandalonePrice;
+export type TStandalonePriceDraftGraphql = TCtpCreateStandalonePrice;
 
 export type TStandalonePriceBuilder = TBuilder<TStandalonePrice>;
 export type TStandalonePriceDraftBuilder = TBuilder<StandalonePriceDraft>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1344,6 +1344,9 @@ importers:
       '@commercetools-test-data/customer-group':
         specifier: 10.13.0
         version: link:../customer-group
+      '@commercetools-test-data/graphql-types':
+        specifier: 10.13.0
+        version: link:../../graphql-types
       '@commercetools-test-data/product':
         specifier: 10.13.0
         version: link:../product


### PR DESCRIPTION
Money and HighPrecisionMoney now use the generated types to avoid issues downstream.