### PR TITLE
Fix ProductDraft compatibility model export

### DIFF
--- a/.changeset/afraid-hairs-own.md
+++ b/.changeset/afraid-hairs-own.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product': patch
+---
+
+Fixes the way the `ProductDraft` model is exported as the current one (introduced in the previous release) is not retro-compatible.

--- a/models/product/src/index.ts
+++ b/models/product/src/index.ts
@@ -1,7 +1,6 @@
 // Export types
 export * from './attribute/types';
 export * from './image/types';
-export * from './product/types';
 export * from './product-catalog-data/types';
 export * from './product-data/types';
 export * from './product-variant/types';
@@ -13,8 +12,8 @@ export * as AttributeDraft from './attribute/attribute-draft';
 export * as Image from './image';
 export * as ImageDraft from './image/image-draft';
 
-export * as Product from './product';
-export * as ProductDraft from './product/product-draft';
+export * from './product';
+export * from './product/product-draft';
 
 export * as ProductCatalogData from './product-catalog-data';
 

--- a/models/product/src/product/index.ts
+++ b/models/product/src/product/index.ts
@@ -5,11 +5,10 @@ import {
   GraphqlModelBuilder,
   RestModelBuilder,
 } from './builders';
+import * as constants from './constants';
 import * as modelPresets from './presets';
 
 export * from './types';
-export * as constants from './constants';
-export * from './product-draft';
 
 export const ProductRest = {
   random: RestModelBuilder,
@@ -21,9 +20,11 @@ export const ProductGraphql = {
   presets: modelPresets.graphqlPresets,
 };
 
-export * as Product from '.';
 /**
  * @deprecated Use `ProductRest` or `ProductGraphql` exported models instead of `Product`.
  */
-export const random = CompatProductModelBuilder;
-export const presets = modelPresets.compatPresets;
+export const Product = {
+  random: CompatProductModelBuilder,
+  presets: modelPresets.compatPresets,
+  constants,
+};

--- a/models/product/src/product/product-draft/index.ts
+++ b/models/product/src/product/product-draft/index.ts
@@ -15,10 +15,9 @@ export const ProductDraftGraphql = {
   presets: modelPresets.graphqlPresets,
 };
 
+export * as ProductDraft from '.';
 /**
  * @deprecated Use `ProductDraftRest` or `ProductDraftGraphql` exported models instead of `ProductDraft`.
  */
-export const ProductDraft = {
-  random: CompatProductModelBuilder,
-  presets: modelPresets.compatPresets,
-};
+export const random = CompatProductModelBuilder;
+export const presets = modelPresets.compatPresets;

--- a/models/product/src/product/product-draft/index.ts
+++ b/models/product/src/product/product-draft/index.ts
@@ -15,9 +15,10 @@ export const ProductDraftGraphql = {
   presets: modelPresets.graphqlPresets,
 };
 
-export * as ProductDraft from '.';
 /**
  * @deprecated Use `ProductDraftRest` or `ProductDraftGraphql` exported models instead of `ProductDraft`.
  */
-export const random = CompatProductModelBuilder;
-export const presets = modelPresets.compatPresets;
+export const ProductDraft = {
+  random: CompatProductModelBuilder,
+  presets: modelPresets.compatPresets,
+};

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/a-789-bc.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/a-789-bc.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/aa-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/aa-123-qr.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/aaa-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/aaa-789-uv.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/air-filter.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/air-filter.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/alternator.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/alternator.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/b-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/b-456-st.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/bb-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/bb-456-st.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/bbb-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/bbb-234-wx.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/brake-pad-set.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/brake-pad-set.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/c-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/c-789-uv.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/cc-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/cc-789-uv.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ccc-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ccc-567-yz.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/d-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/d-234-wx.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/dd-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/dd-234-wx.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ddd-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ddd-890-op.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/e-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/e-567-yz.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ee-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ee-567-yz.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/eee-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/eee-123-qr.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/f-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/f-890-op.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ff-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ff-890-op.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/fff-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/fff-456-st.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/fuel-filter.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/fuel-filter.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/g-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/g-123-qr.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/gg-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/gg-123-qr.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ggg-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ggg-789-uv.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/h-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/h-456-st.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/hh-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/hh-456-st.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/hhh-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/hhh-234-wx.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/hydraulic-hose.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/hydraulic-hose.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/i-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/i-789-uv.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ii-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ii-789-uv.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/iii-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/iii-567-yz.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/j-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/j-234-wx.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/jj-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/jj-234-wx.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/jjj-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/jjj-890-op.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/k-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/k-567-yz.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/kk-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/kk-567-yz.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/l-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/l-890-op.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/led-work-light.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/led-work-light.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ll-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ll-890-op.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/m-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/m-890-op.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/mm-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/mm-123-qr.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/n-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/n-123-qr.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/nn-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/nn-456-st.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/oil-filter.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/oil-filter.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/oo-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/oo-789-uv.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/p-234-qw.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/p-234-qw.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/pin-and-bushing-kit.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/pin-and-bushing-kit.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/piston-ring-set.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/piston-ring-set.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/pneumatic-tire.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/pneumatic-tire.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/pp-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/pp-234-wx.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/qq-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/qq-567-yz.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/r-123-ts.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/r-123-ts.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/rr-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/rr-890-op.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/s-567-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/s-567-uv.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ss-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ss-123-qr.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/starter-motor.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/starter-motor.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/tapered-roller-bearing.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/tapered-roller-bearing.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/tt-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/tt-456-st.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/u-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/u-123-qr.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/uu-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/uu-789-uv.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/v-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/v-456-st.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/vv-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/vv-234-wx.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/w-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/w-789-uv.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ww-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ww-567-yz.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/x-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/x-234-wx.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/x-456-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/x-456-yz.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/xx-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/xx-890-op.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/y-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/y-567-yz.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/yy-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/yy-123-qr.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/z-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/z-890-op.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/zz-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/zz-456-st.ts
@@ -17,8 +17,8 @@ import {
 } from '@commercetools-test-data/tax-category';
 import { ProductVariantDraft } from '../../../../product-variant';
 import { productPriceMode } from '../../../constants';
-import { ProductDraft } from '../../../index';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxTaxCategory = TaxCategoryDraft.presets.sampleDataB2B
   .standardTax()

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/abigail-lounge-chair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/abigail-lounge-chair.ts
@@ -15,9 +15,9 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductDraft } from '../../../';
 import { ProductVariantDraft } from '../../../../product-variant';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxCategory = TaxCategoryDraft.presets.sampleDataB2CLifestyle
   .standardTaxCategory()

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/amalia-rug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/amalia-rug.ts
@@ -15,9 +15,9 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductDraft } from '../../..';
 import { ProductVariantDraft } from '../../../../product-variant';
 import type { TProductDraft } from '../../../types';
+import { ProductDraft } from '../../index';
 
 const standardTaxCategory = TaxCategoryDraft.presets.sampleDataB2CLifestyle
   .standardTaxCategory()


### PR DESCRIPTION
This PR fixes an issue introduced in  #768 where we changed the way the `ProductDraft` model is exported.

The new way is not backwards compatible so we need to adjust what we've changed over there so consumers are not affected.

**NOTE**: Changes in the presets can be ignored. We just needed to adjust some import paths.