### PR TITLE
Prc 3957 update the cart discount test data model to reflect the removal of exclude

### DIFF
--- a/.changeset/clever-mayflies-joke.md
+++ b/.changeset/clever-mayflies-joke.md
@@ -1,5 +1,0 @@
----
-'@commercetools-test-data/cart-discount': minor
----
-
-excludeCount property from cart discounts models

--- a/.changeset/clever-mayflies-joke.md
+++ b/.changeset/clever-mayflies-joke.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart-discount': minor
+---
+
+excludeCount property from cart discounts models

--- a/.changeset/strange-hounds-shout.md
+++ b/.changeset/strange-hounds-shout.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart-discount': minor
+---
+
+remove excludeCount property from cart discounts models

--- a/models/cart-discount/src/cart-discount-pattern-target/builders.spec.ts
+++ b/models/cart-discount/src/cart-discount-pattern-target/builders.spec.ts
@@ -21,7 +21,6 @@ describe('CartDiscountPatternTarget Builder', () => {
             predicate: expect.any(String),
             minCount: expect.any(Number),
             maxCount: expect.toBeOneOf([expect.any(Number), null]),
-            excludeCount: expect.any(Number),
           }),
         ]),
         triggerPattern: expect.arrayContaining([
@@ -33,7 +32,6 @@ describe('CartDiscountPatternTarget Builder', () => {
             predicate: expect.any(String),
             minCount: expect.any(Number),
             maxCount: expect.toBeOneOf([expect.any(Number), null]),
-            excludeCount: expect.any(Number),
           }),
         ]),
       })
