### PR TITLE
New CartDiscountTarget test data model

### DIFF
--- a/.changeset/six-beers-drop.md
+++ b/.changeset/six-beers-drop.md
@@ -1,0 +1,22 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+---
+
+We're introducing a new test data model named `CartDiscountTarget` which can be consumed from the `@commercetools/composable-commerce-test-data/cart-discount` entry point.
+
+This is how it can be used:
+
+```ts
+import {
+  CartDiscountTargetGraphql,
+  CartDiscountTargetRest,
+} from '@commercetools/composable-commerce-test-data/cart-discount';
+
+const graphqlModel = CartDiscountTargetGraphql.random()
+  .type(CartDiscountTargetGraphql.constants.targetTypes.lineItems)
+  .build();
+
+const restModel = CartDiscountTargetRest.random()
+  .type(CartDiscountTargetGraphql.constants.targetTypes.shipping)
+  .build();
+```

--- a/standalone/src/models/cart/cart-discount/cart-discount-target/builders.spec.ts
+++ b/standalone/src/models/cart/cart-discount/cart-discount-target/builders.spec.ts
@@ -1,0 +1,66 @@
+import { targetTypes } from './constants';
+import { CartDiscountTargetRest, CartDiscountTargetGraphql } from './index';
+
+describe('CartDiscountTarget Builder', () => {
+  it('should build properties for the REST representation', () => {
+    const restModel = CartDiscountTargetRest.random().build();
+
+    expect(restModel).toEqual(
+      expect.objectContaining({
+        type: expect.any(String),
+      })
+    );
+  });
+  it('should build properties for the GraphQL representation', () => {
+    const graphqlModel = CartDiscountTargetGraphql.random().build();
+
+    expect(graphqlModel).toEqual(
+      expect.objectContaining({
+        type: expect.any(String),
+        __typename: expect.any(String),
+      })
+    );
+  });
+
+  it('should set the right __typename for the GraphQL representation', () => {
+    let graphqlModel = CartDiscountTargetGraphql.random()
+      .type(targetTypes.customLineItems)
+      .build();
+    expect(graphqlModel.__typename).toBe('CustomLineItemsTarget');
+
+    graphqlModel = CartDiscountTargetGraphql.random()
+      .type(targetTypes.lineItems)
+      .build();
+    expect(graphqlModel.__typename).toBe('LineItemsTarget');
+
+    graphqlModel = CartDiscountTargetGraphql.random()
+      .type(targetTypes.pattern)
+      .build();
+    expect(graphqlModel.__typename).toBe('PatternTarget');
+
+    graphqlModel = CartDiscountTargetGraphql.random()
+      .type(targetTypes.shipping)
+      .build();
+    expect(graphqlModel.__typename).toBe('ShippingTarget');
+
+    graphqlModel = CartDiscountTargetGraphql.random()
+      .type(targetTypes.totalPrice)
+      .build();
+    expect(graphqlModel.__typename).toBe('TotalPriceTarget');
+  });
+
+  it('should include predicate for shipping target', () => {
+    const graphqlModel = CartDiscountTargetGraphql.random()
+      .type(targetTypes.shipping)
+      .build();
+
+    expect(graphqlModel.predicate).toBeDefined();
+  });
+
+  it('should not include predicate for non-shipping target', () => {
+    const graphqlModel = CartDiscountTargetGraphql.random()
+      .type(targetTypes.customLineItems)
+      .build();
+    expect(graphqlModel.predicate).toBeUndefined();
+  });
+});

--- a/standalone/src/models/cart/cart-discount/cart-discount-target/builders.ts
+++ b/standalone/src/models/cart/cart-discount/cart-discount-target/builders.ts
@@ -1,0 +1,25 @@
+import { createSpecializedBuilder } from '@/core';
+import { restFieldsConfig, graphqlFieldsConfig } from './fields-config';
+import type {
+  TCreateCartDiscountTargetBuilder,
+  TCartDiscountTargetGraphql,
+  TCartDiscountTargetRest,
+} from './types';
+
+export const RestModelBuilder: TCreateCartDiscountTargetBuilder<
+  TCartDiscountTargetRest
+> = () =>
+  createSpecializedBuilder({
+    name: 'CartDiscountTargetRestBuilder',
+    type: 'rest',
+    modelFieldsConfig: restFieldsConfig,
+  });
+
+export const GraphqlModelBuilder: TCreateCartDiscountTargetBuilder<
+  TCartDiscountTargetGraphql
+> = () =>
+  createSpecializedBuilder({
+    name: 'CartDiscountTargetGraphqlBuilder',
+    type: 'graphql',
+    modelFieldsConfig: graphqlFieldsConfig,
+  });

--- a/standalone/src/models/cart/cart-discount/cart-discount-target/constants.ts
+++ b/standalone/src/models/cart/cart-discount/cart-discount-target/constants.ts
@@ -1,0 +1,7 @@
+export const targetTypes = {
+  customLineItems: 'customLineItems',
+  lineItems: 'lineItems',
+  pattern: 'pattern',
+  shipping: 'shipping',
+  totalPrice: 'totalPrice',
+};

