### PR TITLE
Add new presets to Cart models

### DIFF
--- a/.changeset/clear-sides-yell.md
+++ b/.changeset/clear-sides-yell.md
@@ -1,0 +1,47 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+---
+
+We're introducing two new `withAllFields` presets for the `DiscountedLisItemPortion` and `DiscountedLineItemPrice` that can be used to generate objects for those models with all the fields populated.
+
+They both accept some params which allow to provide some key values used for the nested models.
+
+Here are some examples on how they can be used:
+
+```ts
+import {
+  DiscountedLineItemPriceGraphql,
+  DiscountedLineItemPortionGraphql,
+} from '@commercetools/composable-commerce-test-data/cart';
+
+// DiscountedLineItemPrice
+
+// When no param is provided we will use these values
+//  - currencyCode: 'EUR'
+//  - target: 'lineItems'
+//  - discountId: 'cart-discount-id'
+const discountedLineItemPrice =
+  DiscountedLineItemPriceGraphql.presets.withAllFields();
+
+// With some custom params
+const discountedLineItemPriceCustomized =
+  DiscountedLineItemPriceGraphql.presets.withAllFields({
+    currencyCode: 'USD',
+  });
+
+// DiscountedLineItemPortionGraphql
+
+// When no param is provided we will use these values
+//  - currencyCode: 'EUR'
+//  - discountId: 'cart-discount-id'
+const discountedLineItemPortion =
+  DiscountedLineItemPortionGraphql.presets.withAllFields();
+
+// With some custom params
+const discountedLineItemPriceCustomized =
+  DiscountedLineItemPriceGraphql.presets.withAllFields({
+    discountId: 'discount-XZV',
+  });
+```
+
+We've also updated the `withAllFields` preset in the `LineItem` test data model so we make sure the `variant` property value that is generated with one boolean attribute filled in its attributes list property.

--- a/standalone/src/models/cart/cart/discounted-line-item-portion/presets/index.ts
+++ b/standalone/src/models/cart/cart/discounted-line-item-portion/presets/index.ts
@@ -1,2 +1,8 @@
-export const restPresets = {};
-export const graphqlPresets = {};
+import * as withAllFieldsPresets from './with-all-fields/with-all-fields';
+
+export const restPresets = {
+  withAllFields: withAllFieldsPresets.restPreset,
+};
+export const graphqlPresets = {
+  withAllFields: withAllFieldsPresets.graphqlPreset,
+};

--- a/standalone/src/models/cart/cart/discounted-line-item-portion/presets/with-all-fields/with-all-fields.spec.ts
+++ b/standalone/src/models/cart/cart/discounted-line-item-portion/presets/with-all-fields/with-all-fields.spec.ts
@@ -1,0 +1,93 @@
+import {
+  TDiscountedLineItemPortionGraphql,
+  TDiscountedLineItemPortionRest,
+} from '../../types';
+import * as withAllFieldsPresets from './with-all-fields';
+
+const validateRestModel = (
+  model: TDiscountedLineItemPortionRest,
+  cartDiscountId: string,
+  currencyCode: string
+) => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      discount: expect.objectContaining({
+        id: cartDiscountId,
+        typeId: 'cart-discount',
+      }),
+      discountedAmount: expect.objectContaining({
+        currencyCode: currencyCode,
+        centAmount: expect.any(Number),
+      }),
+    })
+  );
+};
+
+const validateGraphqlModel = (
+  model: TDiscountedLineItemPortionGraphql,
+  cartDiscountId: string,
+  currencyCode: string
+) => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      discount: expect.objectContaining({
+        id: cartDiscountId,
+        value: expect.objectContaining({
+          __typename: 'RelativeDiscountValue',
+        }),
+        target: expect.objectContaining({
+          __typename: 'LineItemsTarget',
+        }),
+        __typename: 'CartDiscount',
+      }),
+      discountedAmount: expect.objectContaining({
+        currencyCode: currencyCode,
+        __typename: 'Money',
+      }),
+      discountRef: expect.objectContaining({
+        id: cartDiscountId,
+        typeId: 'cart-discount',
+        __typename: 'Reference',
+      }),
+      __typename: 'DiscountedLineItemPortion',
+    })
+  );
+};
+
+describe('DiscountedLineItemPortion "withAllFields" Builder', () => {
+  it('should build properties for the REST preset', () => {
+    const restModel = withAllFieldsPresets.restPreset().build();
+
+    // These are the default params
+    validateRestModel(restModel, 'cart-discount-id', 'EUR');
+  });
+
+  it('should build properties for the REST preset with custom params', () => {
+    const restModel = withAllFieldsPresets
+      .restPreset({
+        currencyCode: 'USD',
+        discountId: 'cart-discount-id-2',
+      })
+      .build();
+
+    validateRestModel(restModel, 'cart-discount-id-2', 'USD');
+  });
+
+  it('should build properties for the GraphQL preset', () => {
+    const graphqlModel = withAllFieldsPresets.graphqlPreset().build();
+
+    // These are the default params
+    validateGraphqlModel(graphqlModel, 'cart-discount-id', 'EUR');
+  });
+
+  it('should build properties for the GraphQL preset with custom params', () => {
+    const graphqlModel = withAllFieldsPresets
+      .graphqlPreset({
+        currencyCode: 'USD',
+        discountId: 'cart-discount-id-2',
+      })
+      .build();
+
+    validateGraphqlModel(graphqlModel, 'cart-discount-id-2', 'USD');
+  });
+});