@@ -62,7 +60,6 @@ describe('CartDiscountPatternTarget Builder', () => {
             predicate: expect.any(String),
             minCount: expect.any(Number),
             maxCount: expect.toBeOneOf([expect.any(Number), null]),
-            excludeCount: expect.any(Number),
           }),
         ]),
         triggerPattern: expect.arrayContaining([

--- a/models/cart-discount/src/cart-discount-pattern-target/src/cart-discount-pattern-target-draft/builders.spec.ts
+++ b/models/cart-discount/src/cart-discount-pattern-target/src/cart-discount-pattern-target-draft/builders.spec.ts
@@ -10,7 +10,6 @@ describe('CartDiscountPatternTargetDraft Builder', () => {
         selectionMode: expect.any(String),
         targetPattern: expect.arrayContaining([
           expect.objectContaining({
-            excludeCount: expect.any(Number),
             maxCount: expect.toBeOneOf([expect.any(Number), null]),
             minCount: expect.any(Number),
             predicate: expect.any(String),
@@ -18,7 +17,6 @@ describe('CartDiscountPatternTargetDraft Builder', () => {
         ]),
         triggerPattern: expect.arrayContaining([
           expect.objectContaining({
-            excludeCount: expect.any(Number),
             maxCount: expect.toBeOneOf([expect.any(Number), null]),
             minCount: expect.any(Number),
             predicate: expect.any(String),

--- a/models/cart-discount/src/count-on-custom-line-item-units/builders.spec.ts
+++ b/models/cart-discount/src/count-on-custom-line-item-units/builders.spec.ts
@@ -13,7 +13,6 @@ describe('CountOnCustomLineItemUnits Builder', () => {
         predicate: expect.any(String),
         minCount: expect.any(Number),
         maxCount: expect.toBeOneOf([expect.any(Number), null]),
-        excludeCount: expect.any(Number),
       })
     );
   });
@@ -28,7 +27,6 @@ describe('CountOnCustomLineItemUnits Builder', () => {
         predicate: expect.any(String),
         minCount: expect.any(Number),
         maxCount: expect.toBeOneOf([expect.any(Number), null]),
-        excludeCount: expect.any(Number),
       })
     );
   });

--- a/models/cart-discount/src/count-on-custom-line-item-units/fields-config.ts
+++ b/models/cart-discount/src/count-on-custom-line-item-units/fields-config.ts
@@ -21,9 +21,6 @@ const commonFieldsConfig = {
   maxCount: fake((f) =>
     f.helpers.arrayElement([null, 0, f.number.int({ min: 1, max: 5 })])
   ),
-  excludeCount: fake((f) =>
-    f.helpers.arrayElement([0, f.number.int({ min: 1, max: 10 })])
-  ),
 };
 
 export const restFieldsConfig: TModelFieldsConfig<TCountOnCustomLineItemUnitsRest> =

--- a/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/builders.spec.ts
+++ b/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/builders.spec.ts
@@ -10,7 +10,6 @@ describe('CountOnCustomLineItemUnitsDraft Builder', () => {
         predicate: expect.any(String),
         minCount: expect.any(Number),
         maxCount: expect.toBeOneOf([expect.any(Number), null]),
-        excludeCount: expect.any(Number),
       })
     );
   });

--- a/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/builders.ts
+++ b/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/builders.ts
@@ -1,9 +1,7 @@
 import { createSpecializedBuilder } from '@commercetools-test-data/core';
+import { TCountOnCustomLineItemUnitsDraftGraphql } from '../../types';
 import { graphqlFieldsConfig } from './fields-config';
-import type {
-  TCreateCountOnCustomLineItemUnitsDraftBuilder,
-  TCountOnCustomLineItemUnitsDraftGraphql,
-} from './types';
+import type { TCreateCountOnCustomLineItemUnitsDraftBuilder } from './types';
 
 export const GraphqlModelBuilder: TCreateCountOnCustomLineItemUnitsDraftBuilder<
   TCountOnCustomLineItemUnitsDraftGraphql

--- a/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/fields-config.ts
+++ b/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/fields-config.ts
@@ -1,5 +1,5 @@
 import { fake, type TModelFieldsConfig } from '@commercetools-test-data/core';
-import type { TCountOnCustomLineItemUnitsDraftGraphql } from './types';
+import { TCountOnCustomLineItemUnitsDraftGraphql } from '../../types';
 
 export const graphqlFieldsConfig: TModelFieldsConfig<TCountOnCustomLineItemUnitsDraftGraphql> =
   {

--- a/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/fields-config.ts
+++ b/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/fields-config.ts
@@ -19,8 +19,5 @@ export const graphqlFieldsConfig: TModelFieldsConfig<TCountOnCustomLineItemUnits
       maxCount: fake((f) =>
         f.helpers.arrayElement([null, 0, f.number.int({ min: 1, max: 5 })])
       ),
-      excludeCount: fake((f) =>
-        f.helpers.arrayElement([0, f.number.int({ min: 1, max: 10 })])
-      ),
     },
   };

--- a/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/types.ts
+++ b/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/types.ts
@@ -1,8 +1,10 @@
 import type { TBuilder } from '@commercetools-test-data/core';
 import { TCtpCountOnCustomLineItemUnitsInput } from '@commercetools-test-data/graphql-types';
 
-export type TCountOnCustomLineItemUnitsDraftGraphql =
-  TCtpCountOnCustomLineItemUnitsInput;
+export type TCountOnCustomLineItemUnitsDraftGraphql = Omit<
+  TCtpCountOnCustomLineItemUnitsInput,
+  'excludeCount'
+>;
 
 export type TCreateCountOnCustomLineItemUnitsDraftBuilder<
   TModel extends TCountOnCustomLineItemUnitsDraftGraphql,

--- a/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/types.ts
+++ b/models/cart-discount/src/count-on-custom-line-item-units/src/count-on-custom-line-item-units-draft/types.ts
@@ -1,10 +1,5 @@
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpCountOnCustomLineItemUnitsInput } from '@commercetools-test-data/graphql-types';
-
-export type TCountOnCustomLineItemUnitsDraftGraphql = Omit<
-  TCtpCountOnCustomLineItemUnitsInput,
-  'excludeCount'
->;
+import { TCountOnCustomLineItemUnitsDraftGraphql } from '../../types';
 
 export type TCreateCountOnCustomLineItemUnitsDraftBuilder<
   TModel extends TCountOnCustomLineItemUnitsDraftGraphql,

--- a/models/cart-discount/src/count-on-custom-line-item-units/types.ts
+++ b/models/cart-discount/src/count-on-custom-line-item-units/types.ts
@@ -13,8 +13,10 @@ export type TCountOnCustomLineItemUnitsGraphql = Omit<
   TCtpCountOnCustomLineItemUnits,
   'excludeCount'
 >;
-export type TCountOnCustomLineItemUnitsDraftGraphql =
-  TCtpCountOnCustomLineItemUnitsInput;
+export type TCountOnCustomLineItemUnitsDraftGraphql = Omit<
+  TCtpCountOnCustomLineItemUnitsInput,
+  'excludeCount'
+>;
 
 export type TCreateCountOnCustomLineItemUnitsBuilder<
   TModel extends

--- a/models/cart-discount/src/count-on-custom-line-item-units/types.ts
+++ b/models/cart-discount/src/count-on-custom-line-item-units/types.ts
@@ -5,8 +5,14 @@ import {
   TCtpCountOnCustomLineItemUnitsInput,
 } from '@commercetools-test-data/graphql-types';
 
-export type TCountOnCustomLineItemUnitsRest = CountOnCustomLineItemUnits;
-export type TCountOnCustomLineItemUnitsGraphql = TCtpCountOnCustomLineItemUnits;
+export type TCountOnCustomLineItemUnitsRest = Omit<
+  CountOnCustomLineItemUnits,
+  'excludeCount'
+>;
+export type TCountOnCustomLineItemUnitsGraphql = Omit<
+  TCtpCountOnCustomLineItemUnits,
+  'excludeCount'
+>;
 export type TCountOnCustomLineItemUnitsDraftGraphql =
   TCtpCountOnCustomLineItemUnitsInput;
 

--- a/models/cart-discount/src/count-on-custom-line-item-units/types.ts
+++ b/models/cart-discount/src/count-on-custom-line-item-units/types.ts
@@ -5,6 +5,7 @@ import {
   TCtpCountOnCustomLineItemUnitsInput,
 } from '@commercetools-test-data/graphql-types';
 
+//@TODO: remove Omit when CountOnCustomLineItemUnits gets the excludeCount field in the SDK
 export type TCountOnCustomLineItemUnitsRest = Omit<
   CountOnCustomLineItemUnits,
   'excludeCount'

--- a/models/cart-discount/src/count-on-line-item-units/builders.spec.ts
+++ b/models/cart-discount/src/count-on-line-item-units/builders.spec.ts
@@ -10,7 +10,6 @@ describe('CountOnLineItemUnits Builder', () => {
         predicate: expect.any(String),
         minCount: expect.any(Number),
         maxCount: expect.toBeOneOf([expect.any(Number), null]),
-        excludeCount: expect.any(Number),
       })
     );
   });
