### PR TITLE
Add missing changeset related to price models update

### DIFF
--- a/.changeset/tall-streets-agree.md
+++ b/.changeset/tall-streets-agree.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/composable-commerce-test-data': patch
+---
+
+Introduce `recurrencePolicy` and `recurrencePolicyRef` fields to both the `StandalonePrice` and `Price` models. https://github.com/commercetools/test-data/pull/831 + https://github.com/commercetools/test-data/pull/829


### PR DESCRIPTION
Following past changes here:
https://github.com/commercetools/test-data/pull/831
https://github.com/commercetools/test-data/pull/829