--- a/standalone/src/models/cart/cart/discounted-line-item-portion/presets/with-all-fields/with-all-fields.ts
+++ b/standalone/src/models/cart/cart/discounted-line-item-portion/presets/with-all-fields/with-all-fields.ts
@@ -1,0 +1,53 @@
+import { TBuilder } from '@/core';
+import {
+  CartDiscount,
+  CartDiscountLineItemsTarget,
+  CartDiscountValueRelative,
+} from '@/models/cart/cart-discount';
+import { Money, ReferenceRest } from '@/models/commons';
+import { GraphqlModelBuilder, RestModelBuilder } from '../../builders';
+import {
+  TDiscountedLineItemPortionGraphql,
+  TDiscountedLineItemPortionRest,
+} from '../../types';
+
+type TPresetParams = {
+  currencyCode?: string;
+  discountId?: string;
+};
+
+const defaultParams = {
+  currencyCode: 'EUR',
+  discountId: 'cart-discount-id',
+};
+
+export const restPreset = (
+  params?: TPresetParams
+): TBuilder<TDiscountedLineItemPortionRest> => {
+  const _params = {
+    ...defaultParams,
+    ...params,
+  };
+  return RestModelBuilder()
+    .discount(
+      ReferenceRest.presets.cartDiscountReference().id(_params.discountId)
+    )
+    .discountedAmount(Money.presets.withCurrency(_params.currencyCode));
+};
+
+export const graphqlPreset = (
+  params?: TPresetParams
+): TBuilder<TDiscountedLineItemPortionGraphql> => {
+  const _params = {
+    ...defaultParams,
+    ...params,
+  };
+  return GraphqlModelBuilder()
+    .discount(
+      CartDiscount.random()
+        .id(_params.discountId)
+        .value(CartDiscountValueRelative.random())
+        .target(CartDiscountLineItemsTarget.random())
+    )
+    .discountedAmount(Money.presets.withCurrency(_params.currencyCode));
+};

--- a/standalone/src/models/cart/cart/discounted-line-item-price/presets/index.ts
+++ b/standalone/src/models/cart/cart/discounted-line-item-price/presets/index.ts
@@ -1,2 +1,8 @@
-export const restPresets = {};
-export const graphqlPresets = {};
+import * as withAllFieldsPresets from './with-all-fields/with-all-fields';
+
+export const restPresets = {
+  withAllFields: withAllFieldsPresets.restPreset,
+};
+export const graphqlPresets = {
+  withAllFields: withAllFieldsPresets.graphqlPreset,
+};

