### PR TITLE
New ProductVariantAvailability test data model

### DIFF
--- a/.changeset/forty-carrots-check.md
+++ b/.changeset/forty-carrots-check.md
@@ -1,0 +1,13 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+---
+
+We're introducing a new model named `ProductVariantAvailability` that can be consumed from the `@commercetools/composable-commerce-test-data/product` entry point.
+
+This is how the new model could be used:
+
+```ts
+import { ProductVariantAvailabilityGraphql } from '@commercetools/composable-commerce-test-data/product';
+
+const model = ProductVariantAvailabilityGraphql.random().build();
+```

--- a/standalone/src/models/product/product/index.ts
+++ b/standalone/src/models/product/product/index.ts
@@ -7,6 +7,7 @@ export * from './product-data/types';
 export * from './product-data/category-order-hint/types';
 export * from './product-data/search-keyword/types';
 export * from './product-data/search-keywords/types';
+export * from './product-variant-availability/types';
 
 // Export models
 export * as Attribute from './attribute';
@@ -24,5 +25,7 @@ export * from './product-data';
 
 export * from './product-variant';
 export * from './product-variant/product-variant-draft';
+
+export * from './product-variant-availability';
 
 export * from './selection-of-product';

--- a/standalone/src/models/product/product/product-variant-availability/builders.spec.ts
+++ b/standalone/src/models/product/product/product-variant-availability/builders.spec.ts
@@ -1,0 +1,37 @@
+import type {
+  TProductVariantAvailabilityRest,
+  TProductVariantAvailabilityGraphql,
+} from './types';
+import {
+  ProductVariantAvailabilityRest,
+  ProductVariantAvailabilityGraphql,
+} from './index';
+
+const validateModel = (
+  model: TProductVariantAvailabilityRest | TProductVariantAvailabilityGraphql
+) => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      id: expect.any(String),
+      isOnStock: expect.any(Boolean),
+      restockableInDays: expect.any(Number),
+      availableQuantity: expect.any(Number),
+      version: null,
+    })
+  );
+};
+
+describe('ProductVariantAvailability Builder', () => {
+  it('should build properties for the REST representation', () => {
+    const restModel = ProductVariantAvailabilityRest.random().build();
+
+    validateModel(restModel);
+    expect(restModel.channels).toBeNull();
+  });
+  it('should build properties for the GraphQL representation', () => {
+    const graphqlModel = ProductVariantAvailabilityGraphql.random().build();
+
+    validateModel(graphqlModel);
+    expect(graphqlModel.__typename).toBe('ProductVariantAvailability');
+  });
+});

--- a/standalone/src/models/product/product/product-variant-availability/builders.ts
+++ b/standalone/src/models/product/product/product-variant-availability/builders.ts
@@ -1,0 +1,25 @@
+import { createSpecializedBuilder } from '@/core';
+import { restFieldsConfig, graphqlFieldsConfig } from './fields-config';
+import type {
+  TCreateProductVariantAvailabilityBuilder,
+  TProductVariantAvailabilityGraphql,
+  TProductVariantAvailabilityRest,
+} from './types';
+
+export const RestModelBuilder: TCreateProductVariantAvailabilityBuilder<
+  TProductVariantAvailabilityRest
+> = () =>
+  createSpecializedBuilder({
+    name: 'ProductVariantAvailabilityRestBuilder',
+    type: 'rest',
+    modelFieldsConfig: restFieldsConfig,
+  });
+
+export const GraphqlModelBuilder: TCreateProductVariantAvailabilityBuilder<
+  TProductVariantAvailabilityGraphql
+> = () =>
+  createSpecializedBuilder({
+    name: 'ProductVariantAvailabilityGraphqlBuilder',
+    type: 'graphql',
+    modelFieldsConfig: graphqlFieldsConfig,
+  });

--- a/standalone/src/models/product/product/product-variant-availability/fields-config.ts
+++ b/standalone/src/models/product/product/product-variant-availability/fields-config.ts
@@ -1,0 +1,29 @@
+import { fake, type TModelFieldsConfig } from '@/core';
+import type {
+  TProductVariantAvailabilityGraphql,
+  TProductVariantAvailabilityRest,
+} from './types';
+
+const commonFieldsConfig = {
+  availableQuantity: fake((f) => f.number.int()),
+  id: fake((f) => f.string.uuid()),
+  isOnStock: fake((f) => f.datatype.boolean()),
+  restockableInDays: fake((f) => f.number.int()),
+  version: null,
+};
+
+export const restFieldsConfig: TModelFieldsConfig<TProductVariantAvailabilityRest> =
+  {
+    fields: {
+      ...commonFieldsConfig,
+      channels: null,
+    },
+  };
+
+export const graphqlFieldsConfig: TModelFieldsConfig<TProductVariantAvailabilityGraphql> =
+  {
+    fields: {
+      ...commonFieldsConfig,
+      __typename: 'ProductVariantAvailability',
+    },
+  };

--- a/standalone/src/models/product/product/product-variant-availability/index.ts
+++ b/standalone/src/models/product/product/product-variant-availability/index.ts
@@ -1,0 +1,12 @@
+import { RestModelBuilder, GraphqlModelBuilder } from './builders';
+import * as ProductVariantAvailabilityPresets from './presets';
+
+export const ProductVariantAvailabilityRest = {
+  random: RestModelBuilder,
+  presets: ProductVariantAvailabilityPresets.restPresets,
+};
+
+export const ProductVariantAvailabilityGraphql = {
+  random: GraphqlModelBuilder,
+  presets: ProductVariantAvailabilityPresets.graphqlPresets,
+};

--- a/standalone/src/models/product/product/product-variant-availability/presets/index.ts
+++ b/standalone/src/models/product/product/product-variant-availability/presets/index.ts
@@ -1,0 +1,2 @@
+export const restPresets = {};
+export const graphqlPresets = {};

--- a/standalone/src/models/product/product/product-variant-availability/types.ts
+++ b/standalone/src/models/product/product/product-variant-availability/types.ts
@@ -1,0 +1,12 @@
+import { ProductVariantAvailability } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@/core';
+import { TCtpProductVariantAvailability } from '@/graphql-types';
+
+export type TProductVariantAvailabilityRest = ProductVariantAvailability;
+export type TProductVariantAvailabilityGraphql = TCtpProductVariantAvailability;
+
+export type TCreateProductVariantAvailabilityBuilder<
+  TModel extends
+    | TProductVariantAvailabilityRest
+    | TProductVariantAvailabilityGraphql,
+> = () => TBuilder<TModel>;


### PR DESCRIPTION
## Description

We're introducing a new model named `ProductVariantAvailability` that can be consumed from the `@commercetools/composable-commerce-test-data/product` entry point.

This is how the new model could be used:
```ts
import { ProductVariantAvailabilityGraphql } from '@commercetools/composable-commerce-test-data/product';

const model = ProductVariantAvailabilityGraphql.random().build();
```
