### PR TITLE
Fix Product test data model compatibility presets

### DIFF
--- a/.changeset/odd-eggs-change.md
+++ b/.changeset/odd-eggs-change.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product': patch
+---
+
+We had a bug in the `Product` compatibility presets where they were always returning a GraphQL value for the `productType` property even when the consumer wanted to build a REST `Product`.

--- a/models/product/src/product/fields-config.ts
+++ b/models/product/src/product/fields-config.ts
@@ -51,6 +51,21 @@ export const restFieldsConfig: TModelFieldsConfig<TProductRest> = {
         .obj(TaxCategory.random().id(taxCategoryId));
     }),
   },
+  postBuild: (model) => {
+    const result = { ...model };
+    // This is required because the 'productType' prop has a different type for REST and GraphQL
+    // and compatibility presets can use just one value for it. We decided to use the GraphQL
+    // one so here we check whether the productType has the GraphQL shape and convert it to
+    // REST (it should be a reference) if needed.
+    if (model.productType && !model.productType.typeId) {
+      result.productType = ReferenceRest.presets
+        .productTypeReference()
+        .id(model.productType.id)
+        .obj(model.productType)
+        .build();
+    }
+    return result;
+  },
 };
 export const graphqlFieldsConfig: TModelFieldsConfig<TProductGraphql> = {
   fields: {

--- a/models/product/src/product/presets/boring-generic-milk.spec.ts
+++ b/models/product/src/product/presets/boring-generic-milk.spec.ts
@@ -1,0 +1,84 @@
+import { TProductGraphql, TProductRest } from '../types';
+import { restPreset, graphqlPreset, compatPreset } from './boring-generic-milk';
+
+function validateRestModel(restModel: TProductRest) {
+  expect(restModel).toEqual(
+    expect.objectContaining({
+      key: 'boring-generic-milk-key',
+      masterData: expect.objectContaining({
+        current: expect.objectContaining({
+          slug: expect.objectContaining({
+            en: 'boring-generic-milk-slug',
+          }),
+        }),
+        published: true,
+      }),
+      productType: expect.objectContaining({
+        typeId: 'product-type',
+        id: expect.any(String),
+        obj: expect.objectContaining({
+          id: expect.any(String),
+          name: 'Milk Product Type',
+        }),
+      }),
+    })
+  );
+}
+
+function validateGraphqlModel(graphqlModel: TProductGraphql) {
+  expect(graphqlModel).toEqual(
+    expect.objectContaining({
+      key: 'boring-generic-milk-key',
+      masterData: expect.objectContaining({
+        current: expect.objectContaining({
+          slug: 'boring-generic-milk-slug',
+        }),
+        published: true,
+        __typename: 'ProductCatalogData',
+      }),
+      productType: expect.objectContaining({
+        name: 'Milk Product Type',
+        __typename: 'ProductTypeDefinition',
+      }),
+      productTypeRef: expect.objectContaining({
+        typeId: 'product-type',
+        __typename: 'Reference',
+      }),
+      __typename: 'Product',
+    })
+  );
+}
+
+describe('Product "boring generic milk" presets', () => {
+  it('builds a REST model', () => {
+    const restModel = restPreset().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = graphqlPreset().build();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});
+
+describe('Product "happy cow milk" compatibility presets', () => {
+  it('builds a default (REST) model', () => {
+    const compatModel = compatPreset().build();
+
+    validateRestModel(compatModel);
+  });
+
+  it('builds a REST model', () => {
+    const restModel = compatPreset().buildRest();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = compatPreset().buildGraphql<TProductGraphql>();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});

--- a/models/product/src/product/presets/boring-generic-milk.ts
+++ b/models/product/src/product/presets/boring-generic-milk.ts
@@ -29,6 +29,6 @@ export const graphqlPreset = (): TBuilder<TProductGraphql> => {
 
 export const compatPreset = (): TBuilder<TProduct> => {
   return populatePreset(Product.random()).productType(
-    ReferenceRest.presets.productTypeReference().obj(ProductType.presets.milk())
+    ProductType.presets.milk()
   );
 };

--- a/models/product/src/product/presets/happy-cow-milk.spec.ts
+++ b/models/product/src/product/presets/happy-cow-milk.spec.ts
@@ -1,0 +1,84 @@
+import { TProductGraphql, TProductRest } from '../types';
+import { restPreset, graphqlPreset, compatPreset } from './happy-cow-milk';
+
+function validateRestModel(restModel: TProductRest) {
+  expect(restModel).toEqual(
+    expect.objectContaining({
+      key: 'happy-cow-milk-key',
+      masterData: expect.objectContaining({
+        current: expect.objectContaining({
+          slug: expect.objectContaining({
+            en: 'happy-cow-milk-slug',
+          }),
+        }),
+        published: true,
+      }),
+      productType: expect.objectContaining({
+        typeId: 'product-type',
+        id: expect.any(String),
+        obj: expect.objectContaining({
+          id: expect.any(String),
+          name: 'Milk Product Type',
+        }),
+      }),
+    })
+  );
+}
+
+function validateGraphqlModel(graphqlModel: TProductGraphql) {
+  expect(graphqlModel).toEqual(
+    expect.objectContaining({
+      key: 'happy-cow-milk-key',
+      masterData: expect.objectContaining({
+        current: expect.objectContaining({
+          slug: 'happy-cow-milk-slug',
+        }),
+        published: true,
+        __typename: 'ProductCatalogData',
+      }),
+      productType: expect.objectContaining({
+        name: 'Milk Product Type',
+        __typename: 'ProductTypeDefinition',
+      }),
+      productTypeRef: expect.objectContaining({
+        typeId: 'product-type',
+        __typename: 'Reference',
+      }),
+      __typename: 'Product',
+    })
+  );
+}
+
+describe('Product "happy cow milk" presets', () => {
+  it('builds a REST model', () => {
+    const restModel = restPreset().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = graphqlPreset().build();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});
+
+describe('Product "happy cow milk" compatibility presets', () => {
+  it('builds a default (REST) model', () => {
+    const compatModel = compatPreset().build();
+
+    validateRestModel(compatModel);
+  });
+
+  it('builds a REST model', () => {
+    const restModel = compatPreset().buildRest();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = compatPreset().buildGraphql<TProductGraphql>();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});

--- a/models/product/src/product/presets/happy-cow-milk.ts
+++ b/models/product/src/product/presets/happy-cow-milk.ts
@@ -27,6 +27,6 @@ export const graphqlPreset = (): TBuilder<TProductGraphql> => {
 
 export const compatPreset = (): TBuilder<TProduct> => {
   return populatePreset(Product.random()).productType(
-    ReferenceRest.presets.productTypeReference().obj(ProductType.presets.milk())
+    ProductType.presets.milk()
   );
 };


### PR DESCRIPTION
We had a bug in the `Product` compatibility presets where they were always returning a GraphQL value for the `productType` property even when the consumer wanted to build a REST `Product`.
