### PR TITLE
chore: add eslint to vscode workspace settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,9 +82,6 @@ dist
 # Editor/IDE
 .idea
 .cursor/*
-.vscode/*
-#!.vscode/settings.json
-!.vscode/spellright.dict
 
 # Cypress
 cypress/screenshots

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "graphql"
+  ]
+}


### PR DESCRIPTION
This pull request adds a new VSCode workspace settings file to enable ESLint validation for several languages, improving code quality and consistency during development.

This solves the following problem and make ESLint run.

> ESLint is not running. By default only TypeScript and JavaScript files are validated. If you want to validate other file types please specify them in the 'eslint.probe' setting.

Development environment improvements:

* Added `.vscode/settings.json` to configure ESLint validation for `javascript`, `javascriptreact`, `typescript`, `typescriptreact`, and `graphql` files.