### PR TITLE
chore: Adding discount code info model

### DIFF
--- a/.changeset/sixty-years-travel.md
+++ b/.changeset/sixty-years-travel.md
@@ -1,0 +1,18 @@
+---
+'@commercetools/composable-commerce-test-data': patch
+---
+
+We're introducing a new model named `DiscountCodeInfo` that can be consumed from the `@commercetools/composable-commerce-test-data/cart` entry point.
+
+This is how the new model could be used:
+
+```ts
+import {
+  DiscountCodeInfoRest,
+  DiscountCodeInfoGraphql,
+} from '@commercetools/composable-commerce-test-data/cart';
+
+const restDiscountCodeInfo = DiscountCodeInfoRest.random().build();
+
+const graphqlDiscountCodeInfo = DiscountCodeInfoGraphql.random().build();
+```

--- a/standalone/src/models/cart/cart/cart/builders.spec.ts
+++ b/standalone/src/models/cart/cart/cart/builders.spec.ts
@@ -3,6 +3,7 @@ import { Company } from '@/models/business-unit';
 import { KeyReference, Reference } from '@/models/commons';
 import { CustomerGroup } from '@/models/customer/customer-group';
 import { CustomFieldBooleanType } from '@/models/type';
+import { DiscountCodeInfoRest, DiscountCodeInfoGraphql } from '../index';
 import { LineItem } from '../line-item';
 import { cartState } from './constants';
 import type { TCart, TCartGraphql, TCartRest } from './types';
@@ -47,7 +48,6 @@ const validateCommonFields = (model: TCartRest | TCartGraphql) => {
       origin: expect.any(String),
       shippingMode: expect.any(String),
       shipping: expect.arrayContaining([]),
-      discountCodes: expect.arrayContaining([expect.any(String)]),
       createdAt: expect.any(String),
       lastModifiedAt: expect.any(String),
       cartState: expect.any(String),
@@ -78,6 +78,18 @@ const validateRestModel = (model: TCartRest) => {
         expect.objectContaining({
           id: expect.any(String),
           quantity: expect.any(Number),
+        }),
+      ]),
+      discountCodes: expect.arrayContaining([
+        expect.objectContaining({
+          discountCode: expect.objectContaining({
+            id: expect.any(String),
+            typeId: 'discount-code',
+            obj: expect.any(Object),
+          }),
+          state: expect.toBeOneOf(
+            Object.values(DiscountCodeInfoRest.constants.discountCodeState)
+          ),
         }),
       ]),
       customerGroup: expect.objectContaining({
@@ -132,6 +144,20 @@ const validateGraphqlModel = (model: TCartGraphql) => {
       lineItems: expect.arrayContaining([
         expect.objectContaining({
           __typename: 'LineItem',
+        }),
+      ]),
+      discountCodes: expect.arrayContaining([
+        expect.objectContaining({
+          discountCode: expect.objectContaining({
+            __typename: 'DiscountCode',
+          }),
+          discountCodeRef: expect.objectContaining({
+            typeId: 'discount-code',
+            __typename: 'Reference',
+          }),
+          state: expect.toBeOneOf(
+            Object.values(DiscountCodeInfoGraphql.constants.discountCodeState)
+          ),
         }),
       ]),
       shippingAddress: expect.objectContaining({

--- a/standalone/src/models/cart/cart/cart/builders.spec.ts
+++ b/standalone/src/models/cart/cart/cart/builders.spec.ts
@@ -88,7 +88,7 @@ const validateRestModel = (model: TCartRest) => {
             obj: expect.any(Object),
           }),
           state: expect.toBeOneOf(
-            Object.values(DiscountCodeInfoRest.constants.state)
+            Object.values(DiscountCodeInfoRest.constants.states)
           ),
         }),
       ]),
@@ -156,7 +156,7 @@ const validateGraphqlModel = (model: TCartGraphql) => {
             __typename: 'Reference',
           }),
           state: expect.toBeOneOf(
-            Object.values(DiscountCodeInfoGraphql.constants.state)
+            Object.values(DiscountCodeInfoGraphql.constants.states)
           ),
         }),
       ]),

--- a/standalone/src/models/cart/cart/cart/builders.spec.ts
+++ b/standalone/src/models/cart/cart/cart/builders.spec.ts
@@ -88,7 +88,7 @@ const validateRestModel = (model: TCartRest) => {
             obj: expect.any(Object),
           }),
           state: expect.toBeOneOf(
-            Object.values(DiscountCodeInfoRest.constants.discountCodeState)
+            Object.values(DiscountCodeInfoRest.constants.state)
           ),
         }),
       ]),
