### PR TITLE
Fix Product model exports

### DIFF
--- a/.changeset/bright-walls-drop.md
+++ b/.changeset/bright-walls-drop.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-test-data/product': patch
+---
+
+Fixed `ProductCatalogData` and `ProductData` sub-models exports.

--- a/models/product/README.md
+++ b/models/product/README.md
@@ -39,54 +39,59 @@ const image = Image.random().build<TImage>();
 
 ```ts
 import {
-  Product,
-  ProductDraft,
-  type TProduct,
-  type TProductDraft,
+  ProductGraphql,
+  ProductRest,
+  ProductGraphqlDraft,
+  ProductRestDraft,
 } from '@commercetools-test-data/product';
 
-const product = Product.random().build<TProduct>();
-const productDraft = ProductDraft.random().build<TProductDraft>();
+const productGraphql = ProductGraphql.random().build();
+const productRest = ProductRest.random().build();
+
+const productGraphqlDraft = ProductGraphqlDraft.random().build();
+const productRestDraft = ProductRestDraft.random().build();
 ```
 
 ## ProductCatalogData
 
 ```ts
 import {
-  ProductCatalogData,
-  type TProductCatalogData,
+  ProductCatalogDataGraphql,
+  ProductCatalogDataRest,
 } from '@commercetools-test-data/product';
 
-const productCatalogData =
-  ProductCatalogData.random().build<TProductCatalogData>();
+const productCatalogDataGraphql = ProductCatalogDataGraphql.random().build();
+const productCatalogDataRest = ProductCatalogDataRest.random().build();
 ```
 
 ## ProductData
 
 ```ts
 import {
-  ProductData,
-  type TProductData,
+  ProductDataGraphql,
+  TProductDataRest,
 } from '@commercetools-test-data/product';
 
 // For REST entities
-const productDataRest = ProductData.random().buildRest<TProductData>();
+const productDataRest = ProductDataRest.random().build();
 
 // For Graphql entities
-const productDataGraphql = ProductData.random().buildGraphql<TProductData>();
+const productDataGraphql = ProductData.random().build();
 ```
 
 ## ProductVariant
 
 ```ts
 import {
-  ProductVariant,
-  ProductVariantDraft,
-  type TProductVariant,
-  type TProductVariantDraft,
+  ProductVariantGraphql,
+  ProductVariantRest,
+  ProductVariantGraphqlDraft,
+  ProductVariantRestDraft,
 } from '@commercetools-test-data/product';
 
-const productVariant = ProductVariant.random().build<TProductVariant>();
-const productVariantDraft =
-  ProductVariantDraft.random().build<TProductVariantDraft>();
+const productVariantGraphql = ProductVariantGraphql.random().build();
+const productVariantRest = ProductVariantRest.random().build();
+
+const productVariantGraphqlDraft = ProductVariantGraphqlDraft.random().build();
+const productVariantRestDraft = ProductVariantGraphqlDraft.random().build();
 ```

--- a/models/product/src/index.ts
+++ b/models/product/src/index.ts
@@ -17,9 +17,9 @@ export * as ImageDraft from './image/image-draft';
 export * from './product';
 export * from './product/product-draft';
 
-export * as ProductCatalogData from './product-catalog-data';
+export * from './product-catalog-data';
 
-export * as ProductData from './product-data';
+export * from './product-data';
 
 export * from './product-variant';
 export * from './product-variant/product-variant-draft';

--- a/models/product/src/product-catalog-data/index.ts
+++ b/models/product/src/product-catalog-data/index.ts
@@ -5,8 +5,6 @@ import {
 } from './builders';
 import * as modelPresets from './presets';
 