@@ -25,7 +24,6 @@ describe('CountOnLineItemUnits Builder', () => {
         predicate: expect.any(String),
         minCount: expect.any(Number),
         maxCount: expect.toBeOneOf([expect.any(Number), null]),
-        excludeCount: expect.any(Number),
       })
     );
   });

--- a/models/cart-discount/src/count-on-line-item-units/fields-config.ts
+++ b/models/cart-discount/src/count-on-line-item-units/fields-config.ts
@@ -21,9 +21,6 @@ const commonFieldsConfig = {
   maxCount: fake((f) =>
     f.helpers.arrayElement([null, 0, f.number.int({ min: 1, max: 5 })])
   ),
-  excludeCount: fake((f) =>
-    f.helpers.arrayElement([0, f.number.int({ min: 1, max: 10 })])
-  ),
 };
 
 export const restFieldsConfig: TModelFieldsConfig<TCountOnLineItemUnitsRest> = {

--- a/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/builders.spec.ts
+++ b/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/builders.spec.ts
@@ -9,7 +9,6 @@ describe('CountOnLineItemUnitsDraft Builder', () => {
         predicate: expect.any(String),
         minCount: expect.any(Number),
         maxCount: expect.toBeOneOf([expect.any(Number), null]),
-        excludeCount: expect.any(Number),
       })
     );
   });

--- a/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/builders.ts
+++ b/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/builders.ts
@@ -1,9 +1,7 @@
 import { createSpecializedBuilder } from '@commercetools-test-data/core';
+import { TCountOnLineItemUnitsDraftGraphql } from '../../types';
 import { graphqlFieldsConfig } from './fields-config';
-import type {
-  TCreateCountOnLineItemUnitsDraftBuilder,
-  TCountOnLineItemUnitsDraftGraphql,
-} from './types';
+import type { TCreateCountOnLineItemUnitsDraftBuilder } from './types';
 
 export const GraphqlModelBuilder: TCreateCountOnLineItemUnitsDraftBuilder<
   TCountOnLineItemUnitsDraftGraphql

--- a/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/fields-config.ts
+++ b/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/fields-config.ts
@@ -19,8 +19,5 @@ export const graphqlFieldsConfig: TModelFieldsConfig<TCountOnLineItemUnitsDraftG
       maxCount: fake((f) =>
         f.helpers.arrayElement([null, 0, f.number.int({ min: 1, max: 5 })])
       ),
