### PR TITLE
Adjust AttributeDefinition post-build function

### DIFF
--- a/standalone/src/models/product-type/attribute-definition/attribute-definition-draft/builders.spec.ts
+++ b/standalone/src/models/product-type/attribute-definition/attribute-definition-draft/builders.spec.ts
@@ -1,3 +1,6 @@
+import { AttributeEnumTypeDraft } from '../../attribute-enum-type/attribute-enum-type-draft';
+import { AttributePlainEnumValueDraft } from '../../attribute-plain-enum-value/attribute-plain-enum-value-draft';
+import { AttributeTextTypeDraft } from '../../attribute-text-type/attribute-text-type-draft';
 import * as constants from '../constants';
 import {
   TAttributeDefinitionDraftGraphql,
@@ -100,5 +103,39 @@ describe('AttributeDefinitionDraft model compatibility builders', () => {
       AttributeDefinitionDraft.random().buildGraphql<TAttributeDefinitionDraftGraphql>();
 
     validateGraphqlModel(graphqlModel);
+  });
+
+  it('builds a GraphQL model with a text type', () => {
+    const graphqlModel = AttributeDefinitionDraft.random()
+      .type(AttributeTextTypeDraft.random().name('text'))
+      .buildGraphql<TAttributeDefinitionDraftGraphql>();
+
+    console.log('graphqlModel', graphqlModel);
+
+    validateGraphqlModel(graphqlModel);
+    expect(graphqlModel.type).toEqual({
+      text: { dummy: null },
+    });
+  });
+
+  it('builds a GraphQL model with an enum type', () => {
+    const graphqlModel = AttributeDefinitionDraft.random()
+      .type(
+        AttributeEnumTypeDraft.random()
+          .name('enum')
+          .values([AttributePlainEnumValueDraft.random()])
+      )
+      .buildGraphql<TAttributeDefinitionDraftGraphql>();
+
+    console.log('graphqlModel', graphqlModel);
+
+    validateGraphqlModel(graphqlModel);
+    expect(graphqlModel.type).toEqual(
+      expect.objectContaining({
+        enum: expect.objectContaining({
+          values: expect.any(Array),
+        }),
+      })
+    );
   });
 });

--- a/standalone/src/models/product-type/attribute-definition/attribute-definition-draft/builders.spec.ts
+++ b/standalone/src/models/product-type/attribute-definition/attribute-definition-draft/builders.spec.ts
@@ -110,8 +110,6 @@ describe('AttributeDefinitionDraft model compatibility builders', () => {
       .type(AttributeTextTypeDraft.random().name('text'))
       .buildGraphql<TAttributeDefinitionDraftGraphql>();
 
-    console.log('graphqlModel', graphqlModel);
-
     validateGraphqlModel(graphqlModel);
     expect(graphqlModel.type).toEqual({
       text: { dummy: null },
@@ -126,8 +124,6 @@ describe('AttributeDefinitionDraft model compatibility builders', () => {
           .values([AttributePlainEnumValueDraft.random()])
       )
       .buildGraphql<TAttributeDefinitionDraftGraphql>();
-
-    console.log('graphqlModel', graphqlModel);
 
     validateGraphqlModel(graphqlModel);
     expect(graphqlModel.type).toEqual(

--- a/standalone/src/models/product-type/attribute-definition/attribute-definition-draft/fields-config.ts
+++ b/standalone/src/models/product-type/attribute-definition/attribute-definition-draft/fields-config.ts
@@ -84,6 +84,18 @@ export const graphqlFieldsConfig: TModelFieldsConfig<TAttributeDefinitionDraftGr
       // the `type` field of this model.
       // We need to inspect the value of the `type` field in order to transform it into the expected format.
       // That's why we have to ignore the typescript warnings.
+      // @ts-expect-error Simple attribute types have `dummy` field
+      if (model.type.dummy) {
+        return {
+          ...model,
+          type: {
+            // @ts-expect-error Simple attribute types have `dummy` field
+            [model.type.dummy]: {
+              dummy: null,
+            },
+          },
+        };
+      }
       // @ts-expect-error AttributeEnumTypeDraftGraphql and AttributeLocalizedEnumTypeDraftGraphql types have a `name` field
       if (model.type.name) {
         // @ts-expect-error AttributeEnumTypeDraftGraphql and AttributeLocalizedEnumTypeDraftGraphql types have a `name` field
@@ -115,18 +127,6 @@ export const graphqlFieldsConfig: TModelFieldsConfig<TAttributeDefinitionDraftGr
             set: {
               // @ts-expect-error AttributeSetTypeDraftGraphql type has a `elementType` field
               elementType: model.type.elementType,
-            },
-          },
-        };
-      }
-      // @ts-expect-error Simple attribute types have `dummy` field
-      if (model.type.dummy) {
-        return {
-          ...model,
-          type: {
-            // @ts-expect-error Simple attribute types have `dummy` field
-            [model.type.dummy]: {
-              dummy: null,
             },
           },
         };


### PR DESCRIPTION
## Description

When working in moving the `Product` model sample data presets I noticed an issue in the `AttributeDefinitionDraft` model when trying to build a GraphQL object with the compatibility builder.

If the attribute type was of type `SimpleAttributeTypeDraft`:
```
{
  dummy: String
}
```
it was not generating the right type value.

We needed to adjust the order of the checks we do in the `postBuild` config callback.
I also added some more tests to verify the update.