### PR TITLE
Fix CustomFieldsRest test data model

### DIFF
--- a/.changeset/fuzzy-mails-dress.md
+++ b/.changeset/fuzzy-mails-dress.md
@@ -1,0 +1,7 @@
+---
+'@commercetools/composable-commerce-test-data': patch
+---
+
+Fixed `CustomFieldsRest` test data model as the default generated version was not populating the `fields` property but that's a required property.
+
+Now we populate it with an empty object.

--- a/standalone/src/models/custom-fields/custom-fields/builders.spec.ts
+++ b/standalone/src/models/custom-fields/custom-fields/builders.spec.ts
@@ -31,6 +31,7 @@ const validateRestModel = (model: TCustomFieldsRest) => {
       fields: expect.any(Object),
     })
   );
+  expect(model.fields).not.toBeNull();
 };
 
 const validateGraphqlModel = (model: TCustomFieldsGraphql) => {
@@ -38,37 +39,46 @@ const validateGraphqlModel = (model: TCustomFieldsGraphql) => {
     expect.objectContaining({
       __typename: 'CustomFieldsType',
       type: expect.objectContaining({
-        id: expect.any(String),
-        key: expect.any(String),
-        name: expect.any(Object),
         __typename: 'TypeDefinition',
       }),
       typeRef: expect.objectContaining({
-        typeId: 'type',
-        id: expect.any(String),
         __typename: 'Reference',
       }),
-      customFieldsRaw: expect.arrayContaining([
-        expect.objectContaining({
-          name: expect.any(String),
-          value: expect.anything(),
-          __typename: 'RawCustomField',
-        }),
-      ]),
     })
   );
 };
 
 describe('CustomFields model builders', () => {
-  it('builds a REST model', () => {
+  it('builds a default REST model', () => {
+    const restModel = RestModelBuilder().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a REST model with fields', () => {
     const restModel = populateRestModel(RestModelBuilder()).build();
 
     validateRestModel(restModel);
   });
 
-  it('builds a GraphQL model', () => {
+  it('builds a default GraphQL model', () => {
+    const graphqlModel = GraphqlModelBuilder().build();
+
+    validateGraphqlModel(graphqlModel);
+  });
+
+  it('builds a GraphQL model with fields', () => {
     const graphqlModel = populateGraphqlModel(GraphqlModelBuilder()).build();
 
     validateGraphqlModel(graphqlModel);
+    expect(graphqlModel).toEqual(
+      expect.objectContaining({
+        customFieldsRaw: expect.arrayContaining([
+          expect.objectContaining({
+            __typename: 'RawCustomField',
+          }),
+        ]),
+      })
+    );
   });
 });

--- a/standalone/src/models/custom-fields/custom-fields/fields-config.ts
+++ b/standalone/src/models/custom-fields/custom-fields/fields-config.ts
@@ -6,8 +6,8 @@ import { TCustomFieldsRest, TCustomFieldsGraphql } from './types';
 export const restFieldsConfig: TModelFieldsConfig<TCustomFieldsRest> = {
   fields: {
     type: fake(() => ReferenceRest.presets.typeReference()),
-    // Use an array ofRawCustomFieldGraphql to create the fields.
-    fields: null,
+    // This is a field container, which is a simple object with string keys and values of any type.
+    fields: {},
   },
 };
 


### PR DESCRIPTION
## Description

Fixed `CustomFieldsRest` test data model as the default generated version was not populating the `fields` property but that's a required property.

Now we populate it with an empty object.
