### PR TITLE
fix(product-data): update slug generation to match pattern

### DIFF
--- a/standalone/src/models/product/product-data/builders.spec.ts
+++ b/standalone/src/models/product/product-data/builders.spec.ts
@@ -27,7 +27,7 @@ function validateRestModel(restModel: TProductDataRest) {
         en: expect.any(String),
       }),
       slug: expect.objectContaining({
-        en: expect.any(String),
+        en: expect.stringMatching(/^[A-Za-z0-9_-]{2,256}$/),
       }),
       metaTitle: expect.objectContaining({
         en: expect.any(String),
@@ -66,12 +66,12 @@ function validateGraphqlModel(graphqlModel: TProductDataGraphql) {
           value: expect.any(String),
         }),
       ]),
-      slug: expect.any(String),
+      slug: expect.stringMatching(/^[A-Za-z0-9_-]{2,256}$/),
       slugAllLocales: expect.arrayContaining([
         expect.objectContaining({
           __typename: 'LocalizedString',
           locale: 'en',
-          value: expect.any(String),
+          value: expect.stringMatching(/^[A-Za-z0-9_-]{2,256}$/),
         }),
       ]),
       categoryOrderHint: expect.any(String),

--- a/standalone/src/models/product/product-data/fields-config.ts
+++ b/standalone/src/models/product/product-data/fields-config.ts
@@ -22,7 +22,7 @@ export const restFieldsConfig: TModelFieldsConfig<TProductDataRest> = {
     ]),
     categoryOrderHints: fake(() => CategoryOrderHintRest.random()),
     description: fake(() => LocalizedString.random()),
-    slug: fake(() => LocalizedString.random()),
+    slug: fake(() => LocalizedString.presets.ofSlugs()),
     metaTitle: fake(() => LocalizedString.random()),
     metaDescription: fake(() => LocalizedString.random()),
     metaKeywords: fake(() => LocalizedString.random()),
@@ -55,7 +55,7 @@ export const graphqlFieldsConfig: TModelFieldsConfig<TProductDataGraphql> = {
     searchKeywords: fake(() => [SearchKeywordsGraphql.random()]),
     skus: fake((f) => [`${f.lorem.word()}-${f.string.alphanumeric(3)}`]),
     slug: null, // computed
-    slugAllLocales: fake(() => LocalizedString.random()),
+    slugAllLocales: fake(() => LocalizedString.presets.ofSlugs()),
     variant: fake(() => ProductVariantGraphql.random()),
     variants: fake(() => [ProductVariantGraphql.random()]),
   },


### PR DESCRIPTION
This pull request introduces stricter validation and updated configurations for the `slug` field in both REST and GraphQL models. The changes ensure that slugs follow a specific pattern and use predefined presets for consistency.

### Validation updates:

* [`standalone/src/models/product/product-data/builders.spec.ts`](diffhunk://#diff-b7ade085741a0a11374d27969ca11cbd38a9489855aba252cda10ed881666864L30-R30): Updated the `slug` field validation in both `validateRestModel` and `validateGraphqlModel` functions to enforce a stricter regex pattern (`/^[A-Za-z0-9_-]{2,256}$/`). This ensures slugs are alphanumeric with optional underscores or hyphens, and have a length between 2 and 256 characters. [[1]](diffhunk://#diff-b7ade085741a0a11374d27969ca11cbd38a9489855aba252cda10ed881666864L30-R30) [[2]](diffhunk://#diff-b7ade085741a0a11374d27969ca11cbd38a9489855aba252cda10ed881666864L69-R74)

### Configuration updates:

* [`standalone/src/models/product/product-data/fields-config.ts`](diffhunk://#diff-8debe3053238e6b302af9a025498e5536bd352294002b088b7cfc913eb6d1f6aL25-R25): Replaced `LocalizedString.random()` with `LocalizedString.presets.ofSlugs()` for the `slug` field in both `restFieldsConfig` and `graphqlFieldsConfig`. This change ensures that slugs are generated using predefined presets for better consistency and alignment with the validation rules. [[1]](diffhunk://#diff-8debe3053238e6b302af9a025498e5536bd352294002b088b7cfc913eb6d1f6aL25-R25) [[2]](diffhunk://#diff-8debe3053238e6b302af9a025498e5536bd352294002b088b7cfc913eb6d1f6aL58-R58)