@@ -156,7 +156,7 @@ const validateGraphqlModel = (model: TCartGraphql) => {
             __typename: 'Reference',
           }),
           state: expect.toBeOneOf(
-            Object.values(DiscountCodeInfoGraphql.constants.discountCodeState)
+            Object.values(DiscountCodeInfoGraphql.constants.state)
           ),
         }),
       ]),

--- a/standalone/src/models/cart/cart/cart/fields-config.ts
+++ b/standalone/src/models/cart/cart/cart/fields-config.ts
@@ -6,12 +6,18 @@ import {
   CentPrecisionMoney,
   ClientLogging,
   KeyReference,
-  Reference,
+  ReferenceGraphql,
+  ReferenceRest,
 } from '@/models/commons';
 import { CustomerGroup } from '@/models/customer/customer-group';
-import { Store } from '@/models/store';
+import { StoreGraphql } from '@/models/store';
 import { createRelatedDates } from '@/utils';
-import { LineItem } from '../index';
+import {
+  DiscountCodeInfoGraphql,
+  DiscountCodeInfoRest,
+  LineItemGraphql,
+  LineItemRest,
+} from '../index';
 import {
   cartState,
   inventoryMode,
@@ -38,7 +44,6 @@ const commonFieldsConfig = {
   taxMode: oneOf(...Object.values(taxMode)),
   taxRoundingMode: oneOf(...Object.values(taxRoundingMode)),
   taxCalculationMode: oneOf(...Object.values(taxCalculationMode)),
-  lineItems: fake(() => [LineItem.random()]),
   customLineItems: [],
   totalLineItemQuantity: fake((f) => f.number.int()),
   shippingAddress: fake(() => Address.random()),
@@ -52,7 +57,6 @@ const commonFieldsConfig = {
   shippingInfo: null,
   shipping: [],
   itemShippingAddresses: fake(() => [Address.random()]),
-  discountCodes: fake((f) => [f.lorem.word()]),
   directDiscounts: [],
   totalPrice: fake(() => CentPrecisionMoney.random()),
   taxedPrice: null,
@@ -72,10 +76,12 @@ const commonFieldsConfig = {
 export const restFieldsConfig: TModelFieldsConfig<TCartRest> = {
   fields: {
     ...commonFieldsConfig,
-    customerGroup: fake(() => Reference.random().typeId('customer-group')),
+    lineItems: fake(() => [LineItemRest.random()]),
+    discountCodes: fake((f) => [DiscountCodeInfoRest.random()]),
+    customerGroup: fake(() => ReferenceRest.presets.customerGroupReference()),
     businessUnit: fake(() => KeyReference.random().typeId('business-unit')),
     store: fake(() => KeyReference.random().typeId('store')),
-    refusedGifts: fake(() => [Reference.random().typeId('cart-discount')]),
+    refusedGifts: fake(() => [ReferenceRest.presets.cartDiscountReference()]),
     priceRoundingMode: oneOf(...Object.values(priceRoundingMode)),
   },
 };
@@ -84,11 +90,13 @@ export const graphqlFieldsConfig: TModelFieldsConfig<TCartGraphql> = {
   fields: {
     ...commonFieldsConfig,
     __typename: 'Cart',
+    discountCodes: fake(() => [DiscountCodeInfoGraphql.random()]),
+    lineItems: fake(() => [LineItemGraphql.random()]),
     customerGroup: fake(() => CustomerGroup.random()),
     customerGroupRef: null,
     businessUnit: fake(() => Company.random()),
     businessUnitRef: null,
-    store: fake(() => Store.random()),
+    store: fake(() => StoreGraphql.random()),
     storeRef: null,
     refusedGifts: fake(() => [CartDiscount.random()]),
     refusedGiftsRefs: null,
@@ -106,13 +114,13 @@ export const graphqlFieldsConfig: TModelFieldsConfig<TCartGraphql> = {
           .buildGraphql()
       : null;
     const customerGroupRef = model.customerGroup
-      ? Reference.presets
+      ? ReferenceGraphql.presets
           .customerGroupReference()
           .id(model.customerGroup.id)
           .buildGraphql()
       : null;
     const refusedGiftsRefs = model.refusedGifts.map((refusedGift) =>
-      Reference.presets
+      ReferenceGraphql.presets
         .cartDiscountReference()
         .id(refusedGift.id)
         .buildGraphql()

--- a/standalone/src/models/cart/cart/discount-code-info/builders.spec.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/builders.spec.ts
@@ -31,7 +31,6 @@ describe('DiscountCodeInfo Builder', () => {
         }),
         state: expect.toBeOneOf(Object.values(states)),
         __typename: 'DiscountCodeInfo',
-        states,
       })
     );
   });

--- a/standalone/src/models/cart/cart/discount-code-info/builders.spec.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/builders.spec.ts
@@ -1,4 +1,4 @@
-import { discountCodeState } from './constants';
+import { states } from './constants';
 import { DiscountCodeInfoRest, DiscountCodeInfoGraphql } from './index';
 
 describe('DiscountCodeInfo Builder', () => {
@@ -12,7 +12,7 @@ describe('DiscountCodeInfo Builder', () => {
           typeId: 'discount-code',
           obj: expect.any(Object),
         }),
-        state: expect.toBeOneOf(Object.values(discountCodeState)),
+        state: expect.toBeOneOf(Object.values(states)),
       })
     );
   });
