### PR TITLE
Ma/adjust product catalog data model

### DIFF
--- a/.changeset/pink-nights-invent.md
+++ b/.changeset/pink-nights-invent.md
@@ -3,4 +3,4 @@
 '@commercetools-test-data/generators': minor
 ---
 
-Updated the `Product data` and `ProductDraft` test models so it does not populate the `categories` property by default. That's an optional property and so the default version of the model should not populate it.
+Updated the `ProductData` and `ProductDraft` test models so it does not populate the `categories` property by default. That's an optional property and so the default version of the model should not populate it.

--- a/.changeset/pink-nights-invent.md
+++ b/.changeset/pink-nights-invent.md
@@ -3,4 +3,4 @@
 '@commercetools-test-data/generators': minor
 ---
 
-Updated the `Product data` test model so it does not populate the `categories` property by default. That's an optional property and so the default version of the model should not populate it.
+Updated the `Product data` and `ProductDraft` test models so it does not populate the `categories` property by default. That's an optional property and so the default version of the model should not populate it.

--- a/.changeset/pink-nights-invent.md
+++ b/.changeset/pink-nights-invent.md
@@ -1,0 +1,6 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+'@commercetools-test-data/generators': minor
+---
+
+Updated the `Product data` test model so it does not populate the `categories` property by default. That's an optional property and so the default version of the model should not populate it.

