### PR TITLE
Fix ProductVariant compatibility builder

### DIFF
--- a/.changeset/forty-actors-dream.md
+++ b/.changeset/forty-actors-dream.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product': patch
+---
+
+Fixes an issue with the `ProductVariant` compatibility builder related to the `attributesRaw` property when a GraphQL representation was requested.

--- a/models/product/src/index.ts
+++ b/models/product/src/index.ts
@@ -3,7 +3,6 @@ export * from './attribute/types';
 export * from './image/types';
 export * from './product-catalog-data/types';
 export * from './product-data/types';
-export * from './product-variant/types';
 
 // Export models
 export * as Attribute from './attribute';
@@ -19,7 +18,7 @@ export * as ProductCatalogData from './product-catalog-data';
 
 export * as ProductData from './product-data';
 
-export * as ProductVariant from './product-variant';
+export * from './product-variant';
 export * from './product-variant/product-variant-draft';
 
 export * from './selection-of-product';

--- a/models/product/src/product-data/builder.spec.ts
+++ b/models/product/src/product-data/builder.spec.ts
@@ -3,7 +3,7 @@
 import { Category } from '@commercetools-test-data/category';
 import { LocalizedString } from '@commercetools-test-data/commons';
 import { createBuilderSpec } from '@commercetools-test-data/core/test-utils';
-import * as ProductVariant from '../product-variant';
+import { ProductVariant } from '../product-variant';
 import { TProductData, TProductDataGraphql } from './types';
 import * as ProductData from './index';
 

--- a/models/product/src/product-data/presets/boring-generic-milk-product-data.ts
+++ b/models/product/src/product-data/presets/boring-generic-milk-product-data.ts
@@ -1,5 +1,5 @@
 import { LocalizedString } from '@commercetools-test-data/commons';
-import * as ProductVariant from '../../product-variant';
+import { ProductVariant } from '../../product-variant';
 import ProductData from '../builder';
 import { TProductDataBuilder } from '../types';
 

--- a/models/product/src/product-data/presets/happy-cow-milk-product-data.ts
+++ b/models/product/src/product-data/presets/happy-cow-milk-product-data.ts
@@ -1,5 +1,5 @@
 import { LocalizedString } from '@commercetools-test-data/commons';
-import * as ProductVariant from '../../product-variant';
+import { ProductVariant } from '../../product-variant';
 import ProductData from '../builder';
 import { TProductDataBuilder } from '../types';
 

--- a/models/product/src/product-variant/builders.spec.ts
+++ b/models/product/src/product-variant/builders.spec.ts
@@ -63,7 +63,12 @@ const validateGraphqlModel = (
         }),
       ]),
       sku: expect.any(String),
-      attributesRaw: [],
+      attributesRaw: expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.any(String),
+          __typename: 'RawProductAttribute',
+        }),
+      ]),
       __typename: 'ProductVariant',
     })
   );

--- a/models/product/src/product-variant/fields-config.ts
+++ b/models/product/src/product-variant/fields-config.ts
@@ -36,10 +36,10 @@ export const graphqlFieldsConfig: TModelFieldsConfig<TProductVariantGraphql> = {
       // @ts-expect-error The GraphQL mode does not have a `attributes` field but we need this logic for the compatibility builder
       model.attributesRaw = model.attributes.map((attribute) => ({
         ...attribute,
-        __typename: 'Attribute',
+        __typename: 'RawProductAttribute',
       }));
       // @ts-expect-error The GraphQL mode does not have a `attributes` field but we need this logic for the compatibility builder
-      delete model.attributes;
+      model.attributes = undefined;
     }
     return model;
   },