--- a/standalone/src/models/cart/cart-discount/cart-discount-target/fields-config.ts
+++ b/standalone/src/models/cart/cart-discount/cart-discount-target/fields-config.ts
@@ -1,0 +1,46 @@
+import { fake, type TModelFieldsConfig } from '@/core';
+import { targetTypes } from './constants';
+import type {
+  TCartDiscountTargetGraphql,
+  TCartDiscountTargetRest,
+} from './types';
+
+// https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscounttarget
+
+const targetTypeToGraphqlTypenameMap: Record<string, string> = {
+  customLineItems: 'CustomLineItemsTarget',
+  lineItems: 'LineItemsTarget',
+  pattern: 'PatternTarget',
+  shipping: 'ShippingTarget',
+  totalPrice: 'TotalPriceTarget',
+};
+
+const commonFieldsConfig = {
+  type: fake((f) => f.helpers.arrayElement(Object.values(targetTypes))),
+};
+
+export const restFieldsConfig: TModelFieldsConfig<TCartDiscountTargetRest> = {
+  fields: {
+    ...commonFieldsConfig,
+  },
+};
+
+export const graphqlFieldsConfig: TModelFieldsConfig<TCartDiscountTargetGraphql> =
+  {
+    fields: {
+      ...commonFieldsConfig,
+      predicate: null,
+      __typename: null,
+    },
+    postBuild: (model) => {
+      const shouldIncludePredicate = model.type === targetTypes.shipping;
+
+      return {
+        ...model,
+        predicate: shouldIncludePredicate
+          ? (model.predicate ?? '1 = 1')
+          : undefined,
+        __typename: targetTypeToGraphqlTypenameMap[model.type],
+      };
+    },
+  };

--- a/standalone/src/models/cart/cart-discount/cart-discount-target/index.ts
+++ b/standalone/src/models/cart/cart-discount/cart-discount-target/index.ts
@@ -1,0 +1,15 @@
+import { RestModelBuilder, GraphqlModelBuilder } from './builders';
+import * as constants from './constants';
+import * as CartDiscountTargetPresets from './presets';
+
+export const CartDiscountTargetRest = {
+  constants,
+  random: RestModelBuilder,
+  presets: CartDiscountTargetPresets.restPresets,
+};
+
+export const CartDiscountTargetGraphql = {
+  constants,
+  random: GraphqlModelBuilder,
+  presets: CartDiscountTargetPresets.graphqlPresets,
+};

--- a/standalone/src/models/cart/cart-discount/cart-discount-target/presets/index.ts
+++ b/standalone/src/models/cart/cart-discount/cart-discount-target/presets/index.ts
@@ -1,0 +1,2 @@
+export const restPresets = {};
+export const graphqlPresets = {};

--- a/standalone/src/models/cart/cart-discount/cart-discount-target/types.ts
+++ b/standalone/src/models/cart/cart-discount/cart-discount-target/types.ts
@@ -1,0 +1,13 @@
+import { CartDiscountTarget } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@/core';
+import { TCtpCartDiscountTarget } from '@/graphql-types';
+
+export type TCartDiscountTargetRest = CartDiscountTarget;
+export type TCartDiscountTargetGraphql = TCtpCartDiscountTarget & {
+  predicate?: string | null;
+  __typename: string;
+};
+
+export type TCreateCartDiscountTargetBuilder<
+  TModel extends TCartDiscountTargetRest | TCartDiscountTargetGraphql,
+> = () => TBuilder<TModel>;

--- a/standalone/src/models/cart/cart-discount/index.ts
+++ b/standalone/src/models/cart/cart-discount/index.ts
@@ -12,6 +12,7 @@ export * from './cart-discount-value-absolute/types';
 export * from './cart-discount-value-fixed/types';
 export * from './cart-discount-value-gift-line-item/types';
 export * from './cart-discount-value-relative/types';
+export * from './cart-discount-target/types';
 
 // Export models
 export * as CartDiscount from './cart-discount';
@@ -44,3 +45,5 @@ export * from './cart-discount-pattern-target';
 export * from './cart-discount-total-price-target';
 export * from './count-on-line-item-units';
 export * from './count-on-custom-line-item-units';
+
+export * from './cart-discount-target';


### PR DESCRIPTION
## Description

We're introducing a new test data model named `CartDiscountTarget` which can be consumed from the `@commercetools/composable-commerce-test-data/cart-discount` entry point.

[Here](https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscounttarget) are the official docs for this resource.

This is how it can be used:

```ts
import {
  CartDiscountTargetGraphql,
  CartDiscountTargetRest,
} from '@commercetools/composable-commerce-test-data/cart-discount';

const graphqlModel = CartDiscountTargetGraphql.random()
  .type(CartDiscountTargetGraphql.constants.targetTypes.lineItems)
  .build();

const restModel = CartDiscountTargetRest.random()
  .type(CartDiscountTargetGraphql.constants.targetTypes.shipping)
  .build();
```