--- a/standalone/src/models/product/product/product-catalog-data/builders.spec.ts
+++ b/standalone/src/models/product/product/product-catalog-data/builders.spec.ts
@@ -15,12 +15,7 @@ function validateRestModel(restModel: TProductCatalogDataRest) {
         name: expect.objectContaining({
           en: expect.any(String),
         }),
-        categories: expect.arrayContaining([
-          expect.objectContaining({
-            id: expect.any(String),
-            typeId: 'category',
-          }),
-        ]),
+        categories: expect.any(Array),
         categoryOrderHints: expect.any(Object),
         description: expect.objectContaining({
           en: expect.any(String),
@@ -46,12 +41,7 @@ function validateRestModel(restModel: TProductCatalogDataRest) {
         name: expect.objectContaining({
           en: expect.any(String),
         }),
-        categories: expect.arrayContaining([
-          expect.objectContaining({
-            id: expect.any(String),
-            typeId: 'category',
-          }),
-        ]),
+        categories: expect.any(Array),
         categoryOrderHints: expect.any(Object),
         description: expect.objectContaining({
           en: expect.any(String),
@@ -112,20 +102,8 @@ function validateGraphqlModel(graphqlModel: TProductCatalogDataGraphql) {
             orderHint: expect.any(String),
           }),
         ]),
-        categoriesRef: expect.arrayContaining([
-          {
-            typeId: 'category',
-            id: expect.any(String),
-            __typename: 'Reference',
-          },
-        ]),
-        categories: expect.arrayContaining([
-          expect.objectContaining({
-            id: expect.any(String),
-            key: expect.any(String),
-            __typename: 'Category',
-          }),
-        ]),
+        categoriesRef: expect.any(Array),
+        categories: expect.any(Array),
         searchKeyword: expect.arrayContaining([]),
         searchKeywords: expect.arrayContaining([]),
         metaTitleAllLocales: expect.arrayContaining([
@@ -190,20 +168,8 @@ function validateGraphqlModel(graphqlModel: TProductCatalogDataGraphql) {
             orderHint: expect.any(String),
           }),
         ]),
-        categoriesRef: expect.arrayContaining([
-          {
-            typeId: 'category',
-            id: expect.any(String),
-            __typename: 'Reference',
-          },
-        ]),
-        categories: expect.arrayContaining([
-          expect.objectContaining({
-            id: expect.any(String),
-            key: expect.any(String),
-            __typename: 'Category',
-          }),
-        ]),
+        categoriesRef: expect.any(Array),
+        categories: expect.any(Array),
         searchKeyword: expect.arrayContaining([]),
         searchKeywords: expect.arrayContaining([]),
         metaTitleAllLocales: expect.arrayContaining([

--- a/standalone/src/models/product/product/product-data/builders.spec.ts
+++ b/standalone/src/models/product/product/product-data/builders.spec.ts
@@ -13,12 +13,7 @@ function validateRestModel(restModel: TProductDataRest) {
       name: expect.objectContaining({
         en: expect.any(String),
       }),
-      categories: expect.arrayContaining([
-        expect.objectContaining({
-          id: expect.any(String),
-          typeId: 'category',
-        }),
-      ]),
+      categories: expect.any(Array),
       categoryOrderHints: expect.objectContaining({
         categoryId: expect.any(String),
         orderHint: expect.any(String),
@@ -82,20 +77,8 @@ function validateGraphqlModel(graphqlModel: TProductDataGraphql) {
           orderHint: expect.any(String),
         }),
       ]),
-      categoriesRef: expect.arrayContaining([
-        {
-          __typename: 'Reference',
-          typeId: 'category',
-          id: expect.any(String),
-        },
-      ]),
-      categories: expect.arrayContaining([
-        expect.objectContaining({
-          __typename: 'Category',
-          id: expect.any(String),
-          key: expect.any(String),
-        }),
-      ]),
+      categoriesRef: expect.any(Array),
+      categories: expect.any(Array),
       searchKeyword: expect.arrayContaining([
         expect.objectContaining({
           __typename: 'SearchKeyword',

--- a/standalone/src/models/product/product/product-data/fields-config.ts
+++ b/standalone/src/models/product/product/product-data/fields-config.ts
@@ -17,9 +17,7 @@ import type { TProductDataGraphql, TProductDataRest } from './types';
 export const restFieldsConfig: TModelFieldsConfig<TProductDataRest> = {
   fields: {
     name: fake(() => LocalizedString.random()),
-    categories: fake(() => [
-      ReferenceRest.random().typeId('category').obj(Category.random()),
-    ]),
+    categories: [],
     categoryOrderHints: fake(() => CategoryOrderHintRest.random()),
     description: fake(() => LocalizedString.random()),
     slug: fake(() => LocalizedString.presets.ofSlugs()),
@@ -36,7 +34,7 @@ export const graphqlFieldsConfig: TModelFieldsConfig<TProductDataGraphql> = {
     __typename: 'ProductData',
     allVariants: fake(() => [ProductVariantGraphql.random()]),
     attributesRaw: fake(() => []),
-    categories: fake(() => [Category.random()]),
+    categories: [],
     categoriesRef: null, // computed
     categoryOrderHint: null, // computed
     categoryOrderHints: fake(() => [CategoryOrderHintGraphql.random()]),

--- a/standalone/src/models/product/product/product/product-draft/builders.spec.ts
+++ b/standalone/src/models/product/product/product/product-draft/builders.spec.ts
@@ -19,11 +19,7 @@ function validateRestModel(restModel: TProductDraftRest) {
         en: expect.any(String),
         fr: expect.any(String),
       }),
-      categories: expect.arrayContaining([
-        expect.objectContaining({
-          typeId: 'category',
-        }),
-      ]),
+      categories: null,
       categoryOrderHints: null,
       masterVariant: expect.objectContaining({
         key: expect.any(String),
@@ -104,11 +100,7 @@ function validateGraphqlModel(graphqlModel: TProductDraftGraphql) {
           value: expect.any(String),
         }),
       ]),
-      categories: expect.arrayContaining([
-        expect.objectContaining({
-          typeId: 'category',
-        }),
-      ]),
+      categories: null,
       categoryOrderHints: null,
       masterVariant: expect.objectContaining({
         key: expect.any(String),

--- a/standalone/src/models/product/product/product/product-draft/fields-config.ts
+++ b/standalone/src/models/product/product/product/product-draft/fields-config.ts
@@ -17,7 +17,7 @@ const commonFieldsConfig = {
   slug: fake(() => LocalizedStringDraft.presets.ofSlugs()),
   key: fake((f) => f.lorem.slug()),
   description: fake(() => LocalizedStringDraft.random()),
-  categories: fake(() => [KeyReferenceDraft.presets.category()]),
+  categories: null,
   categoryOrderHints: null,
   metaTitle: null,
   metaDescription: null,


### PR DESCRIPTION
We're adjusting the Product data model so it does not populate the categories property by default since that's an optional one and those should not exist in a default model.

https://github.com/commercetools/merchant-center-frontend/blob/main/packages-shared/test-data/src/product-data/generator.js#L18