--- a/standalone/src/models/cart/cart/discounted-line-item-price/presets/with-all-fields/with-all-fields.spec.ts
+++ b/standalone/src/models/cart/cart/discounted-line-item-price/presets/with-all-fields/with-all-fields.spec.ts
@@ -1,0 +1,104 @@
+import {
+  TDiscountedLineItemPriceGraphql,
+  TDiscountedLineItemPriceRest,
+} from '../../types';
+import * as withAllFieldsPresets from './with-all-fields';
+
+const validateRestModel = (
+  model: TDiscountedLineItemPriceRest,
+  currencyCode: string,
+  discountId: string
+) => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      value: expect.objectContaining({
+        currencyCode: currencyCode,
+        centAmount: expect.any(Number),
+      }),
+      includedDiscounts: expect.arrayContaining([
+        expect.objectContaining({
+          discount: expect.objectContaining({
+            id: discountId,
+            typeId: 'cart-discount',
+          }),
+          discountedAmount: expect.objectContaining({
+            currencyCode: currencyCode,
+            centAmount: expect.any(Number),
+          }),
+        }),
+      ]),
+    })
+  );
+};
+
+const validateGraphqlModel = (
+  model: TDiscountedLineItemPriceGraphql,
+  currencyCode: string,
+  discountId: string
+) => {
+  expect(model).toEqual(
+    expect.objectContaining({
+      value: expect.objectContaining({
+        currencyCode: currencyCode,
+        __typename: 'Money',
+      }),
+      includedDiscounts: expect.arrayContaining([
+        expect.objectContaining({
+          discount: expect.objectContaining({
+            id: discountId,
+            __typename: 'CartDiscount',
+          }),
+          discountedAmount: expect.objectContaining({
+            currencyCode: currencyCode,
+            __typename: 'Money',
+          }),
+          discountRef: expect.objectContaining({
+            id: discountId,
+            typeId: 'cart-discount',
+            __typename: 'Reference',
+          }),
+          __typename: 'DiscountedLineItemPortion',
+        }),
+      ]),
+      __typename: 'DiscountedLineItemPrice',
+    })
+  );
+};
+
+describe('DiscountedLineItemPrice "withAllFields" preset', () => {
+  it('should build properties for the REST preset', () => {
+    const restModel = withAllFieldsPresets.restPreset().build();
+
+    // These are the default params
+    validateRestModel(restModel, 'EUR', 'cart-discount-id');
+  });
+
+  it('should build properties for the REST preset with custom params', () => {
+    const restModel = withAllFieldsPresets
+      .restPreset({
+        currencyCode: 'USD',
+        discountId: 'cart-discount-id-2',
+      })
+      .build();
+
+    validateRestModel(restModel, 'USD', 'cart-discount-id-2');
+  });
+
+  it('should build properties for the GraphQL preset', () => {
+    const graphqlModel = withAllFieldsPresets.graphqlPreset().build();
+
+    // These are the default params
+    validateGraphqlModel(graphqlModel, 'EUR', 'cart-discount-id');
+  });
+
+  it('should build properties for the GraphQL preset with custom params', () => {
+    const graphqlModel = withAllFieldsPresets
+      .graphqlPreset({
+        currencyCode: 'USD',
+        discountId: 'cart-discount-id-2',
+      })
+      .build();
+
+    validateGraphqlModel(graphqlModel, 'USD', 'cart-discount-id-2');
+  });
+});

--- a/standalone/src/models/cart/cart/discounted-line-item-price/presets/with-all-fields/with-all-fields.ts
+++ b/standalone/src/models/cart/cart/discounted-line-item-price/presets/with-all-fields/with-all-fields.ts
@@ -1,0 +1,57 @@
+import { TBuilder } from '@/core';
+import { Money } from '@/models/commons';
+import {
+  DiscountedLineItemPortionGraphql,
+  DiscountedLineItemPortionRest,
+} from '../../../discounted-line-item-portion';
+import { GraphqlModelBuilder, RestModelBuilder } from '../../builders';
+import {
+  TDiscountedLineItemPriceGraphql,
+  TDiscountedLineItemPriceRest,
+} from '../../types';
+
+type TPresetParams = {
+  currencyCode?: string;
+  target?: string;
+  discountId?: string;
+};
+
+const defaultParams = {
+  currencyCode: 'EUR',
+  target: 'lineItems',
+  discountId: 'cart-discount-id',
+};
+
+export const restPreset = (
+  params: TPresetParams = defaultParams
+): TBuilder<TDiscountedLineItemPriceRest> => {
+  const _params = {
+    ...defaultParams,
+    ...params,
+  };
+  return RestModelBuilder()
+    .value(Money.presets.withCurrency(_params.currencyCode))
+    .includedDiscounts([
+      DiscountedLineItemPortionRest.presets.withAllFields({
+        currencyCode: _params.currencyCode,
+        discountId: _params.discountId,
+      }),
+    ]);
+};
+
+export const graphqlPreset = (
+  params: TPresetParams = defaultParams
+): TBuilder<TDiscountedLineItemPriceGraphql> => {
+  const _params = {
+    ...defaultParams,
+    ...params,
+  };
+  return GraphqlModelBuilder()
+    .value(Money.presets.withCurrency(_params.currencyCode))
+    .includedDiscounts([
+      DiscountedLineItemPortionGraphql.presets.withAllFields({
+        currencyCode: _params.currencyCode,
+        discountId: _params.discountId,
+      }),
+    ]);
+};

