### PR TITLE
feat(product-type): add new models for attribute-nested-type under pr…

### DIFF
--- a/.changeset/sixty-pans-refuse.md
+++ b/.changeset/sixty-pans-refuse.md
@@ -1,5 +1,0 @@
----
-'@commercetools/composable-commerce-test-data': minor
----
-
-Add model for attribute-nested-type

--- a/.changeset/sixty-pans-refuse.md
+++ b/.changeset/sixty-pans-refuse.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+---
+
+Add model for attribute-nested-type

--- a/.changeset/tiny-lamps-deny.md
+++ b/.changeset/tiny-lamps-deny.md
@@ -1,0 +1,19 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+---
+
+We're introducing new models named `AttributeNestedTypeRest` and `AttributeNestedTypeGraphQl` that can be consumed from the `@commercetools/composable-commerce-test-data/product-type` entry point.
+
+This is how the new models could be used:
+
+```ts
+import { AttributeNestedTypeRest } from '@commercetools/composable-commerce-test-data/product-type';
+
+const model = AttributeNestedTypeRest.random().build();
+```
+
+```ts
+import { AttributeNestedTypeGraphql } from '@commercetools/composable-commerce-test-data/product-type';
+
+const model = AttributeNestedTypeGraphql.random().build();
+```

--- a/.changeset/tiny-lamps-deny.md
+++ b/.changeset/tiny-lamps-deny.md
@@ -2,18 +2,16 @@
 '@commercetools/composable-commerce-test-data': minor
 ---
 
-We're introducing new models named `AttributeNestedTypeRest` and `AttributeNestedTypeGraphQl` that can be consumed from the `@commercetools/composable-commerce-test-data/product-type` entry point.
+We're introducing a new test data model named `AttributeNestedType` that can be consumed from the `@commercetools/composable-commerce-test-data/product-type` entry point.
 
-This is how the new models could be used:
-
-```ts
-import { AttributeNestedTypeRest } from '@commercetools/composable-commerce-test-data/product-type';
-
-const model = AttributeNestedTypeRest.random().build();
-```
+This is how it could be used:
 
 ```ts
-import { AttributeNestedTypeGraphql } from '@commercetools/composable-commerce-test-data/product-type';
+import {
+  AttributeNestedTypeGraphql,
+  AttributeNestedTypeRest,
+} from '@commercetools/composable-commerce-test-data/product-type';
 
-const model = AttributeNestedTypeGraphql.random().build();
+const restModel = AttributeNestedTypeRest.random().build();
+const graphqlModel = AttributeNestedTypeGraphql.random().build();
 ```

--- a/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/builders.spec.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/builders.spec.ts
@@ -1,0 +1,44 @@
+import {
+  TAttributeNestedTypeDraftGraphql,
+  TAttributeNestedTypeDraftRest,
+} from '../types';
+import {
+  AttributeNestedTypeDraftGraphql,
+  AttributeNestedTypeDraftRest,
+} from './index';
+
+const validateRestModel = (model: TAttributeNestedTypeDraftRest): void => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      name: 'nested',
+      typeReference: expect.objectContaining({
+        id: expect.any(String),
+        typeId: 'product-type',
+      }),
+    })
+  );
+};
+
+const validateGraphqlModel = (
+  model: TAttributeNestedTypeDraftGraphql
+): void => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      dummy: 'nested',
+    })
+  );
+};
+
+describe('AttributeNestedTypeDraft model builders', () => {
+  it('builds a REST model', () => {
+    const restModel = AttributeNestedTypeDraftRest.random().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = AttributeNestedTypeDraftGraphql.random().build();
+
+    validateGraphqlModel(graphqlModel);
+  });
+});

--- a/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/builders.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/builders.ts
@@ -1,0 +1,25 @@
+import { createSpecializedBuilder } from '@/core';
+import type {
+  TCreateAttributeNestedTypeBuilder,
+  TAttributeNestedTypeDraftGraphql,
+  TAttributeNestedTypeDraftRest,
+} from '../types';
+import { restFieldsConfig, graphqlFieldsConfig } from './fields-config';
+
+export const RestModelBuilder: TCreateAttributeNestedTypeBuilder<
+  TAttributeNestedTypeDraftRest
+> = () =>
+  createSpecializedBuilder({
+    name: 'AttributeNestedTypeDraftRestBuilder',
+    type: 'rest',
+    modelFieldsConfig: restFieldsConfig,
+  });
+
+export const GraphqlModelBuilder: TCreateAttributeNestedTypeBuilder<
+  TAttributeNestedTypeDraftGraphql
+> = () =>
+  createSpecializedBuilder({
+    name: 'AttributeNestedTypeDraftGraphqlBuilder',
+    type: 'graphql',
+    modelFieldsConfig: graphqlFieldsConfig,
+  });

