### PR TITLE
chore(business-unit): add inheritedStores field to Company and Division models

### DIFF
--- a/.changeset/chilly-weeks-know.md
+++ b/.changeset/chilly-weeks-know.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/business-unit': patch
+---
+
+chore: add inheritedStores field to Company and Division entities

--- a/models/business-unit/src/company/builder.spec.ts
+++ b/models/business-unit/src/company/builder.spec.ts
@@ -16,6 +16,7 @@ describe('builder', () => {
         key: expect.any(String),
         status: expect.any(String),
         stores: [],
+        inheritedStores: [],
         storeMode: 'Explicit',
         unitType: 'Company',
         name: expect.any(String),
@@ -55,6 +56,7 @@ describe('builder', () => {
         key: expect.any(String),
         status: expect.any(String),
         stores: [],
+        inheritedStores: [],
         storeMode: 'Explicit',
         unitType: 'Company',
         name: expect.any(String),
@@ -93,16 +95,9 @@ describe('builder', () => {
         key: expect.any(String),
         status: expect.any(String),
         stores: [],
-        storesRef: expect.arrayContaining([
-          expect.objectContaining({
-            typeId: 'store',
-          }),
-        ]),
-        inheritedStoresRef: expect.arrayContaining([
-          expect.objectContaining({
-            typeId: 'store',
-          }),
-        ]),
+        storesRef: [],
+        inheritedStores: [],
+        inheritedStoresRef: [],
         storeMode: expect.any(String),
         unitType: 'Company',
         name: expect.any(String),

--- a/models/business-unit/src/company/generator.ts
+++ b/models/business-unit/src/company/generator.ts
@@ -30,6 +30,7 @@ const generator = Generator<TCompany>({
     key: fake((f) => f.lorem.slug(2)),
     status: oneOf(...Object.values(status)),
     stores: [],
+    inheritedStores: [],
     storeMode: storeMode.Explicit,
     unitType: unitType.Company,
     name: fake((f) => f.lorem.words(2)),

--- a/models/business-unit/src/company/transformers.ts
+++ b/models/business-unit/src/company/transformers.ts
@@ -13,8 +13,25 @@ const transformers = {
     buildFields: ['addresses', 'createdBy', 'lastModifiedBy'],
     replaceFields: ({ fields }) => {
       return {
-        ...(fields as TCompany),
-        storesRef: [KeyReference.random().typeId('store').buildGraphql()],
+        ...fields,
+        storesRef:
+          'stores' in fields
+            ? fields.stores?.map((store) =>
+                KeyReference.random()
+                  .typeId('store')
+                  .key(store.key)
+                  .buildGraphql()
+              )
+            : [],
+        inheritedStoresRef:
+          'inheritedStores' in fields
+            ? fields.inheritedStores?.map((store) =>
+                KeyReference.random()
+                  .typeId('store')
+                  .key(store.key)
+                  .buildGraphql()
+              )
+            : [],
         parentUnitRef: null,
         topLevelUnitRef: KeyReference.random()
           .typeId('business-unit')
@@ -29,9 +46,6 @@ const transformers = {
               },
         ancestors:
           'ancestors' in fields && fields.ancestors ? fields.ancestors : [],
-        inheritedStoresRef: [
-          KeyReference.random().typeId('store').buildGraphql(),
-        ],
         __typename: 'BusinessUnit',
       };
     },

--- a/models/business-unit/src/division/builder.spec.ts
+++ b/models/business-unit/src/division/builder.spec.ts
@@ -16,6 +16,7 @@ describe('builder', () => {
         key: expect.any(String),
         status: expect.any(String),
         stores: [],
+        inheritedStores: [],
         storeMode: expect.any(String),
         unitType: 'Division',
         name: expect.any(String),
@@ -58,6 +59,7 @@ describe('builder', () => {
         key: expect.any(String),
         status: expect.any(String),
         stores: [],
+        inheritedStores: [],
         storeMode: expect.any(String),
         unitType: 'Division',
         name: expect.any(String),
@@ -99,16 +101,9 @@ describe('builder', () => {
         key: expect.any(String),
         status: expect.any(String),
         stores: [],
-        storesRef: expect.arrayContaining([
-          expect.objectContaining({
-            typeId: 'store',
-          }),
-        ]),
-        inheritedStoresRef: expect.arrayContaining([
-          expect.objectContaining({
-            typeId: 'store',
-          }),
-        ]),
+        storesRef: [],
+        inheritedStores: [],
+        inheritedStoresRef: [],
         storeMode: expect.any(String),
         unitType: 'Division',
         name: expect.any(String),

--- a/models/business-unit/src/division/generator.ts
+++ b/models/business-unit/src/division/generator.ts
@@ -25,6 +25,7 @@ const generator = Generator<TDivision>({
     key: fake((f) => f.lorem.slug(2)),
     status: oneOf(...Object.values(status)),
     stores: [],
+    inheritedStores: [],
     storeMode: oneOf(...Object.values(storeMode)),
     unitType: unitType.Division,
     name: fake((f) => f.lorem.words(2)),

--- a/models/business-unit/src/division/transformers.ts
+++ b/models/business-unit/src/division/transformers.ts
@@ -27,8 +27,25 @@ const transformers = {
     {
       buildFields: ['addresses', 'createdBy', 'lastModifiedBy'],
       replaceFields: ({ fields }) => ({
-        ...(fields as TDivision),
-        storesRef: [KeyReference.random().typeId('store').buildGraphql()],
+        ...fields,
+        storesRef:
+          'stores' in fields
+            ? fields.stores?.map((store) =>
+                KeyReference.random()
+                  .typeId('store')
+                  .key(store.key)
+                  .buildGraphql()
+              )
+            : [],
+        inheritedStoresRef:
+          'inheritedStores' in fields
+            ? fields.inheritedStores?.map((store) =>
+                KeyReference.random()
+                  .typeId('store')
+                  .key(store.key)
+                  .buildGraphql()
+              )
+            : [],
         parentUnitRef: KeyReference.random()
           .typeId('business-unit')
           .buildGraphql(),
@@ -45,9 +62,6 @@ const transformers = {
             : Company.random().buildGraphql(),
         ancestors:
           'ancestors' in fields && fields.ancestors ? fields.ancestors : [],
-        inheritedStoresRef: [
-          KeyReference.random().typeId('store').buildGraphql(),
-        ],
         __typename: 'BusinessUnit',
       }),
     }


### PR DESCRIPTION
This PR adds missing inheritedStores field to the generator of Company and Division according to the new SDK (in the default and rest and graphql transformers)