### PR TITLE
Add missing Typescript types

### DIFF
--- a/.changeset/chubby-seas-shop.md
+++ b/.changeset/chubby-seas-shop.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/composable-commerce-test-data': patch
+---
+
+Fixed the `@commercetools/composable-commerce-test-data/product` entry point to export again the `ProductType` test data models Typescript types which were removed by accident.

--- a/standalone/src/models/product/product/index.ts
+++ b/standalone/src/models/product/product/index.ts
@@ -1,6 +1,7 @@
 // Export types
 export * from './attribute/types';
 export * from './image/types';
+export * from './product/types';
 export * from './product-catalog-data/types';
 export * from './product-data/types';
 export * from './product-data/category-order-hint/types';


### PR DESCRIPTION
We accidentally removed the `ProductType` test data model Typescript types from the `@commercetools/composable-commerce-test-data/product` entry point (reference #847).

We're adding them back here.