### PR TITLE
New VariantPricesListView test data model

### DIFF
--- a/.changeset/thirty-bees-cheer.md
+++ b/.changeset/thirty-bees-cheer.md
@@ -1,0 +1,17 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+---
+
+We're introducing a new model named `VariantPricesListView` can be consumed from the `@commercetools/composable-commerce-test-data/my-view` entry point.
+
+There's only a GraphQL version for this model as it only exists in the MC Settings services which only expose a GraphQL API.
+
+This is how the new model could be used:
+
+```
+import {
+  VariantPricesListViewGraphql,
+} from '@commercetools/composable-commerce-test-data/my-view';
+
+const variantPricesListView = VariantPricesListViewGraphql.random().build();
+```

--- a/standalone/src/models/my-view/index.ts
+++ b/standalone/src/models/my-view/index.ts
@@ -2,8 +2,10 @@ export * from './my-view-nested-table/types';
 export * from './my-view-sort/types';
 export * from './my-view-table/types';
 export * from './pim-search-list-view/types';
+export * from './variant-prices-list-view/types';
 
 export * from './my-view-nested-table';
 export * from './my-view-sort';
 export * from './my-view-table';
 export * from './pim-search-list-view';
+export * from './variant-prices-list-view';

--- a/standalone/src/models/my-view/variant-prices-list-view/builders.spec.ts
+++ b/standalone/src/models/my-view/variant-prices-list-view/builders.spec.ts
@@ -1,0 +1,19 @@
+import { VariantPricesListViewGraphql } from './index';
+
+describe('VariantPricesListView Builder', () => {
+  it('should build properties for the GraphQL representation', () => {
+    const graphqlModel = VariantPricesListViewGraphql.random().build();
+
+    expect(graphqlModel).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        createdAt: expect.any(String),
+        projectKey: expect.any(String),
+        updatedAt: expect.any(String),
+        userId: expect.any(String),
+        visibleColumns: [],
+        __typename: 'VariantPricesListView',
+      })
+    );
+  });
+});

--- a/standalone/src/models/my-view/variant-prices-list-view/builders.ts
+++ b/standalone/src/models/my-view/variant-prices-list-view/builders.ts
@@ -1,0 +1,10 @@
+import { createSpecializedBuilder } from '@/core';
+import { graphqlFieldsConfig } from './fields-config';
+import type { TCreateVariantPricesListViewBuilder } from './types';
+
+export const GraphqlModelBuilder: TCreateVariantPricesListViewBuilder = () =>
+  createSpecializedBuilder({
+    name: 'VariantPricesListViewGraphqlBuilder',
+    type: 'graphql',
+    modelFieldsConfig: graphqlFieldsConfig,
+  });

--- a/standalone/src/models/my-view/variant-prices-list-view/fields-config.ts
+++ b/standalone/src/models/my-view/variant-prices-list-view/fields-config.ts
@@ -1,0 +1,18 @@
+import { fake, type TModelFieldsConfig } from '@/core';
+import { createRelatedDates } from '@/utils';
+import type { TVariantPricesListViewGraphql } from './types';
+
+const [getOlderDate, getNewerDate] = createRelatedDates();
+
+export const graphqlFieldsConfig: TModelFieldsConfig<TVariantPricesListViewGraphql> =
+  {
+    fields: {
+      id: fake((f) => f.string.uuid()),
+      createdAt: fake(getOlderDate),
+      projectKey: fake((f) => f.lorem.slug(2)),
+      updatedAt: fake(getNewerDate),
+      userId: fake((f) => f.string.uuid()),
+      visibleColumns: [],
+      __typename: 'VariantPricesListView',
+    },
+  };

--- a/standalone/src/models/my-view/variant-prices-list-view/index.ts
+++ b/standalone/src/models/my-view/variant-prices-list-view/index.ts
@@ -1,0 +1,7 @@
+import { GraphqlModelBuilder } from './builders';
+import * as presets from './presets';
+
+export const VariantPricesListViewGraphql = {
+  random: GraphqlModelBuilder,
+  presets: presets.graphqlPresets,
+};

--- a/standalone/src/models/my-view/variant-prices-list-view/presets/index.ts
+++ b/standalone/src/models/my-view/variant-prices-list-view/presets/index.ts
@@ -1,0 +1,1 @@
+export const graphqlPresets = {};

--- a/standalone/src/models/my-view/variant-prices-list-view/types.ts
+++ b/standalone/src/models/my-view/variant-prices-list-view/types.ts
@@ -1,0 +1,8 @@
+import type { TBuilder } from '@/core';
+import { TMcSettingsVariantPricesListView } from '@/graphql-types';
+
+// There's not REST model as this entity only exists in the MC Settings GraphQL API
+export type TVariantPricesListViewGraphql = TMcSettingsVariantPricesListView;
+
+export type TCreateVariantPricesListViewBuilder =
+  () => TBuilder<TVariantPricesListViewGraphql>;


### PR DESCRIPTION
## Description

We're introducing a new model named `VariantPricesListView` can be consumed from the `@commercetools/composable-commerce-test-data/my-view` entry point.

There's only a GraphQL version for this model as it only exists in the MC Settings services which only expose a GraphQL API.

This is how the new model could be used:

```
import {
  VariantPricesListViewGraphql,
} from '@commercetools/composable-commerce-test-data/my-view';

const variantPricesListView = VariantPricesListViewGraphql.random().build();
```