--- a/standalone/src/models/cart/cart/line-item/constants.ts
+++ b/standalone/src/models/cart/cart/line-item/constants.ts
@@ -1,16 +1,11 @@
-export const inventoryMode = {
-  TrackOnly: 'TrackOnly',
-  ReserveOnOrder: 'ReserveOnOrder',
-  None: 'None',
-} as const;
+import {
+  TCtpInventoryMode,
+  TCtpLineItemMode,
+  TCtpLineItemPriceMode,
+} from '@/graphql-types';
 
-export const priceMode = {
-  Platform: 'Platform',
-  ExternalPrice: 'ExternalPrice',
-  ExternalTotal: 'ExternalTotal',
-} as const;
+export const inventoryMode = TCtpInventoryMode;
 
-export const lineItemMode = {
-  Standard: 'Standard',
-  GiftLineItem: 'GiftLineItem',
-} as const;
+export const priceMode = TCtpLineItemPriceMode;
+
+export const lineItemMode = TCtpLineItemMode;

--- a/standalone/src/models/cart/cart/line-item/field-config.ts
+++ b/standalone/src/models/cart/cart/line-item/field-config.ts
@@ -37,7 +37,7 @@ const commonFieldsConfig = {
   state: [],
   perMethodTaxRate: [],
   priceMode: oneOf(...Object.values(priceMode)),
-  lineItemMode: oneOf(...Object.values(lineItemMode)),
+  lineItemMode: lineItemMode.Standard,
   inventoryMode: oneOf(...Object.values(inventoryMode)),
   shippingDetails: null,
   addedAt: fake(addedAt),

--- a/standalone/src/models/cart/cart/line-item/presets/with-all-fields/with-all-fields.spec.ts
+++ b/standalone/src/models/cart/cart/line-item/presets/with-all-fields/with-all-fields.spec.ts
@@ -57,6 +57,13 @@ const validateRestFields = (model: TLineItemRest) => {
           }),
         }),
       ]),
+      variant: expect.objectContaining({
+        attributes: expect.arrayContaining([
+          expect.objectContaining({
+            name: 'test-boolean-attribute',
+          }),
+        ]),
+      }),
     })
   );
 };
@@ -89,6 +96,15 @@ const validateGraphqlFields = (model: TLineItemGraphql) => {
           }),
         }),
       ]),
+      variant: expect.objectContaining({
+        attributesRaw: expect.arrayContaining([
+          expect.objectContaining({
+            name: 'test-boolean-attribute',
+            __typename: 'RawProductAttribute',
+          }),
+        ]),
+        __typename: 'ProductVariant',
+      }),
     })
   );
 };
@@ -102,6 +118,7 @@ describe('LineItem model builders', () => {
 
   it('builds a GraphQL model', () => {
     const graphqlModel = withAllFieldsPreset.graphqlPreset().build();
+
     validateGraphqlFields(graphqlModel);
   });
 });

--- a/standalone/src/models/cart/cart/line-item/presets/with-all-fields/with-all-fields.ts
+++ b/standalone/src/models/cart/cart/line-item/presets/with-all-fields/with-all-fields.ts
@@ -21,6 +21,10 @@ import {
   Money,
   ReferenceRest,
 } from '@/models/commons';
+import {
+  ProductVariantGraphql,
+  ProductVariantRest,
+} from '@/models/product/product';
 import { GraphqlModelBuilder, RestModelBuilder } from '../../builders';
 import { TLineItemGraphql, TLineItemRest } from '../../types';
 
