### PR TITLE
feat(product-type): add tshirt preset

### DIFF
--- a/.changeset/quick-humans-push.md
+++ b/.changeset/quick-humans-push.md
@@ -2,17 +2,11 @@
 '@commercetools/composable-commerce-test-data': minor
 ---
 
-### Additions
+We're introducing a new preset in `ProductType` test data model called `tshirt` which should help consumers building objects.
 
-We're introducing a new preset in `Product Type` test data model which should help consumers building objects.
-
-#### LineItem
-
-New `tshirt` preset which populates all the model properties.
-Example:
+Here's an example on how it could be used:
 
 ```ts
-import { ProductTypeGraphQl } from '@commercetools/composable-commerce-test-data/product-type';
+import { ProductTypeGraphql } from '@commercetools/composable-commerce-test-data/product-type';
 
-const tshirt = ProductType.presets.tshirt().buildGraphql();
-```
+const tshirt = ProductTypeGraphql.presets.tshirt().build();

--- a/.changeset/quick-humans-push.md
+++ b/.changeset/quick-humans-push.md
@@ -1,0 +1,18 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+---
+
+### Additions
+
+We're introducing a new preset in `Product Type` test data model which should help consumers building objects.
+
+#### LineItem
+
+New `tshirt` preset which populates all the model properties.
+Example:
+
+```ts
+import { ProductTypeGraphQl } from '@commercetools/composable-commerce-test-data/product-type';
+
+const tshirt = ProductType.presets.tshirt().buildGraphql();
+```

--- a/standalone/src/models/product-type/product-type/presets/index.ts
+++ b/standalone/src/models/product-type/product-type/presets/index.ts
@@ -1,13 +1,17 @@
 import * as milkPresets from './milk';
+import * as tshirtPresets from './tshirt';
 
 export const restPresets = {
   milk: milkPresets.restPreset,
+  tshirt: tshirtPresets.restPreset,
 };
 
 export const graphqlPresets = {
   milk: milkPresets.graphqlPreset,
+  tshirt: tshirtPresets.graphqlPreset,
 };
 
 export const compatPresets = {
   milk: milkPresets.compatPreset,
+  tshirt: tshirtPresets.compatPreset,
 };

--- a/standalone/src/models/product-type/product-type/presets/tshirt.spec.ts
+++ b/standalone/src/models/product-type/product-type/presets/tshirt.spec.ts
@@ -1,7 +1,3 @@
-import {
-  attributeConstraints,
-  inputHints,
-} from '../../attribute-definition/constants';
 import { TProductTypeGraphql, TProductTypeRest } from '../types';
 import * as presets from './tshirt';
 

