### PR TITLE
Fix Cart LineItem model

### DIFF
--- a/.changeset/clean-steaks-notice.md
+++ b/.changeset/clean-steaks-notice.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/cart': patch
+---
+
+Remove invalid and unused import.

--- a/models/cart/src/line-item/field-config.ts
+++ b/models/cart/src/line-item/field-config.ts
@@ -16,7 +16,6 @@ import {
   ProductVariantRest,
   ProductVariantGraphql,
 } from '@commercetools-test-data/product';
-import {} from '@commercetools-test-data/product/src/product-variant';
 import { ProductType } from '@commercetools-test-data/product-type';
 import { TaxRate } from '@commercetools-test-data/tax-category';
 import { createRelatedDates } from '@commercetools-test-data/utils';


### PR DESCRIPTION
There was an empty import with an invalid package path in the `LineItem` `fields-config.ts` file which is breaking consumers of this package.