### PR TITLE
chore(test-data): extend CODEOWNERS for sample data preset directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,3 +57,7 @@
 
 /standalone/src/models/*/change-history-* @commercetools/pangolin-team-fe
 /standalone/src/models/*/sample-data-* @commercetools/craft-team-fe
+
+# Sample data preset directories
+**/presets/sample-data-b2c-lifestyle/ @commercetools/craft-team-fe
+**/presets/sample-data-b2b/ @commercetools/craft-team-fe


### PR DESCRIPTION
## Summary

This PR adds our team as codeowners for presets, as a low-touch first point of contact for evaluating possible snapshot regressions against the sample data import feature.