@@ -43,7 +47,8 @@ export const restPreset = (): TBuilder<TLineItemRest> => {
   return RestModelBuilder()
     .state(ItemStateRest.random())
     .taxedPrice(TaxedItemPriceRest.presets.withAllFields())
-    .discountedPricePerQuantity([discountedPricePerQuantity]);
+    .discountedPricePerQuantity([discountedPricePerQuantity])
+    .variant(ProductVariantRest.presets.withBooleanAttributeVariant());
 };
 
 export const graphqlPreset = (): TBuilder<TLineItemGraphql> => {
@@ -73,5 +78,6 @@ export const graphqlPreset = (): TBuilder<TLineItemGraphql> => {
   return GraphqlModelBuilder()
     .state(ItemStateGraphql.random())
     .taxedPrice(TaxedItemPriceGraphql.presets.withAllFields())
-    .discountedPricePerQuantity([discountedPricePerQuantity]);
+    .discountedPricePerQuantity([discountedPricePerQuantity])
+    .variant(ProductVariantGraphql.presets.withBooleanAttributeVariant());
 };

--- a/standalone/src/models/commons/reference/types.ts
+++ b/standalone/src/models/commons/reference/types.ts
@@ -1,22 +1,6 @@
 import type { TBuilder } from '@/core';
 import { TCtpReference } from '@/graphql-types';
 
-// export interface BusinessUnitReference {
-//     readonly typeId: 'business-unit';
-//     /**
-//      *	Unique identifier of the referenced [BusinessUnit](ctp:api:type:BusinessUnit).
-//      *
-//      *
-//      */
-//     readonly id: string;
-//     /**
-//      *	Contains the representation of the expanded BusinessUnit. Only present in responses to requests with [Reference Expansion](/../api/general-concepts#reference-expansion) for BusinessUnit.
-//      *
-//      *
-//      */
-//     readonly obj?: BusinessUnit;
-// }
-
 // Legacy model
 export interface TReference<TypeId = string> {
   typeId: TypeId;
@@ -58,17 +42,6 @@ export type TReferenceDraftRest<TypeId = string> = TReferenceDraft<TypeId>;
 export type TReferenceDraftGraphql<TypeId = string> = TReferenceDraft<TypeId>;
 
 // Builders
-// export type TCreateReferenceBuilder<TypeId = string> =
-//   () => TReferenceBuilder<TypeId>;
-
-// export type TReferenceBuilder<TypeId = string> = TBuilder<TReference<TypeId>>;
-
-// export type TReferenceDraftBuilder<TypeId = string> = TBuilder<
-//   TReferenceDraft<TypeId>
-// >;
-// export type TCreateReferenceDraftBuilder<TypeId = string> =
-//   () => TReferenceDraftBuilder<TypeId>;
-
 export type TCreateReferenceBuilder<
   TReferenceModel extends
     | TReferenceRest


### PR DESCRIPTION
## Description

We're introducing two new `withAllFields` presets for the `DiscountedLisItemPortion` and `DiscountedLineItemPrice` that can be used to generate objects for those models with all the fields populated.

They both accept some params which allow to provide some key values used for the nested models.

Here are some examples on how they can be used:
```ts
import {
  DiscountedLineItemPriceGraphql,
  DiscountedLineItemPortionGraphql,
} from '@commercetools/composable-commerce-test-data/cart';

// DiscountedLineItemPrice

// When no param is provided we will use these values
//  - currencyCode: 'EUR'
//  - target: 'lineItems'
//  - discountId: 'cart-discount-id'
const discountedLineItemPrice = DiscountedLineItemPriceGraphql.presets.withAllFields();

// With some custom params
const discountedLineItemPriceCustomized = DiscountedLineItemPriceGraphql.presets.withAllFields({
  currencyCode: 'USD',
});


// DiscountedLineItemPortionGraphql

// When no param is provided we will use these values
//  - currencyCode: 'EUR'
//  - discountId: 'cart-discount-id'
const discountedLineItemPortion = DiscountedLineItemPortionGraphql.presets.withAllFields();

// With some custom params
const discountedLineItemPriceCustomized = DiscountedLineItemPriceGraphql.presets.withAllFields({
  discountId: 'discount-XZV',
});
```

We've also updated the `withAllFields` preset in the `LineItem` test data model so we make sure the `variant` property value that is generated with one boolean attribute filled in its attributes list property.
