### PR TITLE
fix(Discounts): generate a uuid value for Discounts related models

### DIFF
--- a/.changeset/purple-flies-watch.md
+++ b/.changeset/purple-flies-watch.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/composable-commerce-test-data': patch
+---
+
+Fix ids of discounts related models

--- a/standalone/src/models/cart/cart-discount/cart-discount/generator.ts
+++ b/standalone/src/models/cart/cart-discount/cart-discount/generator.ts
@@ -16,7 +16,7 @@ const [getCreatedAt, getLastModifiedAt] = createRelatedDates();
 
 const generator = Generator<TCartDiscount>({
   fields: {
-    id: fake((f) => f.string.alphanumeric(8)),
+    id: fake((f) => f.string.uuid()),
     version: sequence(),
     key: fake((f) => f.lorem.slug(2)),
     name: fake(() => LocalizedString.random()),

--- a/standalone/src/models/discount-code/generator.ts
+++ b/standalone/src/models/discount-code/generator.ts
@@ -11,7 +11,7 @@ const [getCreatedAt, getLastModifiedAt] = createRelatedDates();
 
 const generator = Generator<TDiscountCode>({
   fields: {
-    id: fake((f) => f.string.alphanumeric(8)),
+    id: fake((f) => f.string.uuid()),
     key: fake((f) => f.string.alphanumeric({ length: { min: 2, max: 256 } })),
     version: sequence(),
     name: fake(() => LocalizedString.random()),

--- a/standalone/src/models/product/product-discount/product-discount/generator.ts
+++ b/standalone/src/models/product/product-discount/product-discount/generator.ts
@@ -14,7 +14,7 @@ const [getCreatedAt, getLastModifiedAt] = createRelatedDates();
 
 const generator = Generator<TProductDiscount>({
   fields: {
-    id: fake((f) => f.string.alphanumeric(8)),
+    id: fake((f) => f.string.uuid()),
     version: sequence(),
     key: fake((f) => f.lorem.slug(2)),
     name: fake(() => LocalizedString.random()),

--- a/standalone/src/models/standalone-price/generator.ts
+++ b/standalone/src/models/standalone-price/generator.ts
@@ -11,7 +11,7 @@ const [getCreatedAt, getLastModifiedAt, getExpiresAt] = createRelatedDates();
 
 const generator = Generator<TStandalonePrice>({
   fields: {
-    id: fake((f) => f.string.alphanumeric(10)),
+    id: fake((f) => f.string.uuid()),
     version: sequence(),
     createdAt: fake(getCreatedAt),
     lastModifiedAt: fake(getLastModifiedAt),


### PR DESCRIPTION
Modifies `id: fake((f) => f.string.alphanumeric(8))` with `id: fake((f) => f.string.uuid()),` for some models owned by Priceless.