--- a/standalone/src/models/product-type/product-type/presets/tshirt.spec.ts
+++ b/standalone/src/models/product-type/product-type/presets/tshirt.spec.ts
@@ -1,0 +1,78 @@
+import {
+  attributeConstraints,
+  inputHints,
+} from '../../attribute-definition/constants';
+import { TProductTypeGraphql, TProductTypeRest } from '../types';
+import * as presets from './tshirt';
+
+const validateRestModel = (
+  model: TProductTypeRest | TProductTypeGraphql
+): void => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      name: 'T-shirt Product Type',
+      attributes: expect.arrayContaining([
+        expect.objectContaining({
+          name: 'country-of-origin',
+        }),
+        expect.objectContaining({
+          name: 'size',
+        }),
+      ]),
+    })
+  );
+};
+
+const validateGraphqlModel = (model: TProductTypeGraphql): void => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      name: 'T-shirt Product Type',
+      attributeDefinitions: expect.objectContaining({
+        results: expect.arrayContaining([
+          expect.objectContaining({
+            name: 'country-of-origin',
+          }),
+          expect.objectContaining({
+            name: 'size',
+          }),
+        ]),
+      }),
+    })
+  );
+};
+
+describe('ProductType model tshirt preset builders', () => {
+  it('builds a REST model', () => {
+    const restModel = presets.restPreset().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = presets.graphqlPreset().build();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});
+
+describe('ProductType model tshirt preset compatibility builders', () => {
+  it('builds a default (REST) model', () => {
+    const restModel = presets.compatPreset().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a REST model', () => {
+    const restModel = presets.compatPreset().buildRest();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = presets
+      .compatPreset()
+      .buildGraphql<TProductTypeGraphql>();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});

--- a/standalone/src/models/product-type/product-type/presets/tshirt.ts
+++ b/standalone/src/models/product-type/product-type/presets/tshirt.ts
@@ -1,0 +1,41 @@
+import { type TBuilder } from '@/core';
+import { AttributeDefinitionRest, AttributeDefinitionGraphql } from '../..';
+import {
+  CompatModelBuilder,
+  GraphqlModelBuilder,
+  RestModelBuilder,
+} from '../builders';
+import type {
+  TProductType,
+  TProductTypeGraphql,
+  TProductTypeRest,
+} from '../types';
+
+export const restPreset = (): TBuilder<TProductTypeRest> =>
+  RestModelBuilder()
+    .name('T-shirt Product Type')
+    .attributes([
+      AttributeDefinitionRest.presets.countryOfOrigin().buildRest(),
+      AttributeDefinitionRest.presets.size().buildRest(),
+    ]);
+
+export const graphqlPreset = (): TBuilder<TProductTypeGraphql> =>
+  GraphqlModelBuilder()
+    .name('T-shirt Product Type')
+    .attributeDefinitions({
+      results: [
+        AttributeDefinitionGraphql.presets.countryOfOrigin().buildGraphql(),
+        AttributeDefinitionGraphql.presets.size().buildGraphql(),
+      ],
+      total: 1,
+      offset: 0,
+      __typename: 'AttributeDefinitionResult',
+    });
+
+export const compatPreset = (): TBuilder<TProductType> =>
+  CompatModelBuilder()
+    .name('T-shirt Product Type')
+    .attributes([
+      AttributeDefinitionRest.presets.countryOfOrigin().buildRest(),
+      AttributeDefinitionRest.presets.size().buildRest(),
+    ]);

--- a/standalone/src/models/product-type/product-type/presets/tshirt.ts
+++ b/standalone/src/models/product-type/product-type/presets/tshirt.ts
@@ -1,5 +1,9 @@
 import { type TBuilder } from '@/core';
-import { AttributeDefinitionRest, AttributeDefinitionGraphql } from '../..';
+import {
+  AttributeDefinitionRest,
+  AttributeDefinitionGraphql,
+  AttributeDefinition,
+} from '../..';
 import {
   CompatModelBuilder,
   GraphqlModelBuilder,
@@ -36,6 +40,6 @@ export const compatPreset = (): TBuilder<TProductType> =>
   CompatModelBuilder()
     .name('T-shirt Product Type')
     .attributes([
-      AttributeDefinitionRest.presets.countryOfOrigin().buildRest(),
-      AttributeDefinitionRest.presets.size().buildRest(),
+      AttributeDefinition.presets.countryOfOrigin().buildRest(),
+      AttributeDefinition.presets.size().buildRest(),
     ]);

--- a/standalone/src/models/product-type/product-type/presets/tshirt.ts
+++ b/standalone/src/models/product-type/product-type/presets/tshirt.ts
@@ -19,8 +19,8 @@ export const restPreset = (): TBuilder<TProductTypeRest> =>
   RestModelBuilder()
     .name('T-shirt Product Type')
     .attributes([
-      AttributeDefinitionRest.presets.countryOfOrigin().buildRest(),
-      AttributeDefinitionRest.presets.size().buildRest(),
+      AttributeDefinitionRest.presets.countryOfOrigin().build(),
+      AttributeDefinitionRest.presets.size().build(),
     ]);
 
 export const graphqlPreset = (): TBuilder<TProductTypeGraphql> =>
@@ -28,8 +28,8 @@ export const graphqlPreset = (): TBuilder<TProductTypeGraphql> =>
     .name('T-shirt Product Type')
     .attributeDefinitions({
       results: [
-        AttributeDefinitionGraphql.presets.countryOfOrigin().buildGraphql(),
-        AttributeDefinitionGraphql.presets.size().buildGraphql(),
+        AttributeDefinitionGraphql.presets.countryOfOrigin().build(),
+        AttributeDefinitionGraphql.presets.size().build(),
       ],
       total: 1,
       offset: 0,

--- a/standalone/src/models/product/product-projection/builder.spec.ts
+++ b/standalone/src/models/product/product-projection/builder.spec.ts
@@ -4,7 +4,7 @@ import { createBuilderSpec } from '@/core/test-utils';
 import { Category } from '@/models/category';
 import { LocalizedString } from '@/models/commons';
 import { ProductVariant } from '@/models/product/product';
-import { ProductType } from '@/models/product-type';
+import { ProductTypeGraphql } from '@/models/product-type';
 import { State } from '@/models/state';
 import { TaxCategory } from '@/models/tax-category';
 import { TProductProjectionGraphql, TProductProjectionRest } from './types';
@@ -175,7 +175,7 @@ describe('builder', () => {
         .id('happy-cow-milk-id')
         .key('happy-cow-milk-key')
         .metaKeywordsAllLocales(LocalizedString.presets.empty().en('happy'))
-        .productType(ProductType.presets.milk().id('product-type-id'))
+        .productType(ProductTypeGraphql.presets.milk().id('product-type-id'))
         .reviewRatingStatistics({
           averageRating: 3.12345,
           highestRating: 4.9,

--- a/standalone/src/models/product/product-projection/presets/happy-cow-milk.ts
+++ b/standalone/src/models/product/product-projection/presets/happy-cow-milk.ts
@@ -1,7 +1,7 @@
 import { TBuilder } from '@/core';
 import { LocalizedString, Reference } from '@/models/commons';
 import { ProductVariant } from '@/models/product/product';
-import { ProductType } from '@/models/product-type';
+import { ProductTypeGraphql, ProductTypeRest } from '@/models/product-type';
 import { RestModelBuilder, GraphqlModelBuilder } from '../builders';
 import { TProductProjectionGraphql, TProductProjectionRest } from '../types';
 
@@ -37,7 +37,9 @@ export const restPreset = (): TBuilder<TProductProjectionRest> => {
     .metaTitle(productName)
     .metaDescription(productDescription)
     .productType(
-      Reference.presets.productTypeReference().obj(ProductType.presets.milk())
+      Reference.presets
+        .productTypeReference()
+        .obj(ProductTypeRest.presets.milk())
     );
 };
 
@@ -48,5 +50,5 @@ export const graphqlPreset = (): TBuilder<TProductProjectionGraphql> => {
     .descriptionAllLocales(productDescription)
     .metaTitleAllLocales(productName)
     .metaDescriptionAllLocales(productDescription)
-    .productType(ProductType.presets.milk());
+    .productType(ProductTypeGraphql.presets.milk());
 };

--- a/standalone/src/models/product/product/product/presets/boring-generic-milk.ts
+++ b/standalone/src/models/product/product/product/presets/boring-generic-milk.ts
@@ -1,6 +1,10 @@
 import type { TBuilder } from '@/core';
 import { ReferenceRest } from '@/models/commons';
-import { ProductType } from '@/models/product-type';
+import {
+  ProductType,
+  ProductTypeGraphql,
+  ProductTypeRest,
+} from '@/models/product-type';
 import {
   ProductCatalogData,
   ProductCatalogDataGraphql,
@@ -18,7 +22,7 @@ export const restPreset = (): TBuilder<TProductRest> => {
     .productType(
       ReferenceRest.presets
         .productTypeReference()
-        .obj(ProductType.presets.milk())
+        .obj(ProductTypeRest.presets.milk())
     );
 };
 
@@ -28,7 +32,7 @@ export const graphqlPreset = (): TBuilder<TProductGraphql> => {
     .masterData(
       ProductCatalogDataGraphql.presets.boringGenericMilkProductCatalogData()
     )
-    .productType(ProductType.presets.milk());
+    .productType(ProductTypeGraphql.presets.milk());
 };
 
 export const compatPreset = (): TBuilder<TProduct> => {

--- a/standalone/src/models/product/product/product/presets/happy-cow-milk.ts
+++ b/standalone/src/models/product/product/product/presets/happy-cow-milk.ts
@@ -1,6 +1,10 @@
 import type { TBuilder } from '@/core';
 import { ReferenceRest } from '@/models/commons';
-import { ProductType } from '@/models/product-type';
+import {
+  ProductType,
+  ProductTypeGraphql,
+  ProductTypeRest,
+} from '@/models/product-type';
 import {
   ProductCatalogDataRest,
   ProductCatalogDataGraphql,
@@ -16,7 +20,7 @@ export const restPreset = (): TBuilder<TProductRest> => {
     .productType(
       ReferenceRest.presets
         .productTypeReference()
-        .obj(ProductType.presets.milk())
+        .obj(ProductTypeRest.presets.milk())
     );
 };
 
@@ -26,7 +30,7 @@ export const graphqlPreset = (): TBuilder<TProductGraphql> => {
     .masterData(
       ProductCatalogDataGraphql.presets.happyCowMilkProductCatalogData()
     )
-    .productType(ProductType.presets.milk());
+    .productType(ProductTypeGraphql.presets.milk());
 };
 
 export const compatPreset = (): TBuilder<TProduct> => {


### PR DESCRIPTION
## Description

### Additions

We're introducing a new preset in the `ProductType` test data model which should help consumers building objects.

#### ProductType

New `tshirt` preset which populates all the model properties.
Example:

```ts
import { ProductTypeGraphql } from '@commercetools/composable-commerce-test-data/product-type';

const tshirt = ProductTypeGraphql.presets.tshirt().build();
```