### PR TITLE
fix: `@commercetools-test-data/type` TS types

### DIFF
--- a/.changeset/small-suits-smoke.md
+++ b/.changeset/small-suits-smoke.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/type': patch
+---
+
+Use generated types from GraphQL schema

--- a/models/cart/src/cart/builders.spec.ts
+++ b/models/cart/src/cart/builders.spec.ts
@@ -125,7 +125,7 @@ const validateGraphqlModel = (model: TCartGraphql) => {
     expect.objectContaining({
       __typename: 'Cart',
       custom: expect.objectContaining({
-        __typename: 'BooleanCustomFieldType',
+        __typename: 'BooleanType',
       }),
       customer: null,
       placement: null,

--- a/models/cart/src/custom-line-item/builders.spec.ts
+++ b/models/cart/src/custom-line-item/builders.spec.ts
@@ -63,7 +63,7 @@ const validateGraphqlFields = (model: TCustomLineItemGraphql) => {
   expect(model).toEqual(
     expect.objectContaining({
       custom: expect.objectContaining({
-        __typename: 'BooleanCustomFieldType',
+        __typename: 'BooleanType',
       }),
       __typename: 'CustomLineItem',
       name: expect.any(String),

--- a/models/channel/src/builder.spec.ts
+++ b/models/channel/src/builder.spec.ts
@@ -128,7 +128,7 @@ const validateGraphqlModel = (model: TChannelGraphql) => {
       }),
       custom: expect.objectContaining({
         name: 'Boolean',
-        __typename: 'BooleanCustomFieldType',
+        __typename: 'BooleanType',
       }),
       geoLocation: expect.objectContaining({
         __typename: 'Geometry',

--- a/models/channel/src/channel-draft/builder.spec.ts
+++ b/models/channel/src/channel-draft/builder.spec.ts
@@ -52,7 +52,7 @@ describe('ChannelDraft builder', () => {
         }),
         custom: expect.objectContaining({
           name: 'Boolean',
-          __typename: 'BooleanCustomFieldType',
+          __typename: 'BooleanType',
         }),
         geoLocation: expect.objectContaining({
           type: 'Point',
@@ -109,7 +109,7 @@ describe('ChannelDraft compatibility builder', () => {
         }),
         custom: expect.objectContaining({
           name: 'Boolean',
-          __typename: 'BooleanCustomFieldType',
+          __typename: 'BooleanType',
         }),
         geoLocation: expect.objectContaining({
           type: 'Point',

--- a/models/type/package.json
+++ b/models/type/package.json
@@ -21,6 +21,7 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-test-data/commons": "10.15.1",
     "@commercetools-test-data/core": "10.15.1",
+    "@commercetools-test-data/graphql-types": "10.15.1",
     "@commercetools-test-data/utils": "10.15.1",
     "@commercetools/platform-sdk": "8.5.0",
     "@faker-js/faker": "^9.0.0"

--- a/models/type/src/custom-field-boolean-type/builder.spec.ts
+++ b/models/type/src/custom-field-boolean-type/builder.spec.ts
@@ -37,7 +37,7 @@ describe('builder', () => {
       CustomFieldBooleanType.random(),
       expect.objectContaining({
         name: 'Boolean',
-        __typename: 'BooleanCustomFieldType',
+        __typename: 'BooleanType',
       })
     )
   );

--- a/models/type/src/custom-field-boolean-type/transformers.ts
+++ b/models/type/src/custom-field-boolean-type/transformers.ts
@@ -19,7 +19,7 @@ const transformers = {
     {
       buildFields: [],
       addFields: () => ({
-        __typename: 'BooleanCustomFieldType',
+        __typename: 'BooleanType',
       }),
     }
   ),

--- a/models/type/src/custom-field-boolean-type/types.ts
+++ b/models/type/src/custom-field-boolean-type/types.ts
@@ -1,6 +1,6 @@
 import type { CustomFieldBooleanType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpBooleanType } from '../../../../graphql-types/src';
+import { TCtpBooleanType } from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldBooleanType = CustomFieldBooleanType;
 export type TCustomFieldBooleanTypeDraft = CustomFieldBooleanType;

--- a/models/type/src/custom-field-boolean-type/types.ts
+++ b/models/type/src/custom-field-boolean-type/types.ts
@@ -1,12 +1,11 @@
 import type { CustomFieldBooleanType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpBooleanType } from '../../../../graphql-types/src';
 
 export type TCustomFieldBooleanType = CustomFieldBooleanType;
 export type TCustomFieldBooleanTypeDraft = CustomFieldBooleanType;
 
-export type TCustomFieldBooleanTypeGraphql = CustomFieldBooleanType & {
-  __typename: 'BooleanCustomFieldType';
-};
+export type TCustomFieldBooleanTypeGraphql = TCtpBooleanType;
 export type TCustomFieldBooleanTypeDraftGraphql = {
   boolean: {
     dummy: string | null;

--- a/models/type/src/custom-field-date-time-type/builder.spec.ts
+++ b/models/type/src/custom-field-date-time-type/builder.spec.ts
@@ -37,7 +37,7 @@ describe('builder', () => {
       AttributeEnumType.random(),
       expect.objectContaining({
         name: 'DateTime',
-        __typename: 'DateTimeCustomFieldType',
+        __typename: 'DateTimeType',
       })
     )
   );

--- a/models/type/src/custom-field-date-time-type/transformers.ts
+++ b/models/type/src/custom-field-date-time-type/transformers.ts
@@ -23,7 +23,7 @@ const transformers = {
   >('graphql', {
     buildFields: [],
     addFields: () => ({
-      __typename: 'DateTimeCustomFieldType',
+      __typename: 'DateTimeType',
     }),
   }),
 };

--- a/models/type/src/custom-field-date-time-type/types.ts
+++ b/models/type/src/custom-field-date-time-type/types.ts
@@ -1,12 +1,11 @@
 import type { CustomFieldDateTimeType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpDateTimeType } from '../../../../graphql-types/src';
 
 export type TCustomFieldDateTimeType = CustomFieldDateTimeType;
 export type TCustomFieldDateTimeTypeDraft = CustomFieldDateTimeType;
 
-export type TCustomFieldDateTimeTypeGraphql = CustomFieldDateTimeType & {
-  __typename: 'DateTimeCustomFieldType';
-};
+export type TCustomFieldDateTimeTypeGraphql = TCtpDateTimeType;
 export type TCustomFieldDateTimeTypeDraftGraphql = {
   datetime: {
     dummy: string | null;

--- a/models/type/src/custom-field-date-time-type/types.ts
+++ b/models/type/src/custom-field-date-time-type/types.ts
@@ -1,6 +1,6 @@
 import type { CustomFieldDateTimeType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpDateTimeType } from '../../../../graphql-types/src';
+import { TCtpDateTimeType } from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldDateTimeType = CustomFieldDateTimeType;
 export type TCustomFieldDateTimeTypeDraft = CustomFieldDateTimeType;

--- a/models/type/src/custom-field-date-type/builder.spec.ts
+++ b/models/type/src/custom-field-date-type/builder.spec.ts
@@ -31,7 +31,7 @@ describe('builder', () => {
       AttributeEnumType.random(),
       expect.objectContaining({
         name: 'Date',
-        __typename: 'DateCustomFieldType',
+        __typename: 'DateType',
       })
     )
   );

--- a/models/type/src/custom-field-date-type/transformers.ts
+++ b/models/type/src/custom-field-date-type/transformers.ts
@@ -13,7 +13,7 @@ const transformers = {
     {
       buildFields: [],
       addFields: () => ({
-        __typename: 'DateCustomFieldType',
+        __typename: 'DateType',
       }),
     }
   ),

--- a/models/type/src/custom-field-date-type/types.ts
+++ b/models/type/src/custom-field-date-type/types.ts
@@ -1,6 +1,6 @@
 import type { CustomFieldDateType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpDateType } from '../../../../graphql-types/src';
+import { TCtpDateType } from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldDateType = CustomFieldDateType;
 export type TCustomFieldDateTypeDraft = CustomFieldDateType;

--- a/models/type/src/custom-field-date-type/types.ts
+++ b/models/type/src/custom-field-date-type/types.ts
@@ -1,12 +1,11 @@
 import type { CustomFieldDateType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpDateType } from '../../../../graphql-types/src';
 
 export type TCustomFieldDateType = CustomFieldDateType;
 export type TCustomFieldDateTypeDraft = CustomFieldDateType;
 
-export type TCustomFieldDateTypeGraphql = CustomFieldDateType & {
-  __typename: 'DateCustomFieldType';
-};
+export type TCustomFieldDateTypeGraphql = TCtpDateType;
 export type TCustomFieldDateTypeDraftGraphql = {
   date: {
     dummy: string | null;

--- a/models/type/src/custom-field-enum-type/types.ts
+++ b/models/type/src/custom-field-enum-type/types.ts
@@ -3,13 +3,12 @@ import type {
   CustomFieldEnumValue,
 } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpEnumType } from '../../../../graphql-types/src';
 
 export type TCustomFieldEnumType = CustomFieldEnumType;
 export type TCustomFieldEnumTypeDraft = CustomFieldEnumType;
 
-export type TCustomFieldEnumTypeGraphql = CustomFieldEnumType & {
-  __typename: 'EnumType';
-};
+export type TCustomFieldEnumTypeGraphql = TCtpEnumType;
 export type TCustomFieldEnumTypeDraftGraphql = {
   enum: { values: Array<CustomFieldEnumValue> };
 };

--- a/models/type/src/custom-field-enum-type/types.ts
+++ b/models/type/src/custom-field-enum-type/types.ts
@@ -3,7 +3,7 @@ import type {
   CustomFieldEnumValue,
 } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpEnumType } from '../../../../graphql-types/src';
+import { TCtpEnumType } from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldEnumType = CustomFieldEnumType;
 export type TCustomFieldEnumTypeDraft = CustomFieldEnumType;

--- a/models/type/src/custom-field-enum-value/types.ts
+++ b/models/type/src/custom-field-enum-value/types.ts
@@ -1,13 +1,12 @@
 import { CustomFieldEnumValue } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpEnumValue, TCtpEnumValueInput } from '../../../../graphql-types/src';
 
 export type TCustomFieldEnumValue = CustomFieldEnumValue;
 export type TCustomFieldEnumValueDraft = CustomFieldEnumValue;
 
-export type TCustomFieldEnumValueGraphql = TCustomFieldEnumValue & {
-  __typename: 'EnumValue';
-};
-export type TCustomFieldEnumValueDraftGraphql = TCustomFieldEnumValueDraft;
+export type TCustomFieldEnumValueGraphql = TCtpEnumValue;
+export type TCustomFieldEnumValueDraftGraphql = TCtpEnumValueInput;
 
 export type TCustomFieldEnumValueBuilder = TBuilder<TCustomFieldEnumValue>;
 export type TCustomFieldEnumValueDraftBuilder =

--- a/models/type/src/custom-field-enum-value/types.ts
+++ b/models/type/src/custom-field-enum-value/types.ts
@@ -1,6 +1,9 @@
 import { CustomFieldEnumValue } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpEnumValue, TCtpEnumValueInput } from '../../../../graphql-types/src';
+import {
+  TCtpEnumValue,
+  TCtpEnumValueInput,
+} from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldEnumValue = CustomFieldEnumValue;
 export type TCustomFieldEnumValueDraft = CustomFieldEnumValue;

--- a/models/type/src/custom-field-localized-enum-type/builder.spec.ts
+++ b/models/type/src/custom-field-localized-enum-type/builder.spec.ts
@@ -60,23 +60,20 @@ describe('builder', () => {
       CustomFieldLocalizedEnumType.random(),
       expect.objectContaining({
         name: 'lenum',
-        values: expect.objectContaining({
-          results: [
-            expect.objectContaining({
-              key: expect.any(String),
-              labelAllLocales: expect.arrayContaining([
-                expect.objectContaining({
-                  locale: 'en',
-                  value: expect.any(String),
-                  __typename: 'LocalizedString',
-                }),
-              ]),
-              __typename: 'LocalizedEnumValue',
-            }),
-          ],
-          __typename: 'LocalizableEnumValueTypeResult',
-        }),
-        __typename: 'LocalizableEnumCustomFieldType',
+        values: [
+          {
+            key: expect.any(String),
+            labelAllLocales: expect.arrayContaining([
+              expect.objectContaining({
+                locale: 'en',
+                value: expect.any(String),
+                __typename: 'LocalizedString',
+              }),
+            ]),
+            __typename: 'LocalizedEnumValue',
+          },
+        ],
+        __typename: 'LocalizedEnumType',
       })
     )
   );

--- a/models/type/src/custom-field-localized-enum-type/transformers.ts
+++ b/models/type/src/custom-field-localized-enum-type/transformers.ts
@@ -1,3 +1,4 @@
+import { CustomFieldLocalizedEnumValue } from '@commercetools/platform-sdk';
 import { buildField, Transformer } from '@commercetools-test-data/core';
 import { TCustomFieldLocalizedEnumValueGraphql } from '../custom-field-localized-enum-value';
 import {
@@ -21,13 +22,13 @@ const transformers = {
     buildFields: [],
     replaceFields: ({ fields }) => ({
       ...fields,
-      values: {
-        results: fields.values!.map((value) =>
-          buildField(value, 'graphql')
-        ) as unknown as Array<TCustomFieldLocalizedEnumValueGraphql>,
-        __typename: 'LocalizableEnumValueTypeResult',
-      },
-      __typename: 'LocalizableEnumCustomFieldType',
+      values: fields.values!.map((value) =>
+        buildField<
+          CustomFieldLocalizedEnumValue,
+          TCustomFieldLocalizedEnumValueGraphql
+        >(value, 'graphql')
+      ),
+      __typename: 'LocalizedEnumType',
     }),
   }),
 };

--- a/models/type/src/custom-field-localized-enum-type/types.ts
+++ b/models/type/src/custom-field-localized-enum-type/types.ts
@@ -1,6 +1,6 @@
 import { CustomFieldLocalizedEnumType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpLocalizedEnumType } from '../../../../graphql-types/src';
+import { TCtpLocalizedEnumType } from '@commercetools-test-data/graphql-types';
 import { TCustomFieldLocalizedEnumValueDraftGraphql } from '../custom-field-localized-enum-value';
 
 export type TCustomFieldLocalizedEnumType = CustomFieldLocalizedEnumType;

--- a/models/type/src/custom-field-localized-enum-type/types.ts
+++ b/models/type/src/custom-field-localized-enum-type/types.ts
@@ -1,23 +1,12 @@
 import { CustomFieldLocalizedEnumType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import {
-  TCustomFieldLocalizedEnumValueDraftGraphql,
-  TCustomFieldLocalizedEnumValueGraphql,
-} from '../custom-field-localized-enum-value';
+import { TCtpLocalizedEnumType } from '../../../../graphql-types/src';
+import { TCustomFieldLocalizedEnumValueDraftGraphql } from '../custom-field-localized-enum-value';
 
 export type TCustomFieldLocalizedEnumType = CustomFieldLocalizedEnumType;
 export type TCustomFieldLocalizedEnumTypeDraft = CustomFieldLocalizedEnumType;
 
-export type TCustomFieldLocalizedEnumTypeGraphql = Omit<
-  TCustomFieldLocalizedEnumType,
-  'values'
-> & {
-  values: {
-    results: Array<TCustomFieldLocalizedEnumValueGraphql>;
-    __typename: 'LocalizableEnumValueTypeResult';
-  };
-  __typename: 'LocalizableEnumCustomFieldType';
-};
+export type TCustomFieldLocalizedEnumTypeGraphql = TCtpLocalizedEnumType;
 
 export type TCustomFieldLocalizedEnumTypeDraftGraphql = {
   lenum: {

--- a/models/type/src/custom-field-localized-enum-value/transformers.ts
+++ b/models/type/src/custom-field-localized-enum-value/transformers.ts
@@ -21,7 +21,8 @@ const transformers = {
     buildFields: [],
     removeFields: ['label'],
     addFields: ({ fields }) => ({
-      labelAllLocales: LocalizedString.toLocalizedField(fields.label),
+      labelAllLocales:
+        LocalizedString.toLocalizedField(fields.label) ?? undefined,
       __typename: 'LocalizedEnumValue',
     }),
   }),

--- a/models/type/src/custom-field-localized-enum-value/types.ts
+++ b/models/type/src/custom-field-localized-enum-value/types.ts
@@ -1,20 +1,16 @@
 import { CustomFieldLocalizedEnumValue } from '@commercetools/platform-sdk';
-import { TLocalizedStringGraphql } from '@commercetools-test-data/commons/src';
 import type { TBuilder } from '@commercetools-test-data/core';
+import {
+  TCtpLocalizedEnumValue,
+  TCtpLocalizedEnumValueInput,
+} from '../../../../graphql-types/src';
 
 export type TCustomFieldLocalizedEnumValue = CustomFieldLocalizedEnumValue;
 export type TCustomFieldLocalizedEnumValueDraft = CustomFieldLocalizedEnumValue;
 
-export type TCustomFieldLocalizedEnumValueGraphql = Omit<
-  TCustomFieldLocalizedEnumValue,
-  // In GraphQL, we prefer to use `nameAllLocales` instead of `name`.
-  'label'
-> & {
-  labelAllLocales: TLocalizedStringGraphql | null;
-  __typename: 'LocalizedEnumValue';
-};
+export type TCustomFieldLocalizedEnumValueGraphql = TCtpLocalizedEnumValue;
 export type TCustomFieldLocalizedEnumValueDraftGraphql =
-  TCustomFieldLocalizedEnumValueDraft;
+  TCtpLocalizedEnumValueInput;
 
 export type TCustomFieldLocalizedEnumValueBuilder =
   TBuilder<TCustomFieldLocalizedEnumValue>;

--- a/models/type/src/custom-field-localized-enum-value/types.ts
+++ b/models/type/src/custom-field-localized-enum-value/types.ts
@@ -3,7 +3,7 @@ import type { TBuilder } from '@commercetools-test-data/core';
 import {
   TCtpLocalizedEnumValue,
   TCtpLocalizedEnumValueInput,
-} from '../../../../graphql-types/src';
+} from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldLocalizedEnumValue = CustomFieldLocalizedEnumValue;
 export type TCustomFieldLocalizedEnumValueDraft = CustomFieldLocalizedEnumValue;

--- a/models/type/src/custom-field-localized-stringtype/builder.spec.ts
+++ b/models/type/src/custom-field-localized-stringtype/builder.spec.ts
@@ -43,7 +43,7 @@ describe('builder', () => {
       CustomFieldLocalizedStringType.random(),
       expect.objectContaining({
         name: 'LocalizedString',
-        __typename: 'LocalizableStringtypeCustomFieldType',
+        __typename: 'LocalizedStringType',
       })
     )
   );

--- a/models/type/src/custom-field-localized-stringtype/transformers.ts
+++ b/models/type/src/custom-field-localized-stringtype/transformers.ts
@@ -20,7 +20,7 @@ const transformers = {
   >('graphql', {
     buildFields: [],
     addFields: () => ({
-      __typename: 'LocalizableStringtypeCustomFieldType',
+      __typename: 'LocalizedStringType',
     }),
   }),
 };

--- a/models/type/src/custom-field-localized-stringtype/types.ts
+++ b/models/type/src/custom-field-localized-stringtype/types.ts
@@ -1,15 +1,12 @@
 import { CustomFieldLocalizedStringType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpLocalizedStringType } from '../../../../graphql-types/src';
 
 export type TCustomFieldLocalizedStringType = CustomFieldLocalizedStringType;
 export type TCustomFieldLocalizedStringTypeDraft =
   CustomFieldLocalizedStringType;
 
-export type TCustomFieldLocalizedStringTypeGraphql =
-  TCustomFieldLocalizedStringType & {
-    __typename: 'LocalizableStringtypeCustomFieldType';
-  };
-
+export type TCustomFieldLocalizedStringTypeGraphql = TCtpLocalizedStringType;
 export type TCustomFieldLocalizedStringTypeDraftGraphql = {
   lstringtype: {
     dummy: string | null;

--- a/models/type/src/custom-field-localized-stringtype/types.ts
+++ b/models/type/src/custom-field-localized-stringtype/types.ts
@@ -1,6 +1,6 @@
 import { CustomFieldLocalizedStringType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpLocalizedStringType } from '../../../../graphql-types/src';
+import { TCtpLocalizedStringType } from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldLocalizedStringType = CustomFieldLocalizedStringType;
 export type TCustomFieldLocalizedStringTypeDraft =

--- a/models/type/src/custom-field-money-type/builder.spec.ts
+++ b/models/type/src/custom-field-money-type/builder.spec.ts
@@ -31,7 +31,7 @@ describe('builder', () => {
       AttributeEnumType.random(),
       expect.objectContaining({
         name: 'Money',
-        __typename: 'MoneyCustomFieldType',
+        __typename: 'MoneyType',
       })
     )
   );

--- a/models/type/src/custom-field-money-type/transformers.ts
+++ b/models/type/src/custom-field-money-type/transformers.ts
@@ -16,7 +16,7 @@ const transformers = {
     {
       buildFields: [],
       addFields: () => ({
-        __typename: 'MoneyCustomFieldType',
+        __typename: 'MoneyType',
       }),
     }
   ),

--- a/models/type/src/custom-field-money-type/types.ts
+++ b/models/type/src/custom-field-money-type/types.ts
@@ -1,12 +1,11 @@
 import type { CustomFieldMoneyType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpMoneyType } from '../../../../graphql-types/src';
 
 export type TCustomFieldMoneyType = CustomFieldMoneyType;
 export type TCustomFieldMoneyTypeDraft = CustomFieldMoneyType;
 
-export type TCustomFieldMoneyTypeGraphql = CustomFieldMoneyType & {
-  __typename: 'MoneyCustomFieldType';
-};
+export type TCustomFieldMoneyTypeGraphql = TCtpMoneyType;
 export type TCustomFieldMoneyTypeDraftGraphql = {
   money: {
     dummy: string | null;

--- a/models/type/src/custom-field-money-type/types.ts
+++ b/models/type/src/custom-field-money-type/types.ts
@@ -1,6 +1,6 @@
 import type { CustomFieldMoneyType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpMoneyType } from '../../../../graphql-types/src';
+import { TCtpMoneyType } from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldMoneyType = CustomFieldMoneyType;
 export type TCustomFieldMoneyTypeDraft = CustomFieldMoneyType;

--- a/models/type/src/custom-field-number-type/builder.spec.ts
+++ b/models/type/src/custom-field-number-type/builder.spec.ts
@@ -31,7 +31,7 @@ describe('builder', () => {
       CustomFieldNumberType.random(),
       expect.objectContaining({
         name: 'Number',
-        __typename: 'NumberCustomFieldType',
+        __typename: 'NumberType',
       })
     )
   );

--- a/models/type/src/custom-field-number-type/transformers.ts
+++ b/models/type/src/custom-field-number-type/transformers.ts
@@ -16,7 +16,7 @@ const transformers = {
     {
       buildFields: [],
       addFields: () => ({
-        __typename: 'NumberCustomFieldType',
+        __typename: 'NumberType',
       }),
     }
   ),

--- a/models/type/src/custom-field-number-type/types.ts
+++ b/models/type/src/custom-field-number-type/types.ts
@@ -1,12 +1,11 @@
 import type { CustomFieldNumberType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpNumberType } from '../../../../graphql-types/src';
 
 export type TCustomFieldNumberType = CustomFieldNumberType;
 export type TCustomFieldNumberTypeDraft = CustomFieldNumberType;
 
-export type TCustomFieldNumberTypeGraphql = CustomFieldNumberType & {
-  __typename: 'NumberCustomFieldType';
-};
+export type TCustomFieldNumberTypeGraphql = TCtpNumberType;
 export type TCustomFieldNumberTypeDraftGraphql = {
   number: {
     dummy: string | null;

--- a/models/type/src/custom-field-number-type/types.ts
+++ b/models/type/src/custom-field-number-type/types.ts
@@ -1,6 +1,6 @@
 import type { CustomFieldNumberType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpNumberType } from '../../../../graphql-types/src';
+import { TCtpNumberType } from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldNumberType = CustomFieldNumberType;
 export type TCustomFieldNumberTypeDraft = CustomFieldNumberType;

--- a/models/type/src/custom-field-reference-type/builder.spec.ts
+++ b/models/type/src/custom-field-reference-type/builder.spec.ts
@@ -40,7 +40,7 @@ describe('builder', () => {
       expect.objectContaining({
         name: 'Reference',
         referenceTypeId: expect.any(String),
-        __typename: 'ReferenceCustomFieldType',
+        __typename: 'ReferenceType',
       })
     )
   );

--- a/models/type/src/custom-field-reference-type/transformers.ts
+++ b/models/type/src/custom-field-reference-type/transformers.ts
@@ -23,7 +23,7 @@ const transformers = {
   >('graphql', {
     buildFields: [],
     addFields: () => ({
-      __typename: 'ReferenceCustomFieldType',
+      __typename: 'ReferenceType',
     }),
   }),
 };

--- a/models/type/src/custom-field-reference-type/types.ts
+++ b/models/type/src/custom-field-reference-type/types.ts
@@ -1,13 +1,11 @@
 import type { CustomFieldReferenceType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpReferenceType } from '../../../../graphql-types/src';
 
 export type TCustomFieldReferenceType = CustomFieldReferenceType;
 export type TCustomFieldReferenceTypeDraft = CustomFieldReferenceType;
 
-export type TCustomFieldReferenceTypeGraphql = CustomFieldReferenceType & {
-  __typename: 'ReferenceCustomFieldType';
-};
-
+export type TCustomFieldReferenceTypeGraphql = TCtpReferenceType;
 export type TCustomFieldReferenceTypeDraftGraphql = {
   reference: {
     referenceTypeId: TCustomFieldReferenceTypeGraphql['referenceTypeId'];

--- a/models/type/src/custom-field-reference-type/types.ts
+++ b/models/type/src/custom-field-reference-type/types.ts
@@ -1,6 +1,6 @@
 import type { CustomFieldReferenceType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpReferenceType } from '../../../../graphql-types/src';
+import { TCtpReferenceType } from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldReferenceType = CustomFieldReferenceType;
 export type TCustomFieldReferenceTypeDraft = CustomFieldReferenceType;

--- a/models/type/src/custom-field-set-type/builder.spec.ts
+++ b/models/type/src/custom-field-set-type/builder.spec.ts
@@ -41,7 +41,7 @@ describe('builder', () => {
           name: 'Boolean',
           __typename: 'BooleanType',
         },
-        __typename: 'SetCustomFieldType',
+        __typename: 'SetType',
       })
     )
   );

--- a/models/type/src/custom-field-set-type/builder.spec.ts
+++ b/models/type/src/custom-field-set-type/builder.spec.ts
@@ -39,7 +39,7 @@ describe('builder', () => {
         name: 'Set',
         elementType: {
           name: 'Boolean',
-          __typename: 'BooleanCustomFieldType',
+          __typename: 'BooleanType',
         },
         __typename: 'SetCustomFieldType',
       })

--- a/models/type/src/custom-field-set-type/transformers.ts
+++ b/models/type/src/custom-field-set-type/transformers.ts
@@ -17,7 +17,7 @@ const transformers = {
     {
       buildFields: ['elementType'],
       addFields: () => ({
-        __typename: 'SetCustomFieldType',
+        __typename: 'SetType',
       }),
     }
   ),

--- a/models/type/src/custom-field-set-type/types.ts
+++ b/models/type/src/custom-field-set-type/types.ts
@@ -1,6 +1,6 @@
 import { CustomFieldSetType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpSetType } from '../../../../graphql-types/src';
+import { TCtpSetType } from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldSetType = CustomFieldSetType;
 export type TCustomFieldSetTypeDraft = CustomFieldSetType;

--- a/models/type/src/custom-field-set-type/types.ts
+++ b/models/type/src/custom-field-set-type/types.ts
@@ -1,12 +1,11 @@
 import { CustomFieldSetType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpSetType } from '../../../../graphql-types/src';
 
 export type TCustomFieldSetType = CustomFieldSetType;
 export type TCustomFieldSetTypeDraft = CustomFieldSetType;
 
-export type TCustomFieldSetTypeGraphql = TCustomFieldSetType & {
-  __typename: 'SetCustomFieldType';
-};
+export type TCustomFieldSetTypeGraphql = TCtpSetType;
 export type TCustomFieldSetTypeDraftGraphql = {
   set: {
     elementType: TCustomFieldSetTypeGraphql['elementType'];

--- a/models/type/src/custom-field-string-type/builder.spec.ts
+++ b/models/type/src/custom-field-string-type/builder.spec.ts
@@ -31,7 +31,7 @@ describe('builder', () => {
       AttributeEnumType.random(),
       expect.objectContaining({
         name: 'String',
-        __typename: 'StringCustomFieldType',
+        __typename: 'StringType',
       })
     )
   );

--- a/models/type/src/custom-field-string-type/transformers.ts
+++ b/models/type/src/custom-field-string-type/transformers.ts
@@ -16,7 +16,7 @@ const transformers = {
     {
       buildFields: [],
       addFields: () => ({
-        __typename: 'StringCustomFieldType',
+        __typename: 'StringType',
       }),
     }
   ),

--- a/models/type/src/custom-field-string-type/types.ts
+++ b/models/type/src/custom-field-string-type/types.ts
@@ -1,12 +1,11 @@
 import type { CustomFieldStringType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpStringType } from '../../../../graphql-types/src';
 
 export type TCustomFieldStringType = CustomFieldStringType;
 export type TCustomFieldStringTypeDraft = CustomFieldStringType;
 
-export type TCustomFieldStringTypeGraphql = CustomFieldStringType & {
-  __typename: 'StringCustomFieldType';
-};
+export type TCustomFieldStringTypeGraphql = TCtpStringType;
 export type TCustomFieldStringTypeDraftGraphql = {
   string: {
     dummy: string | null;

--- a/models/type/src/custom-field-string-type/types.ts
+++ b/models/type/src/custom-field-string-type/types.ts
@@ -1,6 +1,6 @@
 import type { CustomFieldStringType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpStringType } from '../../../../graphql-types/src';
+import { TCtpStringType } from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldStringType = CustomFieldStringType;
 export type TCustomFieldStringTypeDraft = CustomFieldStringType;

--- a/models/type/src/custom-field-time-type/builder.spec.ts
+++ b/models/type/src/custom-field-time-type/builder.spec.ts
@@ -31,7 +31,7 @@ describe('builder', () => {
       AttributeEnumType.random(),
       expect.objectContaining({
         name: 'Time',
-        __typename: 'TimeCustomFieldType',
+        __typename: 'TimeType',
       })
     )
   );

--- a/models/type/src/custom-field-time-type/transformers.ts
+++ b/models/type/src/custom-field-time-type/transformers.ts
@@ -13,7 +13,7 @@ const transformers = {
     {
       buildFields: [],
       addFields: () => ({
-        __typename: 'TimeCustomFieldType',
+        __typename: 'TimeType',
       }),
     }
   ),

--- a/models/type/src/custom-field-time-type/types.ts
+++ b/models/type/src/custom-field-time-type/types.ts
@@ -1,6 +1,6 @@
 import type { CustomFieldTimeType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpTimeType } from '../../../../graphql-types/src';
+import { TCtpTimeType } from '@commercetools-test-data/graphql-types';
 
 export type TCustomFieldTimeType = CustomFieldTimeType;
 export type TCustomFieldTimeTypeDraft = CustomFieldTimeType;

--- a/models/type/src/custom-field-time-type/types.ts
+++ b/models/type/src/custom-field-time-type/types.ts
@@ -1,12 +1,11 @@
 import type { CustomFieldTimeType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpTimeType } from '../../../../graphql-types/src';
 
 export type TCustomFieldTimeType = CustomFieldTimeType;
 export type TCustomFieldTimeTypeDraft = CustomFieldTimeType;
 
-export type TCustomFieldTimeTypeGraphql = CustomFieldTimeType & {
-  __typename: 'TimeCustomFieldType';
-};
+export type TCustomFieldTimeTypeGraphql = TCtpTimeType;
 export type TCustomFieldTimeTypeDraftGraphql = {
   time: {
     dummy: string | null;

--- a/models/type/src/enum-value/types.ts
+++ b/models/type/src/enum-value/types.ts
@@ -1,5 +1,5 @@
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpEnumValue } from '../../../../graphql-types/src';
+import { TCtpEnumValue } from '@commercetools-test-data/graphql-types';
 
 export type TEnumValue = {
   key: string;

--- a/models/type/src/enum-value/types.ts
+++ b/models/type/src/enum-value/types.ts
@@ -1,13 +1,12 @@
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpEnumValue } from '../../../../graphql-types/src';
 
 export type TEnumValue = {
   key: string;
   label: string;
 };
 
-export type TEnumValueGraphql = TEnumValue & {
-  __typename: 'EnumValue';
-};
+export type TEnumValueGraphql = TCtpEnumValue;
 
 export type TEnumValueBuilder = TBuilder<TEnumValue>;
 export type TCreateEnumValueBuilder = () => TEnumValueBuilder;

--- a/models/type/src/field-definition/transformers.ts
+++ b/models/type/src/field-definition/transformers.ts
@@ -12,7 +12,8 @@ const transformers = {
   graphql: Transformer<TFieldDefinition, TFieldDefinitionGraphql>('graphql', {
     buildFields: ['label', 'type'],
     addFields: ({ fields }) => ({
-      labelAllLocales: LocalizedString.toLocalizedField(fields.label),
+      labelAllLocales:
+        LocalizedString.toLocalizedField(fields.label) ?? undefined,
       __typename: 'FieldDefinition',
     }),
   }),

--- a/models/type/src/field-definition/types.ts
+++ b/models/type/src/field-definition/types.ts
@@ -1,26 +1,17 @@
 import { FieldDefinition } from '@commercetools/platform-sdk';
-import {
-  TLocalizedStringDraftGraphql,
-  TLocalizedStringGraphql,
-} from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
+import {
+  TCtpFieldDefinition,
+  TCtpFieldDefinitionInput,
+} from '../../../../graphql-types/src';
 
 export type TFieldDefinition = FieldDefinition;
 
 export type TFieldDefinitionDraft = FieldDefinition;
 
-export type TFieldDefinitionGraphql = TFieldDefinition & {
-  labelAllLocales: TLocalizedStringGraphql | null;
-  __typename: 'FieldDefinition';
-};
+export type TFieldDefinitionGraphql = TCtpFieldDefinition;
 
-export type TFieldDefinitionDraftGraphql = Omit<
-  TFieldDefinitionDraft,
-  'label' | 'inputHint'
-> & {
-  label: TLocalizedStringDraftGraphql;
-  inputHint?: TLocalizedStringDraftGraphql | null;
-};
+export type TFieldDefinitionDraftGraphql = TCtpFieldDefinitionInput;
 
 export type TFieldDefinitionBuilder = TBuilder<TFieldDefinition>;
 

--- a/models/type/src/field-definition/types.ts
+++ b/models/type/src/field-definition/types.ts
@@ -3,7 +3,7 @@ import type { TBuilder } from '@commercetools-test-data/core';
 import {
   TCtpFieldDefinition,
   TCtpFieldDefinitionInput,
-} from '../../../../graphql-types/src';
+} from '@commercetools-test-data/graphql-types';
 
 export type TFieldDefinition = FieldDefinition;
 

--- a/models/type/src/field-type/types.ts
+++ b/models/type/src/field-type/types.ts
@@ -1,6 +1,6 @@
 import type { FieldType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpFieldType } from '../../../../graphql-types/src';
+import { TCtpFieldType } from '@commercetools-test-data/graphql-types';
 import { TCustomFieldEnumValue } from '../custom-field-enum-value';
 import { TCustomFieldLocalizedEnumValue } from '../custom-field-localized-enum-value';
 

--- a/models/type/src/field-type/types.ts
+++ b/models/type/src/field-type/types.ts
@@ -1,5 +1,6 @@
 import type { FieldType } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpFieldType } from '../../../../graphql-types/src';
 import { TCustomFieldEnumValue } from '../custom-field-enum-value';
 import { TCustomFieldLocalizedEnumValue } from '../custom-field-localized-enum-value';
 
@@ -12,9 +13,7 @@ export type TFieldType = {
   elementType?: TFieldType;
 };
 
-export type TFieldTypeGraphql = TFieldType & {
-  __typename: string;
-};
+export type TFieldTypeGraphql = TCtpFieldType;
 
 export type TFieldTypeBuilder = TBuilder<TFieldType>;
 export type TCreateFieldTypeBuilder = () => TFieldTypeBuilder;

--- a/models/type/src/localized-enum-value/types.ts
+++ b/models/type/src/localized-enum-value/types.ts
@@ -1,5 +1,5 @@
 import type { TBuilder } from '@commercetools-test-data/core';
-import { TCtpLocalizedEnumValue } from '../../../../graphql-types/src';
+import { TCtpLocalizedEnumValue } from '@commercetools-test-data/graphql-types';
 
 export type TLocalizedEnumValue = {
   key: string;

--- a/models/type/src/localized-enum-value/types.ts
+++ b/models/type/src/localized-enum-value/types.ts
@@ -1,15 +1,12 @@
-import type { TLocalizedStringGraphql } from '@commercetools-test-data/commons';
 import type { TBuilder } from '@commercetools-test-data/core';
+import { TCtpLocalizedEnumValue } from '../../../../graphql-types/src';
 
 export type TLocalizedEnumValue = {
   key: string;
   label: string;
 };
 
-export type TLocalizedEnumValueGraphql = TLocalizedEnumValue & {
-  labelAllLocales: TLocalizedStringGraphql;
-  __typename: 'LocalizedEnumValue';
-};
+export type TLocalizedEnumValueGraphql = TCtpLocalizedEnumValue;
 
 export type TLocalizedEnumValueBuilder = TBuilder<TLocalizedEnumValue>;
 export type TCreateLocalizedEnumValueBuilder = () => TLocalizedEnumValueBuilder;

--- a/models/type/src/type/transformers.ts
+++ b/models/type/src/type/transformers.ts
@@ -31,13 +31,14 @@ const transformers = {
       'fieldDefinitions',
     ],
     addFields: ({ fields }) => {
-      const nameAllLocales = LocalizedString.toLocalizedField(fields.name);
+      const nameAllLocales =
+        LocalizedString.toLocalizedField(fields.name) ?? undefined;
       const descriptionAllLocales = LocalizedString.toLocalizedField(
         fields.description
       );
 
       return {
-        __typename: 'Type',
+        __typename: 'TypeDefinition',
         nameAllLocales,
         descriptionAllLocales,
       };

--- a/models/type/src/type/types.ts
+++ b/models/type/src/type/types.ts
@@ -1,13 +1,15 @@
 import type { Type, TypeDraft } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@commercetools-test-data/core';
+import {
+  TCtpTypeDefinition,
+  TCtpTypeDefinitionDraft,
+} from '../../../../graphql-types/src';
 
 export type TType = Type;
 export type TTypeDraft = TypeDraft;
 
-export type TTypeGraphql = TType & {
-  __typename: 'Type';
-};
-export type TTypeDraftGraphql = TTypeDraft;
+export type TTypeGraphql = TCtpTypeDefinition;
+export type TTypeDraftGraphql = TCtpTypeDefinitionDraft;
 
 export type TTypeBuilder = TBuilder<TType>;
 export type TTypeDraftBuilder = TBuilder<TTypeDraft>;

--- a/models/type/src/type/types.ts
+++ b/models/type/src/type/types.ts
@@ -3,7 +3,7 @@ import type { TBuilder } from '@commercetools-test-data/core';
 import {
   TCtpTypeDefinition,
   TCtpTypeDefinitionDraft,
-} from '../../../../graphql-types/src';
+} from '@commercetools-test-data/graphql-types';
 
 export type TType = Type;
 export type TTypeDraft = TypeDraft;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1455,6 +1455,9 @@ importers:
       '@commercetools-test-data/core':
         specifier: 10.15.1
         version: link:../../core
+      '@commercetools-test-data/graphql-types':
+        specifier: 10.15.1
+        version: link:../../graphql-types
       '@commercetools-test-data/utils':
         specifier: 10.15.1
         version: link:../../utils


### PR DESCRIPTION
Some of the models available in `@commercetools-test-data/type` were generating wrong data shapes.
This PR introduces GraphQL generated types and fixes the issues.

![Screenshot 2025-04-09 at 18 22 55](https://github.com/user-attachments/assets/72b10300-7147-4edc-ba50-0fe60ad3fa4d)
