### PR TITLE
Implement Resource Identifier model

### DIFF
--- a/.changeset/thirty-worlds-matter.md
+++ b/.changeset/thirty-worlds-matter.md
@@ -2,4 +2,22 @@
 '@commercetools/composable-commerce-test-data': minor
 ---
 
-Implement resource identifier model
+We're introducing a new model named `ResourceIdentifier` that can be consumed from the `@commercetools/composable-commerce-test-data/commons` entry point.
+
+This is how the new model could be used:
+
+```ts
+import { ResourceIdentifierRest } from '@commercetools/composable-commerce-test-data/commons';
+
+const restModel = ResourceIdentifierRest.random().build();
+```
+
+```ts
+import { ResourceIdentifierGraphql } from '@commercetools/composable-commerce-test-data/commons';
+
+const graphqlModel = ResourceIdentifierGraphql.random().build();
+```
+
+`ResourceIdentifier` model provide support for mocking reference-like fields for draft models, such as `StandalonePriceDraft`.
+
+This model allows setting either `id` or `key`, as expected in reference fields across draft types (e.g. `channel`, `customerGroup`, `recurrencePolicy`).

--- a/.changeset/thirty-worlds-matter.md
+++ b/.changeset/thirty-worlds-matter.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+---
+
+Implement resource identifier model

--- a/standalone/src/models/commons/index.ts
+++ b/standalone/src/models/commons/index.ts
@@ -38,3 +38,4 @@ export * from './discounted-line-item-portion';
 export * from './discounted-line-item-price';
 export * from './geometry';
 export * from './reference';
+export * from './resource-identifier';

--- a/standalone/src/models/commons/index.ts
+++ b/standalone/src/models/commons/index.ts
@@ -13,6 +13,7 @@ export * from './money/types';
 export * from './price/types';
 export * from './price-tier/types';
 export * from './reference/types';
+export * from './resource-identifier/types';
 
 // Export models
 export * as Address from './address';

