### PR TITLE
New ItemState test data model

### DIFF
--- a/.changeset/orange-results-hang.md
+++ b/.changeset/orange-results-hang.md
@@ -1,0 +1,17 @@
+---
+'@commercetools/composable-commerce-test-data': patch
+---
+
+We're introducing a new test data model named `ItemState` which can be consumed from the `@commercetools/composable-commerce-test-data/cart` entry point.
+
+This is how it can be used:
+
+```ts
+import {
+  ItemStateGraphql,
+  ItemStateRest,
+} from '@commercetools/composable-commerce-test-data/cart';
+
+const graphqlModel = ItemStateGraphql.random().build();
+const restModel = ItemStateRest.random().build();
+```

--- a/.changeset/orange-results-hang.md
+++ b/.changeset/orange-results-hang.md
@@ -1,5 +1,5 @@
 ---
-'@commercetools/composable-commerce-test-data': patch
+'@commercetools/composable-commerce-test-data': minor
 ---
 
 We're introducing a new test data model named `ItemState` which can be consumed from the `@commercetools/composable-commerce-test-data/cart` entry point.

--- a/standalone/src/models/cart/cart/index.ts
+++ b/standalone/src/models/cart/cart/index.ts
@@ -1,11 +1,12 @@
 // Export types
-export * from './custom-line-item/types';
 export * from './cart/types';
-export * from './item-shipping-details/types';
-export * from './item-shipping-target/types';
-export * from './line-item/types';
+export * from './custom-line-item/types';
 export * from './discount-on-total-price/types';
 export * from './discounted-total-price-portion/types';
+export * from './item-shipping-details/types';
+export * from './item-shipping-target/types';
+export * from './item-state/types';
+export * from './line-item/types';
 export * from './shipping/types';
 
 // Export models
@@ -22,6 +23,7 @@ export * from './discounted-line-item-price-for-quantity';
 export * from './item-shipping-details';
 export * from './item-shipping-details/item-shipping-details-draft';
 export * from './item-shipping-target';
+export * from './item-state';
 export * from './line-item';
 export * from './line-item/line-item-draft';
 export * from './shipping';

--- a/standalone/src/models/cart/cart/item-state/builders.spec.ts
+++ b/standalone/src/models/cart/cart/item-state/builders.spec.ts
@@ -1,0 +1,34 @@
+import { ItemStateRest, ItemStateGraphql } from './index';
+
+describe('ItemState Builder', () => {
+  it('should build properties for the REST representation', () => {
+    const restModel = ItemStateRest.random().build();
+
+    expect(restModel).toEqual(
+      expect.objectContaining({
+        quantity: expect.any(Number),
+        state: expect.objectContaining({
+          id: expect.any(String),
+          typeId: 'state',
+        }),
+      })
+    );
+  });
+  it('should build properties for the GraphQL representation', () => {
+    const graphqlModel = ItemStateGraphql.random().build();
+
+    expect(graphqlModel).toEqual(
+      expect.objectContaining({
+        quantity: expect.any(Number),
+        state: expect.objectContaining({
+          __typename: 'State',
+        }),
+        stateRef: expect.objectContaining({
+          typeId: 'state',
+          __typename: 'Reference',
+        }),
+        __typename: 'ItemState',
+      })
+    );
+  });
+});

--- a/standalone/src/models/cart/cart/item-state/builders.ts
+++ b/standalone/src/models/cart/cart/item-state/builders.ts
@@ -1,0 +1,23 @@
+import { createSpecializedBuilder } from '@/core';
+import { restFieldsConfig, graphqlFieldsConfig } from './fields-config';
+import type {
+  TCreateItemStateBuilder,
+  TItemStateGraphql,
+  TItemStateRest,
+} from './types';
+
+export const RestModelBuilder: TCreateItemStateBuilder<TItemStateRest> = () =>
+  createSpecializedBuilder({
+    name: 'ItemStateRestBuilder',
+    type: 'rest',
+    modelFieldsConfig: restFieldsConfig,
+  });
+
+export const GraphqlModelBuilder: TCreateItemStateBuilder<
+  TItemStateGraphql
+> = () =>
+  createSpecializedBuilder({
+    name: 'ItemStateGraphqlBuilder',
+    type: 'graphql',
+    modelFieldsConfig: graphqlFieldsConfig,
+  });

--- a/standalone/src/models/cart/cart/item-state/fields-config.ts
+++ b/standalone/src/models/cart/cart/item-state/fields-config.ts
@@ -1,0 +1,38 @@
+import { fake, type TModelFieldsConfig } from '@/core';
+import { ReferenceGraphql, ReferenceRest } from '@/models/commons';
+import { State } from '@/models/state';
+import type { TItemStateGraphql, TItemStateRest } from './types';
+
+// Reference REST docs: https://docs.commercetools.com/api/projects/carts#itemstate
+
+const commonFieldsConfig = {
+  quantity: fake((f) => f.number.int({ min: 1, max: 25 })),
+};
+
+export const restFieldsConfig: TModelFieldsConfig<TItemStateRest> = {
+  fields: {
+    ...commonFieldsConfig,
+    state: fake(() => ReferenceRest.presets.stateReference()),
+  },
+};
+
+export const graphqlFieldsConfig: TModelFieldsConfig<TItemStateGraphql> = {
+  fields: {
+    ...commonFieldsConfig,
+    state: fake(() => State.random()),
+    stateRef: null,
+    __typename: 'ItemState',
+  },
+  postBuild: (model) => {
+    const stateRef = ReferenceGraphql.presets.stateReference();
+
+    if (model.state) {
+      stateRef.id(model.state.id);
+    }
+
+    return {
+      ...model,
+      stateRef: stateRef.build(),
+    };
+  },
+};

--- a/standalone/src/models/cart/cart/item-state/index.ts
+++ b/standalone/src/models/cart/cart/item-state/index.ts
@@ -1,0 +1,12 @@
+import { RestModelBuilder, GraphqlModelBuilder } from './builders';
+import * as ItemStatePresets from './presets';
+
+export const ItemStateRest = {
+  random: RestModelBuilder,
+  presets: ItemStatePresets.restPresets,
+};
+
+export const ItemStateGraphql = {
+  random: GraphqlModelBuilder,
+  presets: ItemStatePresets.graphqlPresets,
+};

--- a/standalone/src/models/cart/cart/item-state/presets/index.ts
+++ b/standalone/src/models/cart/cart/item-state/presets/index.ts
@@ -1,0 +1,2 @@
+export const restPresets = {};
+export const graphqlPresets = {};

--- a/standalone/src/models/cart/cart/item-state/types.ts
+++ b/standalone/src/models/cart/cart/item-state/types.ts
@@ -1,0 +1,10 @@
+import { ItemState } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@/core';
+import { TCtpItemState } from '@/graphql-types';
+
+export type TItemStateRest = ItemState;
+export type TItemStateGraphql = TCtpItemState;
+
+export type TCreateItemStateBuilder<
+  TModel extends TItemStateRest | TItemStateGraphql,
+> = () => TBuilder<TModel>;


### PR DESCRIPTION
## Description

We're introducing a new test data model named `ItemState` which can be consumed from the `@commercetools/composable-commerce-test-data/cart` entry point.

[Here](https://docs.commercetools.com/api/projects/carts#itemstate) are the official docs for this resource.

This is how it can be used:

```ts
import {
  ItemStateGraphql,
  ItemStateRest,
} from '@commercetools/composable-commerce-test-data/cart';

const graphqlModel = ItemStateGraphql.random().build();
const restModel = ItemStateRest.random().build();
```