--- a/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/fields-config.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/fields-config.ts
@@ -1,5 +1,5 @@
 import { fake, TModelFieldsConfig } from '@/core';
-import { ReferenceDraftRest, ReferenceDraftGraphql } from '@/models/commons';
+import { ReferenceDraftRest } from '@/models/commons';
 import {
   TAttributeNestedTypeDraftGraphql,
   TAttributeNestedTypeDraftRest,

--- a/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/fields-config.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/fields-config.ts
@@ -1,0 +1,25 @@
+import { fake, TModelFieldsConfig } from '@/core';
+import { ReferenceDraftRest, ReferenceDraftGraphql } from '@/models/commons';
+import {
+  TAttributeNestedTypeDraftGraphql,
+  TAttributeNestedTypeDraftRest,
+} from '../types';
+
+// https://docs.commercetools.com/api/projects/productTypes#attributenestedtype
+
+export const restFieldsConfig: TModelFieldsConfig<TAttributeNestedTypeDraftRest> =
+  {
+    fields: {
+      name: fake(() => 'nested'),
+      typeReference: fake(() =>
+        ReferenceDraftRest.presets.productTypeReference()
+      ),
+    },
+  };
+
+export const graphqlFieldsConfig: TModelFieldsConfig<TAttributeNestedTypeDraftGraphql> =
+  {
+    fields: {
+      dummy: 'nested',
+    },
+  };

--- a/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/index.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/index.ts
@@ -1,0 +1,12 @@
+import { RestModelBuilder, GraphqlModelBuilder } from './builders';
+import * as modelPresets from './presets';
+
+export const AttributeNestedTypeDraftRest = {
+  random: RestModelBuilder,
+  presets: modelPresets.restPresets,
+};
+
+export const AttributeNestedTypeDraftGraphql = {
+  random: GraphqlModelBuilder,
+  presets: modelPresets.graphqlPresets,
+};

--- a/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/presets/index.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/presets/index.ts
@@ -1,0 +1,3 @@
+export const restPresets = {};
+export const graphqlPresets = {};
+export const compatPresets = {};

--- a/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/presets/index.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/attribute-nested-type-draft/presets/index.ts
@@ -1,3 +1,2 @@
 export const restPresets = {};
 export const graphqlPresets = {};
-export const compatPresets = {};

--- a/standalone/src/models/product-type/attribute-nested-type/builders.spec.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/builders.spec.ts
@@ -1,41 +1,32 @@
-import { TAttributeNestedTypeGraphql, TAttributeNestedTypeRest } from './types';
 import { AttributeNestedTypeGraphql, AttributeNestedTypeRest } from './index';
 
-function validateRestModel(model: TAttributeNestedTypeRest) {
-  expect(model).toEqual(
-    expect.objectContaining({
-      name: 'nested',
-      typeReference: expect.objectContaining({
-        id: expect.any(String),
-        typeId: 'product-type',
-      }),
-    })
-  );
-}
-
-function validateGraphqlModel(model: TAttributeNestedTypeGraphql) {
-  expect(model).toEqual(
-    expect.objectContaining({
-      name: 'nested',
-      typeRef: expect.objectContaining({
-        id: expect.any(String),
-        typeId: 'product',
-      }),
-    })
-  );
-}
-
-describe('AttributeMoneyType model builders', () => {
+describe('AttributeNestedType model builders', () => {
   it('builds a REST model', () => {
     const restModel = AttributeNestedTypeRest.random().build();
 
-    validateRestModel(restModel);
+    expect(restModel).toEqual(
+      expect.objectContaining({
+        name: 'nested',
+        typeReference: expect.objectContaining({
+          id: expect.any(String),
+          typeId: 'product-type',
+        }),
+      })
+    );
   });
 
   it('builds a GraphQL model', () => {
     const graphqlModel = AttributeNestedTypeGraphql.random().build();
 
-    validateGraphqlModel(graphqlModel);
-    expect(graphqlModel.__typename).toEqual('NestedAttributeDefinitionType');
+    expect(graphqlModel).toEqual(
+      expect.objectContaining({
+        name: 'nested',
+        typeRef: expect.objectContaining({
+          typeId: 'product-type',
+          __typename: 'Reference',
+        }),
+        __typename: 'NestedAttributeDefinitionType',
+      })
+    );
   });
 });

--- a/standalone/src/models/product-type/attribute-nested-type/builders.spec.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/builders.spec.ts
@@ -1,0 +1,41 @@
+import { TAttributeNestedTypeGraphql, TAttributeNestedTypeRest } from './types';
+import { AttributeNestedTypeGraphql, AttributeNestedTypeRest } from './index';
+
+function validateRestModel(model: TAttributeNestedTypeRest) {
+  expect(model).toEqual(
+    expect.objectContaining({
+      name: 'nested',
+      typeReference: expect.objectContaining({
+        id: expect.any(String),
+        typeId: 'product-type',
+      }),
+    })
+  );
+}
+
+function validateGraphqlModel(model: TAttributeNestedTypeGraphql) {
+  expect(model).toEqual(
+    expect.objectContaining({
+      name: 'nested',
+      typeRef: expect.objectContaining({
+        id: expect.any(String),
+        typeId: 'product',
+      }),
+    })
+  );
+}
+
+describe('AttributeMoneyType model builders', () => {
+  it('builds a REST model', () => {
+    const restModel = AttributeNestedTypeRest.random().build();
+
+    validateRestModel(restModel);
+  });
+
+  it('builds a GraphQL model', () => {
+    const graphqlModel = AttributeNestedTypeGraphql.random().build();
+
+    validateGraphqlModel(graphqlModel);
+    expect(graphqlModel.__typename).toEqual('NestedAttributeDefinitionType');
+  });
+});

--- a/standalone/src/models/product-type/attribute-nested-type/builders.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/builders.ts
@@ -1,0 +1,25 @@
+import { createSpecializedBuilder } from '@/core';
+import { restFieldsConfig, graphqlFieldsConfig } from './fields-config';
+import type {
+  TCreateAttributeNestedTypeBuilder,
+  TAttributeNestedTypeGraphql,
+  TAttributeNestedTypeRest,
+} from './types';
+
+export const RestModelBuilder: TCreateAttributeNestedTypeBuilder<
+  TAttributeNestedTypeRest
+> = () =>
+  createSpecializedBuilder({
+    name: 'AttributeNestedTypeRestBuilder',
+    type: 'rest',
+    modelFieldsConfig: restFieldsConfig,
+  });
+
+export const GraphqlModelBuilder: TCreateAttributeNestedTypeBuilder<
+  TAttributeNestedTypeGraphql
+> = () =>
+  createSpecializedBuilder({
+    name: 'AttributeNestedTypeGraphqlBuilder',
+    type: 'graphql',
+    modelFieldsConfig: graphqlFieldsConfig,
+  });

--- a/standalone/src/models/product-type/attribute-nested-type/fields-config.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/fields-config.ts
@@ -1,0 +1,25 @@
+import { fake, TModelFieldsConfig } from '@/core';
+import { ReferenceGraphql, ReferenceRest } from '@/models/commons';
+import { TAttributeNestedTypeGraphql, TAttributeNestedTypeRest } from './types';
+
+// https://docs.commercetools.com/api/projects/productTypes#attributenestedtype
+
+const commonFieldsConfig = {
+  name: fake(() => 'nested'),
+};
+
+export const restFieldsConfig: TModelFieldsConfig<TAttributeNestedTypeRest> = {
+  fields: {
+    ...commonFieldsConfig,
+    typeReference: fake(() => ReferenceRest.presets.productTypeReference()),
+  },
+};
+
+export const graphqlFieldsConfig: TModelFieldsConfig<TAttributeNestedTypeGraphql> =
+  {
+    fields: {
+      ...commonFieldsConfig,
+      typeRef: fake(() => ReferenceGraphql.presets.productReference()),
+      __typename: 'NestedAttributeDefinitionType',
+    },
+  };

--- a/standalone/src/models/product-type/attribute-nested-type/fields-config.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/fields-config.ts
@@ -5,7 +5,7 @@ import { TAttributeNestedTypeGraphql, TAttributeNestedTypeRest } from './types';
 // https://docs.commercetools.com/api/projects/productTypes#attributenestedtype
 
 const commonFieldsConfig = {
-  name: fake(() => 'nested'),
+  name: 'nested',
 };
 
 export const restFieldsConfig: TModelFieldsConfig<TAttributeNestedTypeRest> = {
@@ -19,7 +19,7 @@ export const graphqlFieldsConfig: TModelFieldsConfig<TAttributeNestedTypeGraphql
   {
     fields: {
       ...commonFieldsConfig,
-      typeRef: fake(() => ReferenceGraphql.presets.productReference()),
+      typeRef: fake(() => ReferenceGraphql.presets.productTypeReference()),
       __typename: 'NestedAttributeDefinitionType',
     },
   };

--- a/standalone/src/models/product-type/attribute-nested-type/index.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/index.ts
@@ -1,0 +1,12 @@
+import { RestModelBuilder, GraphqlModelBuilder } from './builders';
+import * as modelPresets from './presets';
+
+export const AttributeNestedTypeRest = {
+  random: RestModelBuilder,
+  presets: modelPresets.restPresets,
+};
+
+export const AttributeNestedTypeGraphql = {
+  random: GraphqlModelBuilder,
+  presets: modelPresets.graphqlPresets,
+};

--- a/standalone/src/models/product-type/attribute-nested-type/presets/index.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/presets/index.ts
@@ -1,0 +1,3 @@
+export const restPresets = {};
+export const graphqlPresets = {};
+export const compatPresets = {};

--- a/standalone/src/models/product-type/attribute-nested-type/presets/index.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/presets/index.ts
@@ -1,3 +1,2 @@
 export const restPresets = {};
 export const graphqlPresets = {};
-export const compatPresets = {};

--- a/standalone/src/models/product-type/attribute-nested-type/types.ts
+++ b/standalone/src/models/product-type/attribute-nested-type/types.ts
@@ -1,0 +1,23 @@
+import type { AttributeNestedType } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@/core';
+import {
+  TCtpNestedAttributeDefinitionType,
+  TCtpSimpleAttributeTypeDraft,
+} from '@/graphql-types';
+
+// REST types
+export type TAttributeNestedTypeRest = AttributeNestedType;
+export type TAttributeNestedTypeDraftRest = AttributeNestedType;
+
+// GraphQL types
+export type TAttributeNestedTypeGraphql = TCtpNestedAttributeDefinitionType;
+export type TAttributeNestedTypeDraftGraphql = TCtpSimpleAttributeTypeDraft;
+
+// Builders types
+export type TCreateAttributeNestedTypeBuilder<
+  TAttributeNestedTypeModel extends
+    | TAttributeNestedTypeRest
+    | TAttributeNestedTypeDraftRest
+    | TAttributeNestedTypeGraphql
+    | TAttributeNestedTypeDraftGraphql,
+> = () => TBuilder<TAttributeNestedTypeModel>;

--- a/standalone/src/models/product-type/index.ts
+++ b/standalone/src/models/product-type/index.ts
@@ -35,6 +35,8 @@ export * from './attribute-localized-enum-value';
 export * from './attribute-localized-enum-value/attribute-localized-enum-value-draft';
 export * from './attribute-localizable-text-type';
 export * from './attribute-localizable-text-type/attribute-localized-text-type-draft';
+export * from './attribute-nested-type';
+export * from './attribute-nested-type/attribute-nested-type-draft';
 export * from './attribute-number-type';
 export * from './attribute-number-type/attribute-number-type-draft';
 export * from './attribute-money-type';

--- a/standalone/src/models/product-type/index.ts
+++ b/standalone/src/models/product-type/index.ts
@@ -7,6 +7,7 @@ export * from './attribute-enum-type/types';
 export * from './attribute-localized-enum-type/types';
 export * from './attribute-localized-enum-value/types';
 export * from './attribute-localizable-text-type/types';
+export * from './attribute-nested-type/types';
 export * from './attribute-number-type/types';
 export * from './attribute-money-type/types';
 export * from './attribute-plain-enum-value/types';


### PR DESCRIPTION
We're introducing new models named `AttributeNestedTypeRest` and `AttributeNestedTypeGraphQl` that can be consumed from the `@commercetools/composable-commerce-test-data/product-type` entry point.

This is how the new models could be used:

```ts
import { AttributeNestedTypeRest } from '@commercetools/composable-commerce-test-data/product-type';

const model = AttributeNestedTypeRest.random().build();
```

```ts
import { AttributeNestedTypeGraphql } from '@commercetools/composable-commerce-test-data/product-type';

const model = AttributeNestedTypeGraphql.random().build();
```