--- a/models/product/src/product-variant/fields-config.ts
+++ b/models/product/src/product-variant/fields-config.ts
@@ -27,7 +27,20 @@ export const restFieldsConfig: TModelFieldsConfig<TProductVariantRest> = {
 export const graphqlFieldsConfig: TModelFieldsConfig<TProductVariantGraphql> = {
   fields: {
     ...commonFieldsConfig,
-    attributesRaw: [],
+    attributesRaw: fake(() => [Attribute.random()]),
     __typename: 'ProductVariant',
+  },
+  postBuild: (model, context) => {
+    // @ts-expect-error The GraphQL mode does not have a `attributes` field but we need this logic for the compatibility builder
+    if (context.isCompatMode && model.attributes) {
+      // @ts-expect-error The GraphQL mode does not have a `attributes` field but we need this logic for the compatibility builder
+      model.attributesRaw = model.attributes.map((attribute) => ({
+        ...attribute,
+        __typename: 'Attribute',
+      }));
+      // @ts-expect-error The GraphQL mode does not have a `attributes` field but we need this logic for the compatibility builder
+      delete model.attributes;
+    }
+    return model;
   },
 };

--- a/models/product/src/product-variant/index.ts
+++ b/models/product/src/product-variant/index.ts
@@ -5,9 +5,6 @@ import {
 } from './builders';
 import * as modelPresets from './presets';
 
-export * from './product-variant-draft';
-export * as ProductVariant from '.';
-
 export * from './types';
 
 export const ProductVariantRest = {
@@ -23,5 +20,7 @@ export const ProductVariantGraphql = {
 /**
  * @deprecated Use `ProductVariantRest` or `ProductVariantGraphql` exported models instead of `ProductVariant`.
  */
-export const random = CompatProductVariantModelBuilder;
-export const presets = modelPresets.compatPresets;
+export const ProductVariant = {
+  random: CompatProductVariantModelBuilder,
+  presets: modelPresets.compatPresets,
+};

--- a/models/product/src/product-variant/presets/boring-generic-milk-master-variant.spec.ts
+++ b/models/product/src/product-variant/presets/boring-generic-milk-master-variant.spec.ts
@@ -1,0 +1,76 @@
+import { TProductVariantGraphql, TProductVariantRest } from '../types';
+import {
+  restPreset,
+  graphqlPreset,
+  compatPreset,
+} from './boring-generic-milk-master-variant';
+
+const validateRestModel = (model: TProductVariantRest) => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      id: 1,
+      key: 'boring-generic-milk-master-variant-key',
+      sku: 'boring-generic-milk-master-variant-sku',
+      attributes: expect.arrayContaining([
+        expect.objectContaining({
+          name: 'cow-name',
+          value: 'unknown',
+        }),
+      ]),
+    })
+  );
+};
+
+const validateGraphqlModel = (
+  model: TProductVariantRest | TProductVariantGraphql
+) => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      id: 1,
+      key: 'boring-generic-milk-master-variant-key',
+      sku: 'boring-generic-milk-master-variant-sku',
+      attributesRaw: expect.arrayContaining([
+        expect.objectContaining({
+          name: 'cow-name',
+          value: 'unknown',
+          __typename: 'RawProductAttribute',
+        }),
+      ]),
+      __typename: 'ProductVariant',
+    })
+  );
+};
+
+describe('BoringGenericMilkMasterVariant preset builders', () => {
+  it('builds a REST model', () => {
+    const restModel = restPreset().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = graphqlPreset().build();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});
+
+describe('BoringGenericMilkMasterVariant preset compatibility builders', () => {
+  it('builds a default (REST) model', () => {
+    const restModel = compatPreset().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a REST model', () => {
+    const restModel = compatPreset().buildRest();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = compatPreset().buildGraphql();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});

--- a/models/product/src/product-variant/presets/happy-cow-milk-master-variant.spec.ts
+++ b/models/product/src/product-variant/presets/happy-cow-milk-master-variant.spec.ts
@@ -1,0 +1,85 @@
+import { TProductVariantGraphql, TProductVariantRest } from '../types';
+import {
+  restPreset,
+  graphqlPreset,
+  compatPreset,
+} from './happy-cow-milk-master-variant';
+
+const validateRestModel = (model: TProductVariantRest) => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      id: 1,
+      key: 'happy-cow-master-variant-key',
+      sku: 'happy-cow-master-variant-sku',
+      attributes: expect.arrayContaining([
+        expect.objectContaining({
+          name: 'cow-name',
+          value: 'Buryonka',
+        }),
+        expect.objectContaining({
+          name: 'lactose-free',
+          value: false,
+        }),
+      ]),
+    })
+  );
+};
+
+const validateGraphqlModel = (
+  model: TProductVariantRest | TProductVariantGraphql
+) => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      id: 1,
+      key: 'happy-cow-master-variant-key',
+      sku: 'happy-cow-master-variant-sku',
+      attributesRaw: expect.arrayContaining([
+        expect.objectContaining({
+          name: 'cow-name',
+          value: 'Buryonka',
+          __typename: 'RawProductAttribute',
+        }),
+        expect.objectContaining({
+          name: 'lactose-free',
+          value: false,
+          __typename: 'RawProductAttribute',
+        }),
+      ]),
+      __typename: 'ProductVariant',
+    })
+  );
+};
+
+describe('HappyCowMilkMasterVariant preset builders', () => {
+  it('builds a REST model', () => {
+    const restModel = restPreset().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = graphqlPreset().build();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});
+
+describe('HappyCowMilkMasterVariant preset compatibility builders', () => {
+  it('builds a default (REST) model', () => {
+    const restModel = compatPreset().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a REST model', () => {
+    const restModel = compatPreset().buildRest();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = compatPreset().buildGraphql();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});

--- a/models/product/src/product-variant/presets/with-boolean-attribute-preset.spec.ts
+++ b/models/product/src/product-variant/presets/with-boolean-attribute-preset.spec.ts
@@ -1,0 +1,84 @@
+import { TProductVariantGraphql, TProductVariantRest } from '../types';
+import {
+  restPreset,
+  graphqlPreset,
+  compatPreset,
+} from './with-boolean-attribute-preset';
+
+const validateRestModel = (model: TProductVariantRest) => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      attributes: expect.arrayContaining([
+        expect.objectContaining({
+          name: 'test-boolean-attribute',
+          value: true,
+        }),
+      ]),
+    })
+  );
+};
+
+const validateGraphqlModel = (
+  model: TProductVariantRest | TProductVariantGraphql
+) => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      attributesRaw: expect.arrayContaining([
+        expect.objectContaining({
+          name: 'test-boolean-attribute',
+          value: true,
+          attributeDefinition: expect.objectContaining({
+            attributeConstraint: 'None',
+            inputHint: 'SingleLine',
+            inputTip: 'Test set attribute',
+            isRequired: false,
+            isSearchable: false,
+            label: 'Test set attribute',
+            name: 'test-boolean-attribute',
+            type: expect.objectContaining({
+              name: 'boolean',
+              __typename: 'BooleanAttributeDefinitionType',
+            }),
+            __typename: 'AttributeDefinition',
+          }),
+          __typename: 'RawProductAttribute',
+        }),
+      ]),
+      __typename: 'ProductVariant',
+    })
+  );
+};
+
+describe('WithBooleanAttribute preset builders', () => {
+  it('builds a REST model', () => {
+    const restModel = restPreset().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = graphqlPreset().build();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});
+
+describe('WithBooleanAttribute preset compatibility builders', () => {
+  it('builds a default (REST) model', () => {
+    const restModel = compatPreset().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a REST model', () => {
+    const restModel = compatPreset().buildRest();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = compatPreset().buildGraphql();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});

--- a/models/product/src/product-variant/presets/with-boolean-attribute-preset.ts
+++ b/models/product/src/product-variant/presets/with-boolean-attribute-preset.ts
@@ -12,6 +12,22 @@ import {
   TProductVariantRest,
 } from '../types';
 
+const buildGraphqlAttribute = () =>
+  Attribute.random()
+    .name('test-boolean-attribute')
+    .value(true)
+    .attributeDefinition(
+      AttributeDefinition.random()
+        .attributeConstraint('None')
+        .inputHint('SingleLine')
+        .inputTip(LocalizedString.random().en('Test set attribute'))
+        .isRequired(false)
+        .isSearchable(false)
+        .label(LocalizedString.random().en('Test set attribute'))
+        .name('test-boolean-attribute')
+        .type(AttributeBooleanType.random())
+    );
+
 export const restPreset = (): TBuilder<TProductVariantRest> => {
   return ProductVariantRest.random().attributes([
     Attribute.random().name('test-boolean-attribute').value(true),
@@ -20,25 +36,10 @@ export const restPreset = (): TBuilder<TProductVariantRest> => {
 
 export const graphqlPreset = (): TBuilder<TProductVariantGraphql> => {
   return ProductVariantGraphql.random().attributesRaw([
-    Attribute.random()
-      .name('test-boolean-attribute')
-      .value(true)
-      .attributeDefinition(
-        AttributeDefinition.random()
-          .attributeConstraint('None')
-          .inputHint('SingleLine')
-          .inputTip(LocalizedString.random().en('Test set attribute'))
-          .isRequired(false)
-          .isSearchable(false)
-          .label(LocalizedString.random().en('Test set attribute'))
-          .name('test-boolean-attribute')
-          .type(AttributeBooleanType.random())
-      ),
+    buildGraphqlAttribute(),
   ]);
 };
 
 export const compatPreset = (): TBuilder<TProductVariant> => {
-  return ProductVariant.random().attributes([
-    Attribute.random().name('test-boolean-attribute').value(true),
-  ]);
+  return ProductVariant.random().attributes([buildGraphqlAttribute()]);
 };

--- a/models/product/src/product/product-draft/fields-config.ts
+++ b/models/product/src/product/product-draft/fields-config.ts
@@ -12,7 +12,7 @@ import {
 import {
   ProductVariantDraftGraphql,
   ProductVariantDraftRest,
-} from '../../product-variant';
+} from '../../product-variant/product-variant-draft';
 import { productPriceMode } from '../constants';
 import type { TProductDraftGraphql, TProductDraftRest } from '../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/a-789-bc.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/a-789-bc.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/aa-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/aa-123-qr.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/aaa-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/aaa-789-uv.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/air-filter.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/air-filter.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/alternator.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/alternator.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/b-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/b-456-st.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/bb-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/bb-456-st.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/bbb-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/bbb-234-wx.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/brake-pad-set.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/brake-pad-set.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/c-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/c-789-uv.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/cc-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/cc-789-uv.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ccc-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ccc-567-yz.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/d-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/d-234-wx.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/dd-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/dd-234-wx.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ddd-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ddd-890-op.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/e-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/e-567-yz.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ee-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ee-567-yz.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/eee-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/eee-123-qr.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/f-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/f-890-op.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ff-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ff-890-op.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/fff-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/fff-456-st.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/fuel-filter.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/fuel-filter.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/g-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/g-123-qr.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/gg-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/gg-123-qr.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ggg-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ggg-789-uv.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/h-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/h-456-st.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/hh-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/hh-456-st.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/hhh-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/hhh-234-wx.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/hydraulic-hose.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/hydraulic-hose.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/i-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/i-789-uv.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ii-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ii-789-uv.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/iii-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/iii-567-yz.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/j-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/j-234-wx.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/jj-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/jj-234-wx.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/jjj-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/jjj-890-op.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/k-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/k-567-yz.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/kk-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/kk-567-yz.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/l-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/l-890-op.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/led-work-light.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/led-work-light.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ll-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ll-890-op.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/m-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/m-890-op.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/mm-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/mm-123-qr.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/n-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/n-123-qr.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/nn-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/nn-456-st.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/oil-filter.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/oil-filter.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/oo-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/oo-789-uv.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/p-234-qw.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/p-234-qw.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/pin-and-bushing-kit.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/pin-and-bushing-kit.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/piston-ring-set.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/piston-ring-set.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/pneumatic-tire.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/pneumatic-tire.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/pp-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/pp-234-wx.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/qq-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/qq-567-yz.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/r-123-ts.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/r-123-ts.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/rr-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/rr-890-op.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/s-567-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/s-567-uv.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ss-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ss-123-qr.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/starter-motor.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/starter-motor.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/tapered-roller-bearing.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/tapered-roller-bearing.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/tt-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/tt-456-st.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/u-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/u-123-qr.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/uu-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/uu-789-uv.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/v-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/v-456-st.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/vv-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/vv-234-wx.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/w-789-uv.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/w-789-uv.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/ww-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/ww-567-yz.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/x-234-wx.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/x-234-wx.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/x-456-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/x-456-yz.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/xx-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/xx-890-op.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/y-567-yz.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/y-567-yz.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/yy-123-qr.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/yy-123-qr.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/z-890-op.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/z-890-op.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2b/zz-456-st.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2b/zz-456-st.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { productPriceMode } from '../../../constants';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/abigail-lounge-chair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/abigail-lounge-chair.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/amalia-rug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/amalia-rug.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import type { TProductDraft } from '../../../types';
 import { ProductDraft } from '../../index';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/aria-rug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/aria-rug.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/art-deco-chair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/art-deco-chair.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/art-deco-coffee-table.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/art-deco-coffee-table.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/ashen-rug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/ashen-rug.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/ben-pillow-cover.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/ben-pillow-cover.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/braided-rug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/braided-rug.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/bruno-chair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/bruno-chair.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/canela-three-seater-sofa.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/canela-three-seater-sofa.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/charcoal-chair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/charcoal-chair.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/charlie-armchair.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/charlie-armchair.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/chianti-wine-glass.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/chianti-wine-glass.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/classic-beer-mug.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/classic-beer-mug.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/classic-champagne-glasses.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/classic-champagne-glasses.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/classic-coffee-cup.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/classic-coffee-cup.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/classic-serving-tray.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/classic-serving-tray.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/clink-champagne-glass.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/clink-champagne-glass.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/cloud-queen-bed.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-b2c-lifestyle/cloud-queen-bed.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/anniversary-shirt.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/denim-jacket.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/flair-jeans.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/halloween-top.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/maternity-top.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/necklace.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/prom-dress.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sandals.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/skinny-jeans.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/sport-coat.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/summer-dress.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/toddler-trousers.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 

--- a/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.ts
+++ b/models/product/src/product/product-draft/presets/sample-data-fashion/tote-bag.ts
@@ -15,7 +15,7 @@ import {
   TaxCategoryDraft,
   type TTaxCategoryDraft,
 } from '@commercetools-test-data/tax-category';
-import { ProductVariantDraft } from '../../../../product-variant/index';
+import { ProductVariantDraft } from '../../../../product-variant/product-variant-draft';
 import { ProductDraft } from '../../../product-draft';
 import type { TProductDraft } from '../../../types';
 


### PR DESCRIPTION
We've found an issue in the `ProductVariant` compatibility builder related to the `attributesRaw` property when a GraphQL representation was requested as it was not populated.

I also took the change to refactor the way we export that model to be easier to reason about and maintain.

Most of the changes in the PR are consequence of the export refactor. Please take a look to the inline comments to find the relevant parts to review.