-      excludeCount: fake((f) =>
-        f.helpers.arrayElement([0, f.number.int({ min: 1, max: 10 })])
-      ),
     },
   };

--- a/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/fields-config.ts
+++ b/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/fields-config.ts
@@ -1,5 +1,5 @@
 import { fake, type TModelFieldsConfig } from '@commercetools-test-data/core';
-import type { TCountOnLineItemUnitsDraftGraphql } from './types';
+import { TCountOnLineItemUnitsDraftGraphql } from '../../types';
 
 export const graphqlFieldsConfig: TModelFieldsConfig<TCountOnLineItemUnitsDraftGraphql> =
   {

--- a/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/types.ts
+++ b/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/types.ts
@@ -1,7 +1,10 @@
 import type { TBuilder } from '@commercetools-test-data/core';
 import { TCtpCountOnLineItemUnitsInput } from '@commercetools-test-data/graphql-types';
 
-export type TCountOnLineItemUnitsDraftGraphql = TCtpCountOnLineItemUnitsInput;
+export type TCountOnLineItemUnitsDraftGraphql = Omit<
+  TCtpCountOnLineItemUnitsInput,
+  'excludeCount'
+>;
 
 export type TCreateCountOnLineItemUnitsDraftBuilder<
   TModel extends TCountOnLineItemUnitsDraftGraphql,

--- a/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/types.ts
+++ b/models/cart-discount/src/count-on-line-item-units/src/count-on-line-item-units-draft/types.ts
@@ -1,10 +1,5 @@
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpCountOnLineItemUnitsInput } from '@commercetools-test-data/graphql-types';
-
-export type TCountOnLineItemUnitsDraftGraphql = Omit<
-  TCtpCountOnLineItemUnitsInput,
-  'excludeCount'
->;
+import { TCountOnLineItemUnitsDraftGraphql } from '../../types';
 
 export type TCreateCountOnLineItemUnitsDraftBuilder<
   TModel extends TCountOnLineItemUnitsDraftGraphql,

--- a/models/cart-discount/src/count-on-line-item-units/types.ts
+++ b/models/cart-discount/src/count-on-line-item-units/types.ts
@@ -5,8 +5,14 @@ import {
   TCtpCountOnLineItemUnitsInput,
 } from '@commercetools-test-data/graphql-types';
 
-export type TCountOnLineItemUnitsRest = CountOnLineItemUnits;
-export type TCountOnLineItemUnitsGraphql = TCtpCountOnLineItemUnits;
+export type TCountOnLineItemUnitsRest = Omit<
+  CountOnLineItemUnits,
+  'excludeCount'
+>;
+export type TCountOnLineItemUnitsGraphql = Omit<
+  TCtpCountOnLineItemUnits,
+  'excludeCount'
+>;
 export type TCountOnLineItemUnitsDraftGraphql = TCtpCountOnLineItemUnitsInput;
 
 export type TCreateCountOnLineItemUnitsBuilder<

--- a/models/cart-discount/src/count-on-line-item-units/types.ts
+++ b/models/cart-discount/src/count-on-line-item-units/types.ts
@@ -13,7 +13,10 @@ export type TCountOnLineItemUnitsGraphql = Omit<
   TCtpCountOnLineItemUnits,
   'excludeCount'
 >;
-export type TCountOnLineItemUnitsDraftGraphql = TCtpCountOnLineItemUnitsInput;
+export type TCountOnLineItemUnitsDraftGraphql = Omit<
+  TCtpCountOnLineItemUnitsInput,
+  'excludeCount'
+>;
 
 export type TCreateCountOnLineItemUnitsBuilder<
   TModel extends

--- a/models/cart-discount/src/count-on-line-item-units/types.ts
+++ b/models/cart-discount/src/count-on-line-item-units/types.ts
@@ -5,6 +5,7 @@ import {
   TCtpCountOnLineItemUnitsInput,
 } from '@commercetools-test-data/graphql-types';
 
+//@TODO: remove Omit when CountOnLineItemUnits gets the excludeCount field in the SDK
 export type TCountOnLineItemUnitsRest = Omit<
   CountOnLineItemUnits,
   'excludeCount'


### PR DESCRIPTION
excludeCount property has been deprecated and should be removed from all our cart discount related models