@@ -29,8 +29,9 @@ describe('DiscountCodeInfo Builder', () => {
           typeId: 'discount-code',
           __typename: 'Reference',
         }),
-        state: expect.toBeOneOf(Object.values(discountCodeState)),
+        state: expect.toBeOneOf(Object.values(states)),
         __typename: 'DiscountCodeInfo',
+        states,
       })
     );
   });

--- a/standalone/src/models/cart/cart/discount-code-info/builders.spec.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/builders.spec.ts
@@ -1,0 +1,37 @@
+import { discountCodeState } from './constants';
+import { DiscountCodeInfoRest, DiscountCodeInfoGraphql } from './index';
+
+describe('DiscountCodeInfo Builder', () => {
+  it('should build properties for the REST representation', () => {
+    const restModel = DiscountCodeInfoRest.random().build();
+
+    expect(restModel).toEqual(
+      expect.objectContaining({
+        discountCode: expect.objectContaining({
+          id: expect.any(String),
+          typeId: 'discount-code',
+          obj: expect.any(Object),
+        }),
+        state: expect.toBeOneOf(Object.values(discountCodeState)),
+      })
+    );
+  });
+  it('should build properties for the GraphQL representation', () => {
+    const graphqlModel = DiscountCodeInfoGraphql.random().build();
+
+    console.log(graphqlModel);
+    expect(graphqlModel).toEqual(
+      expect.objectContaining({
+        discountCode: expect.objectContaining({
+          __typename: 'DiscountCode',
+        }),
+        discountCodeRef: expect.objectContaining({
+          typeId: 'discount-code',
+          __typename: 'Reference',
+        }),
+        state: expect.toBeOneOf(Object.values(discountCodeState)),
+        __typename: 'DiscountCodeInfo',
+      })
+    );
+  });
+});

--- a/standalone/src/models/cart/cart/discount-code-info/builders.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/builders.ts
@@ -1,0 +1,25 @@
+import { createSpecializedBuilder } from '@/core';
+import { restFieldsConfig, graphqlFieldsConfig } from './fields-config';
+import type {
+  TCreateDiscountCodeInfoBuilder,
+  TDiscountCodeInfoGraphql,
+  TDiscountCodeInfoRest,
+} from './types';
+
+export const RestModelBuilder: TCreateDiscountCodeInfoBuilder<
+  TDiscountCodeInfoRest
+> = () =>
+  createSpecializedBuilder({
+    name: 'DiscountCodeInfoRestBuilder',
+    type: 'rest',
+    modelFieldsConfig: restFieldsConfig,
+  });
+
+export const GraphqlModelBuilder: TCreateDiscountCodeInfoBuilder<
+  TDiscountCodeInfoGraphql
+> = () =>
+  createSpecializedBuilder({
+    name: 'DiscountCodeInfoGraphqlBuilder',
+    type: 'graphql',
+    modelFieldsConfig: graphqlFieldsConfig,
+  });

--- a/standalone/src/models/cart/cart/discount-code-info/constants.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/constants.ts
@@ -1,3 +1,3 @@
 import { TCtpDiscountCodeState } from '@/graphql-types';
 
-export const discountCodeState = TCtpDiscountCodeState;
+export const state = TCtpDiscountCodeState;

--- a/standalone/src/models/cart/cart/discount-code-info/constants.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/constants.ts
@@ -1,0 +1,3 @@
+import { TCtpDiscountCodeState } from '@/graphql-types';
+
+export const discountCodeState = TCtpDiscountCodeState;

--- a/standalone/src/models/cart/cart/discount-code-info/constants.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/constants.ts
@@ -1,3 +1,3 @@
 import { TCtpDiscountCodeState } from '@/graphql-types';
 
-export const state = TCtpDiscountCodeState;
+export const states = TCtpDiscountCodeState;

