### PR TITLE
Fix non-synchronised recurrence policy ids in GraphQL builds

### DIFF
--- a/.changeset/cyan-crabs-allow.md
+++ b/.changeset/cyan-crabs-allow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/composable-commerce-test-data': patch
+---
+
+Fix non-synchronised recurrence-policy ids in GQL builds

--- a/standalone/src/models/commons/price/builder.spec.ts
+++ b/standalone/src/models/commons/price/builder.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable jest/no-disabled-tests */
 /* eslint-disable jest/valid-title */
 import { createBuilderSpec } from '@/core/test-utils';
+import { ReferenceGraphql } from '../reference';
 import type { TPrice, TPriceGraphql } from './types';
 import * as Price from './index';
 
@@ -85,4 +86,14 @@ describe('builder', () => {
       })
     )
   );
+
+  it('should sync ids between recurrencePolicy and recurrencePolicyRef in a GraphQL build', () => {
+    const price = Price.random()
+      .recurrencePolicy(
+        ReferenceGraphql.random().typeId('recurrence-policy').id('123')
+      )
+      .buildGraphql<TPriceGraphql>();
+
+    expect(price.recurrencePolicy?.id).toBe(price.recurrencePolicyRef?.id);
+  });
 });

--- a/standalone/src/models/commons/price/transformers.ts
+++ b/standalone/src/models/commons/price/transformers.ts
@@ -35,15 +35,19 @@ const transformers = {
       'custom',
       'recurrencePolicy',
     ],
-    addFields: ({ fields }) => ({
-      recurrencePolicyRef: fields.recurrencePolicy
+    replaceFields: ({ fields }) => {
+      const recurrencePolicyRef = fields.recurrencePolicy
         ? ReferenceGraphql.random()
             .typeId('recurrence-policy')
             .id(fields.recurrencePolicy.id)
             .build()
-        : null,
-      __typename: 'ProductPrice',
-    }),
+        : null;
+      return {
+        ...fields,
+        recurrencePolicyRef,
+        __typename: 'ProductPrice',
+      } as TPriceGraphql;
+    },
   }),
 };
 


### PR DESCRIPTION
In the transformer file, replaced `addFields` with `replaceFields` because `addFields` couldn’t handle nested objects like `recurrencePolicy`. It can only reads plain values from the `fields` object.