### PR TITLE
New OrdersListView test data model

### DIFF
--- a/.changeset/sharp-actors-type.md
+++ b/.changeset/sharp-actors-type.md
@@ -1,0 +1,16 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+---
+
+We're introducing a new model named `OrdersListListView` can be consumed from the `@commercetools/composable-commerce-test-data/my-view` entry point.
+
+There's only a GraphQL version for this model as it only exists in the MC Settings services which only expose a GraphQL API.
+
+This is how the new model could be used:
+
+```
+import {
+  OrdersListViewGraphql,
+} from '@commercetools/composable-commerce-test-data/my-view';
+const ordersListView = OrdersListViewGraphql.random().build();
+```

--- a/standalone/src/models/my-view/index.ts
+++ b/standalone/src/models/my-view/index.ts
@@ -1,11 +1,13 @@
 export * from './my-view-nested-table/types';
 export * from './my-view-sort/types';
 export * from './my-view-table/types';
+export * from './orders-list-view/types';
 export * from './pim-search-list-view/types';
 export * from './variant-prices-list-view/types';
 
 export * from './my-view-nested-table';
 export * from './my-view-sort';
 export * from './my-view-table';
+export * from './orders-list-view';
 export * from './pim-search-list-view';
 export * from './variant-prices-list-view';

--- a/standalone/src/models/my-view/orders-list-view/builders.spec.ts
+++ b/standalone/src/models/my-view/orders-list-view/builders.spec.ts
@@ -1,0 +1,25 @@
+import { OrdersListViewGraphql } from './index';
+
+describe('OrdersListView Builder', () => {
+  it('should build properties for the GraphQL representation', () => {
+    const graphqlModel = OrdersListViewGraphql.random().build();
+
+    expect(graphqlModel).toEqual(
+      expect.objectContaining({
+        createdAt: expect.any(String),
+        filters: [],
+        id: expect.any(String),
+        isActive: true,
+        nameAllLocales: null,
+        projectKey: expect.any(String),
+        search: null,
+        searchParams: null,
+        sort: null,
+        table: null,
+        updatedAt: expect.any(String),
+        userId: expect.any(String),
+        __typename: 'OrdersListView',
+      })
+    );
+  });
+});

--- a/standalone/src/models/my-view/orders-list-view/builders.ts
+++ b/standalone/src/models/my-view/orders-list-view/builders.ts
@@ -1,0 +1,10 @@
+import { createSpecializedBuilder } from '@/core';
+import { graphqlFieldsConfig } from './fields-config';
+import type { TCreateOrdersListViewBuilder } from './types';
+
+export const GraphqlModelBuilder: TCreateOrdersListViewBuilder = () =>
+  createSpecializedBuilder({
+    name: 'OrdersListViewGraphqlBuilder',
+    type: 'graphql',
+    modelFieldsConfig: graphqlFieldsConfig,
+  });

--- a/standalone/src/models/my-view/orders-list-view/fields-config.ts
+++ b/standalone/src/models/my-view/orders-list-view/fields-config.ts
@@ -1,0 +1,23 @@
+import { fake, type TModelFieldsConfig } from '@/core';
+import { createRelatedDates } from '@/utils';
+import type { TOrdersListViewGraphql } from './types';
+
+const [getOlderDate, getNewerDate] = createRelatedDates();
+
+export const graphqlFieldsConfig: TModelFieldsConfig<TOrdersListViewGraphql> = {
+  fields: {
+    createdAt: fake(getOlderDate),
+    filters: [],
+    id: fake((f) => f.string.uuid()),
+    isActive: fake(() => true),
+    nameAllLocales: null,
+    projectKey: fake((f) => f.lorem.slug(2)),
+    search: null,
+    searchParams: null,
+    sort: null,
+    table: null,
+    updatedAt: fake(getNewerDate),
+    userId: fake((f) => f.string.uuid()),
+    __typename: 'OrdersListView',
+  },
+};

--- a/standalone/src/models/my-view/orders-list-view/index.ts
+++ b/standalone/src/models/my-view/orders-list-view/index.ts
@@ -1,0 +1,10 @@
+import { GraphqlModelBuilder } from './builders';
+import * as OrdersListViewPresets from './presets';
+
+// This model does not have a REST version as it only exists in the MC Settings service
+// which only supports GraphQL.
+
+export const OrdersListViewGraphql = {
+  random: GraphqlModelBuilder,
+  presets: OrdersListViewPresets.graphqlPresets,
+};

--- a/standalone/src/models/my-view/orders-list-view/presets/index.ts
+++ b/standalone/src/models/my-view/orders-list-view/presets/index.ts
@@ -1,0 +1,1 @@
+export const graphqlPresets = {};

--- a/standalone/src/models/my-view/orders-list-view/types.ts
+++ b/standalone/src/models/my-view/orders-list-view/types.ts
@@ -1,0 +1,10 @@
+import type { TBuilder } from '@/core';
+import { TMcSettingsOrdersListView } from '@/graphql-types';
+
+// This model does not have a REST version as it only exists in the MC Settings service
+// which only supports GraphQL.
+
+export type TOrdersListViewGraphql = TMcSettingsOrdersListView;
+
+export type TCreateOrdersListViewBuilder =
+  () => TBuilder<TOrdersListViewGraphql>;


### PR DESCRIPTION
## Description

We're introducing a new model named `OrdersListListView` can be consumed from the `@commercetools/composable-commerce-test-data/my-view` entry point.

There's only a GraphQL version for this model as it only exists in the MC Settings services which only expose a GraphQL API.

This is how the new model could be used:

```
import {
  OrdersListViewGraphql,
} from '@commercetools/composable-commerce-test-data/my-view';
const ordersListView = OrdersListViewGraphql.random().build();
```