--- a/standalone/src/models/cart/cart/discount-code-info/fields-config.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/fields-config.ts
@@ -1,0 +1,39 @@
+import { fake, oneOf, type TModelFieldsConfig } from '@/core';
+import { ReferenceRest, ReferenceGraphql } from '@/models/commons';
+import { DiscountCode } from '@/models/discount/discount-code';
+import { discountCodeState } from './constants';
+import type { TDiscountCodeInfoGraphql, TDiscountCodeInfoRest } from './types';
+
+const commonFieldsConfig = {
+  state: oneOf(...Object.values(discountCodeState)),
+};
+
+export const restFieldsConfig: TModelFieldsConfig<TDiscountCodeInfoRest> = {
+  fields: {
+    ...commonFieldsConfig,
+    discountCode: fake(() => ReferenceRest.presets.discountCodeReference()),
+  },
+};
+
+export const graphqlFieldsConfig: TModelFieldsConfig<TDiscountCodeInfoGraphql> =
+  {
+    fields: {
+      ...commonFieldsConfig,
+      discountCode: fake(() => DiscountCode.random()),
+      discountCodeRef: null,
+      __typename: 'DiscountCodeInfo',
+    },
+    postBuild: (model) => {
+      const discountCodeRef = model.discountCode
+        ? ReferenceGraphql.presets
+            .discountCodeReference()
+            .id(model.discountCode.id)
+            .buildGraphql()
+        : model.discountCodeRef;
+
+      return {
+        ...model,
+        discountCodeRef,
+      };
+    },
+  };

--- a/standalone/src/models/cart/cart/discount-code-info/fields-config.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/fields-config.ts
@@ -1,11 +1,11 @@
 import { fake, oneOf, type TModelFieldsConfig } from '@/core';
 import { ReferenceRest, ReferenceGraphql } from '@/models/commons';
 import { DiscountCode } from '@/models/discount/discount-code';
-import { discountCodeState } from './constants';
+import { states } from './constants';
 import type { TDiscountCodeInfoGraphql, TDiscountCodeInfoRest } from './types';
 
 const commonFieldsConfig = {
-  state: oneOf(...Object.values(discountCodeState)),
+  state: oneOf(...Object.values(states)),
 };
 
 export const restFieldsConfig: TModelFieldsConfig<TDiscountCodeInfoRest> = {

--- a/standalone/src/models/cart/cart/discount-code-info/index.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/index.ts
@@ -1,0 +1,16 @@
+import { RestModelBuilder, GraphqlModelBuilder } from './builders';
+import * as constants from './constants';
+import * as DiscountCodeInfoPresets from './presets';
+export * from './types';
+
+export const DiscountCodeInfoRest = {
+  constants,
+  random: RestModelBuilder,
+  presets: DiscountCodeInfoPresets.restPresets,
+};
+
+export const DiscountCodeInfoGraphql = {
+  constants,
+  random: GraphqlModelBuilder,
+  presets: DiscountCodeInfoPresets.graphqlPresets,
+};

--- a/standalone/src/models/cart/cart/discount-code-info/index.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/index.ts
@@ -1,7 +1,6 @@
 import { RestModelBuilder, GraphqlModelBuilder } from './builders';
 import * as constants from './constants';
 import * as DiscountCodeInfoPresets from './presets';
-export * from './types';
 
 export const DiscountCodeInfoRest = {
   constants,

--- a/standalone/src/models/cart/cart/discount-code-info/presets/index.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/presets/index.ts
@@ -1,0 +1,2 @@
+export const restPresets = {};
+export const graphqlPresets = {};

--- a/standalone/src/models/cart/cart/discount-code-info/types.ts
+++ b/standalone/src/models/cart/cart/discount-code-info/types.ts
@@ -1,0 +1,10 @@
+import { DiscountCodeInfo } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@/core';
+import { TCtpDiscountCodeInfo } from '@/graphql-types';
+
+export type TDiscountCodeInfoRest = DiscountCodeInfo;
+export type TDiscountCodeInfoGraphql = TCtpDiscountCodeInfo;
+
+export type TCreateDiscountCodeInfoBuilder<
+  TModel extends TDiscountCodeInfoRest | TDiscountCodeInfoGraphql,
+> = () => TBuilder<TModel>;

--- a/standalone/src/models/cart/cart/index.ts
+++ b/standalone/src/models/cart/cart/index.ts
@@ -2,6 +2,7 @@
 export * from './cart/types';
 export * from './custom-line-item/types';
 export * from './discount-on-total-price/types';
+export * from './discount-code-info/types';
 export * from './discounted-total-price-portion/types';
 export * from './item-shipping-details/types';
 export * from './item-shipping-target/types';
@@ -15,6 +16,7 @@ export * from './cart/cart-draft';
 export * from './custom-line-item';
 export * from './custom-line-item/custom-line-item-draft';
 export * from './direct-discount';
+export * from './discount-code-info';
 export * from './discount-on-total-price';
 export * from './discounted-total-price-portion';
 export * from './discounted-line-item-portion';


### PR DESCRIPTION
With current cart model, `discountCodes` was just array of the discount codes. But actually it should be array of `DiscountCodeInfo`. As `DiscountCodeInfo` model was not available, I have added it in this PR and also fixing cart model