-export * from './types';
-
 export const ProductCatalogDataRest = {
   random: RestModelBuilder,
   presets: modelPresets.restPresets,

--- a/models/product/src/product-data/category-order-hint/builders.spec.ts
+++ b/models/product/src/product-data/category-order-hint/builders.spec.ts
@@ -1,9 +1,8 @@
-import {
-  CategoryOrderHintGraphql,
-  CategoryOrderHintRest,
-  type TCategoryOrderHintGraphql,
-  type TCategoryOrderHintRest,
-} from './index';
+import type {
+  TCategoryOrderHintGraphql,
+  TCategoryOrderHintRest,
+} from './types';
+import { CategoryOrderHintGraphql, CategoryOrderHintRest } from './index';
 
 function validateRestModel(restModel: TCategoryOrderHintRest) {
   expect(restModel).toEqual(

--- a/models/product/src/product-data/category-order-hint/index.ts
+++ b/models/product/src/product-data/category-order-hint/index.ts
@@ -1,8 +1,6 @@
 import { GraphqlModelBuilder, RestModelBuilder } from './builders';
 import * as modelPresets from './presets';
 
-export * from './types';
-
 export const CategoryOrderHintRest = {
   random: RestModelBuilder,
   presets: modelPresets.restPresets,

--- a/models/product/src/product-data/index.ts
+++ b/models/product/src/product-data/index.ts
@@ -8,7 +8,6 @@ import * as modelPresets from './presets';
 export * as CategoryOrderHint from './category-order-hint';
 export * as SearchKeyword from './search-keyword';
 export * as SearchKeywords from './search-keywords';
-export * from './types';
 
 export const ProductDataRest = {
   random: RestModelBuilder,

--- a/models/product/src/product-data/search-keyword/builders.spec.ts
+++ b/models/product/src/product-data/search-keyword/builders.spec.ts
@@ -1,9 +1,5 @@
-import {
-  SearchKeywordGraphql,
-  SearchKeywordRest,
-  type TSearchKeywordGraphql,
-  type TSearchKeywordRest,
-} from './index';
+import type { TSearchKeywordGraphql, TSearchKeywordRest } from './types';
+import { SearchKeywordGraphql, SearchKeywordRest } from './index';
 
 function validateRestModel(restModel: TSearchKeywordRest) {
   expect(restModel).toEqual(

--- a/models/product/src/product-data/search-keyword/index.ts
+++ b/models/product/src/product-data/search-keyword/index.ts
@@ -1,8 +1,6 @@
 import { RestModelBuilder, GraphqlModelBuilder } from './builders';
 import * as modelPresets from './presets';
 
-export * from './types';
-
 export const SearchKeywordRest = {
   random: RestModelBuilder,
   presets: modelPresets.restPresets,

--- a/models/product/src/product-data/search-keywords/builders.spec.ts
+++ b/models/product/src/product-data/search-keywords/builders.spec.ts
@@ -1,10 +1,6 @@
 import { SearchKeywordGraphql, SearchKeywordRest } from '../search-keyword';
-import {
-  SearchKeywordsGraphql,
-  SearchKeywordsRest,
-  type TSearchKeywordsGraphql,
-  type TSearchKeywordsRest,
-} from './index';
+import type { TSearchKeywordsGraphql, TSearchKeywordsRest } from './types';
+import { SearchKeywordsGraphql, SearchKeywordsRest } from './index';
 
 function validateRestModel(restModel: TSearchKeywordsRest) {
   expect(restModel).toEqual(

--- a/models/product/src/product-data/search-keywords/index.ts
+++ b/models/product/src/product-data/search-keywords/index.ts
@@ -1,8 +1,6 @@
 import { RestModelBuilder, GraphqlModelBuilder } from './builders';
 import * as modelPresets from './presets';
 
-export * from './types';
-
 export const SearchKeywordsRest = {
   random: RestModelBuilder,
   presets: modelPresets.restPresets,


### PR DESCRIPTION
We have an issue with the way we export some of the models in the `@commercetools-test-data/product` package coming from a recent migration.

This kind of imports:
```
import { ProductCatalogData } from '@commercetools-test-data/product';
```
do not work as we're namespacing those models twice.

Consumers would need to do something like this:
```
import { ProductCatalogData } from '@commercetools-test-data/product';

const model = ProductCatalogData.ProductCatalogData.random().build();
```

In this PR we're fixing the exports and also updating the README to reflect the new GraphQL and REST models.