--- a/standalone/src/models/commons/resource-identifier/builders.spec.ts
+++ b/standalone/src/models/commons/resource-identifier/builders.spec.ts
@@ -29,13 +29,13 @@ const validateGraphqlModel = (graphqlModel: TResourceIdentifierGraphql) => {
 };
 
 describe('ResourceIdentifier model builders', () => {
-  it('builds a REST model', () => {
+  it('builds a REST model with default values', () => {
     const restModel = ResourceIdentifierRest.random().build();
 
     validateRestModel(restModel);
   });
 
-  it('builds a populated REST model', () => {
+  it('builds a REST model with custom values', () => {
     const restModel = ResourceIdentifierRest.random()
       .id('12345')
       .key('test-key')
@@ -47,13 +47,13 @@ describe('ResourceIdentifier model builders', () => {
     expect(restModel.typeId).toEqual('foo');
   });
 
-  it('builds a GraphQL model', () => {
+  it('builds a GraphQL model with default values', () => {
     const graphqlModel = ResourceIdentifierGraphql.random().build();
 
     validateGraphqlModel(graphqlModel);
   });
 
-  it('builds a populated GraphQL model', () => {
+  it('builds a GraphQL model with custom values', () => {
     const graphqlModel = ResourceIdentifierGraphql.random()
       .id('12345')
       .key('test-key')
@@ -63,23 +63,6 @@ describe('ResourceIdentifier model builders', () => {
     expect(graphqlModel.id).toEqual('12345');
     expect(graphqlModel.key).toEqual('test-key');
     expect(graphqlModel.typeId).toEqual('foo');
-    expect(graphqlModel.__typename).toEqual('ResourceIdentifier');
-  });
-
-  it('builds REST model with custom typeId', () => {
-    const restModel = ResourceIdentifierRest.random()
-      .typeId('custom-type')
-      .build();
-
-    validateRestModel(restModel, 'custom-type');
-  });
-
-  it('builds GraphQL model with custom typeId', () => {
-    const graphqlModel = ResourceIdentifierGraphql.random()
-      .typeId('custom-type')
-      .build();
-
-    expect(graphqlModel.typeId).toEqual('custom-type');
     expect(graphqlModel.__typename).toEqual('ResourceIdentifier');
   });
 });

--- a/standalone/src/models/commons/resource-identifier/builders.spec.ts
+++ b/standalone/src/models/commons/resource-identifier/builders.spec.ts
@@ -1,0 +1,85 @@
+import type {
+  TResourceIdentifierGraphql,
+  TResourceIdentifierRest,
+} from './types';
+import { ResourceIdentifierRest, ResourceIdentifierGraphql } from './index';
+
+const validateRestModel = (
+  restModel: TResourceIdentifierRest,
+  typeId: string | null = null
+) => {
+  expect(restModel).toEqual(
+    expect.objectContaining({
+      id: expect.any(String),
+      key: expect.any(String),
+      typeId,
+    })
+  );
+};
+
+const validateGraphqlModel = (graphqlModel: TResourceIdentifierGraphql) => {
+  expect(graphqlModel).toEqual(
+    expect.objectContaining({
+      id: expect.any(String),
+      key: expect.any(String),
+      typeId: null,
+      __typename: 'ResourceIdentifier',
+    })
+  );
+};
+
+describe('ResourceIdentifier model builders', () => {
+  it('builds a REST model', () => {
+    const restModel = ResourceIdentifierRest.random().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a populated REST model', () => {
+    const restModel = ResourceIdentifierRest.random()
+      .id('12345')
+      .key('test-key')
+      .typeId('foo')
+      .build();
+
+    expect(restModel.id).toEqual('12345');
+    expect(restModel.key).toEqual('test-key');
+    expect(restModel.typeId).toEqual('foo');
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = ResourceIdentifierGraphql.random().build();
+
+    validateGraphqlModel(graphqlModel);
+  });
+
+  it('builds a populated GraphQL model', () => {
+    const graphqlModel = ResourceIdentifierGraphql.random()
+      .id('12345')
+      .key('test-key')
+      .typeId('foo')
+      .build();
+
+    expect(graphqlModel.id).toEqual('12345');
+    expect(graphqlModel.key).toEqual('test-key');
+    expect(graphqlModel.typeId).toEqual('foo');
+    expect(graphqlModel.__typename).toEqual('ResourceIdentifier');
+  });
+
+  it('builds REST model with custom typeId', () => {
+    const restModel = ResourceIdentifierRest.random()
+      .typeId('custom-type')
+      .build();
+
+    validateRestModel(restModel, 'custom-type');
+  });
+
+  it('builds GraphQL model with custom typeId', () => {
+    const graphqlModel = ResourceIdentifierGraphql.random()
+      .typeId('custom-type')
+      .build();
+
+    expect(graphqlModel.typeId).toEqual('custom-type');
+    expect(graphqlModel.__typename).toEqual('ResourceIdentifier');
+  });
+});

--- a/standalone/src/models/commons/resource-identifier/builders.ts
+++ b/standalone/src/models/commons/resource-identifier/builders.ts
@@ -1,0 +1,25 @@
+import { createSpecializedBuilder } from '@/core';
+import { restFieldsConfig, graphqlFieldsConfig } from './fields-config';
+import type {
+  TCreateResourceIdentifierBuilder,
+  TResourceIdentifierGraphql,
+  TResourceIdentifierRest,
+} from './types';
+
+export const RestModelBuilder: TCreateResourceIdentifierBuilder<
+  TResourceIdentifierRest
+> = () =>
+  createSpecializedBuilder({
+    name: 'ResourceIdentifierRestBuilder',
+    type: 'rest',
+    modelFieldsConfig: restFieldsConfig,
+  });
+
+export const GraphqlModelBuilder: TCreateResourceIdentifierBuilder<
+  TResourceIdentifierGraphql
+> = () =>
+  createSpecializedBuilder({
+    name: 'ResourceIdentifierGraphqlBuilder',
+    type: 'graphql',
+    modelFieldsConfig: graphqlFieldsConfig,
+  });

--- a/standalone/src/models/commons/resource-identifier/fields-config.ts
+++ b/standalone/src/models/commons/resource-identifier/fields-config.ts
@@ -1,0 +1,25 @@
+import { fake, type TModelFieldsConfig } from '@/core';
+import type {
+  TResourceIdentifierGraphql,
+  TResourceIdentifierRest,
+} from './types';
+
+const commonFieldsConfig = {
+  key: fake((f) => f.string.uuid()),
+  id: fake((f) => f.string.uuid()),
+  typeId: null,
+};
+
+export const restFieldsConfig: TModelFieldsConfig<TResourceIdentifierRest> = {
+  fields: {
+    ...commonFieldsConfig,
+  },
+};
+
+export const graphqlFieldsConfig: TModelFieldsConfig<TResourceIdentifierGraphql> =
+  {
+    fields: {
+      ...commonFieldsConfig,
+      __typename: 'ResourceIdentifier',
+    },
+  };

--- a/standalone/src/models/commons/resource-identifier/index.ts
+++ b/standalone/src/models/commons/resource-identifier/index.ts
@@ -1,6 +1,5 @@
 import { RestModelBuilder, GraphqlModelBuilder } from './builders';
 import * as ResourceIdentifierPresets from './presets';
-export * from './types';
 
 export const ResourceIdentifierRest = {
   random: RestModelBuilder,

--- a/standalone/src/models/commons/resource-identifier/index.ts
+++ b/standalone/src/models/commons/resource-identifier/index.ts
@@ -1,0 +1,13 @@
+import { RestModelBuilder, GraphqlModelBuilder } from './builders';
+import * as ResourceIdentifierPresets from './presets';
+export * from './types';
+
+export const ResourceIdentifierRest = {
+  random: RestModelBuilder,
+  presets: ResourceIdentifierPresets.restPresets,
+};
+
+export const ResourceIdentifierGraphql = {
+  random: GraphqlModelBuilder,
+  presets: ResourceIdentifierPresets.graphqlPresets,
+};

--- a/standalone/src/models/commons/resource-identifier/presets/index.ts
+++ b/standalone/src/models/commons/resource-identifier/presets/index.ts
@@ -1,0 +1,2 @@
+export const restPresets = {};
+export const graphqlPresets = {};

--- a/standalone/src/models/commons/resource-identifier/types.ts
+++ b/standalone/src/models/commons/resource-identifier/types.ts
@@ -1,0 +1,10 @@
+import { IResourceIdentifier } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@/core';
+import { TCtpResourceIdentifier } from '@/graphql-types';
+
+export type TResourceIdentifierRest = IResourceIdentifier;
+export type TResourceIdentifierGraphql = TCtpResourceIdentifier;
+
+export type TCreateResourceIdentifierBuilder<
+  TModel extends TResourceIdentifierRest | TResourceIdentifierGraphql,
+> = () => TBuilder<TModel>;

--- a/standalone/src/resource-identifier.ts
+++ b/standalone/src/resource-identifier.ts
@@ -1,0 +1,1 @@
+export * from './models/commons/resource-identifier';


### PR DESCRIPTION
Recurrence policies are still not available in the SDK and this PR introduces a `Resource Identifier` model that will be used to mock a "drafted" Recurrence Policy field inside a standalone price form. See https://next-docs-subscriptions-docs.commercetools.vercel.app/api/projects/standalone-prices#standalonepricedraft

`StandalonePriceDraft` builder needs some adjustments in our e2e test in order to mock properly a recurrence policy field builder.