### PR TITLE
Fix codeowners rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@
 /codegen* @commercetools/shield-team-fe
 
 # Models
-/models @commercetools/merchant-center-tech-leadership @commercetools/test-automation-engineers
+/models/ @commercetools/merchant-center-tech-leadership @commercetools/test-automation-engineers
 
 /models/associate-role @commercetools/customers-team-fe
 /models/attribute-group @commercetools/pacman-team-fe


### PR DESCRIPTION
We noticed one of the rules configured in the `CODEOWNERS` file does not seem to be working:
```
/models @commercetools/merchant-center-tech-leadership @commercetools/test-automation-engineers
```

We think it might be because of a missing trailing slash so we're introducing it in this PR.

Thanks @tdeekens for the suggestion 🙇 