### PR TITLE
fix: wrong builder name when generating draft models

### DIFF
--- a/generators/src/new-test-model/new-test-model.generator.ts
+++ b/generators/src/new-test-model/new-test-model.generator.ts
@@ -176,7 +176,7 @@ export const newTestModelGenerator: CodeGenerator = {
             isPresetExampleRequired,
             modelName: `${modelName}Draft`,
             modelCodename: `${modelCodename}-draft`,
-            nonDraftModelName: modelName,
+            baseModelName: modelName,
             graphqlTypePrefix,
           }),
           { encoding: 'utf-8' }

--- a/generators/src/new-test-model/templates/model/builders.tpl
+++ b/generators/src/new-test-model/templates/model/builders.tpl
@@ -1,15 +1,15 @@
 import { createSpecializedBuilder } from '@/core';
 import { restFieldsConfig, graphqlFieldsConfig } from './fields-config';
-import type { TCreate{{@if(it.isDraftModel !== true)}}{{it.modelName}}{{#else}}{{it.nonDraftModelName}}{{/if}}Builder, T{{it.modelName}}Graphql, T{{it.modelName}}Rest } from '{{@if(it.isDraftModel !== true)}}.{{#else}}..{{/if}}/types';
+import type { TCreate{{@if(it.isDraftModel !== true)}}{{it.modelName}}{{#else}}{{it.baseModelName}}{{/if}}Builder, T{{it.modelName}}Graphql, T{{it.modelName}}Rest } from '{{@if(it.isDraftModel !== true)}}.{{#else}}..{{/if}}/types';
 
-export const RestModelBuilder: TCreate{{@if(it.isDraftModel !== true)}}{{it.modelName}}{{#else}}{{it.nonDraftModelName}}{{/if}}Builder<T{{it.modelName}}Rest> = () =>
+export const RestModelBuilder: TCreate{{@if(it.isDraftModel !== true)}}{{it.modelName}}{{#else}}{{it.baseModelName}}{{/if}}Builder<T{{it.modelName}}Rest> = () =>
   createSpecializedBuilder({
     name: '{{it.modelName}}RestBuilder',
     type: 'rest',
     modelFieldsConfig: restFieldsConfig,
   });
 
-export const GraphqlModelBuilder: TCreate{{@if(it.isDraftModel !== true)}}{{it.modelName}}{{#else}}{{it.nonDraftModelName}}{{/if}}Builder<T{{it.modelName}}Graphql> = () =>
+export const GraphqlModelBuilder: TCreate{{@if(it.isDraftModel !== true)}}{{it.modelName}}{{#else}}{{it.baseModelName}}{{/if}}Builder<T{{it.modelName}}Graphql> = () =>
   createSpecializedBuilder({
     name: '{{it.modelName}}GraphqlBuilder',
     type: 'graphql',


### PR DESCRIPTION
I just run `pnpm generate-model` to create some models and I realized that the name of the builder type for draft  models is wrong.
Is 
```ts
import type {
  TCreateDiscountGroupDraftBuilder,
  TDiscountGroupDraftGraphql,
  TDiscountGroupDraftRest,
} from '../types';
```
and should be
```ts
import type {
  TCreateDiscountGroupBuilder,
  TDiscountGroupDraftGraphql,
  TDiscountGroupDraftRest,
} from '../types';
```

I've introduced a new property (`nonDraftModelName`) when running `renderTemplate` for draft models.
Let me know if any other approach suits best with repo guidelines.