### PR TITLE
PRC-4280: Add isActive to the Discount Group test-data models

### DIFF
--- a/.changeset/purple-hotels-hide.md
+++ b/.changeset/purple-hotels-hide.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+---
+
+Add isActive field to discount group models

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: ^24.0.0
         version: 24.2.1
       '@commercetools/platform-sdk':
-        specifier: 8.13.0
-        version: 8.13.0
+        specifier: 8.16.0
+        version: 8.16.0
       '@faker-js/faker':
         specifier: ^9.0.0
         version: 9.6.0
@@ -935,12 +935,12 @@ packages:
     peerDependencies:
       eslint: 8.x
 
-  '@commercetools/platform-sdk@8.13.0':
-    resolution: {integrity: sha512-NkRPpCRLxuS0hO9m4WbCazhmIILMc/Aqw204k6loIsG1kDKXO6at5jQxRa4l2FP6wwwo741Mo9y844ziyCf5FA==}
+  '@commercetools/platform-sdk@8.16.0':
+    resolution: {integrity: sha512-tgYJsmhzPE2c0S9LeGpgz9nuHaLF2F7t8hyi6aIRGxR2HxcIMFFZeyU8tAuBkPyQyUGtCWVS4m2nq8iDEm9iWg==}
     engines: {node: '>=18'}
 
-  '@commercetools/ts-client@4.1.0':
-    resolution: {integrity: sha512-IbEq0mnudNlWVBxLdxJz6NL+IQLOsxnKofKOLxWXlWSJMiu5H4nmIciuLzhiRsEbmUm/EagGN2NJs5IOE0NQ1A==}
+  '@commercetools/ts-client@4.2.1':
+    resolution: {integrity: sha512-nFI5ojerOwkVMNGYh8owtpYg2C5DJWWqravD1Fy9PZAznVkUUp7LvYf52wcLw/0OnvFCVLKLx/DD501XF+xQfA==}
     engines: {node: '>=18'}
 
   '@commitlint/cli@19.8.1':
@@ -6572,11 +6572,11 @@ snapshots:
       - supports-color
       - ts-jest
 
-  '@commercetools/platform-sdk@8.13.0':
+  '@commercetools/platform-sdk@8.16.0':
     dependencies:
-      '@commercetools/ts-client': 4.1.0
+      '@commercetools/ts-client': 4.2.1
 
-  '@commercetools/ts-client@4.1.0':
+  '@commercetools/ts-client@4.2.1':
     dependencies:
       buffer: 6.0.3
 

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -135,7 +135,7 @@
     "@babel/runtime-corejs3": "^7.17.9",
     "@commercetools-frontend/application-config": "^24.0.0",
     "@commercetools-frontend/constants": "^24.0.0",
-    "@commercetools/platform-sdk": "8.13.0",
+    "@commercetools/platform-sdk": "8.16.0",
     "@faker-js/faker": "^9.0.0",
     "@types/lodash": "^4.17.0",
     "lodash": "^4.17.21",

--- a/standalone/src/models/discount/discount-group/builders.spec.ts
+++ b/standalone/src/models/discount/discount-group/builders.spec.ts
@@ -16,6 +16,7 @@ describe('DiscountGroup Builder', () => {
         sortOrder: expect.any(String),
         name: null,
         description: null,
+        isActive: expect.any(Boolean),
       })
     );
   });
@@ -37,6 +38,7 @@ describe('DiscountGroup Builder', () => {
         nameAllLocales: null,
         descriptionAllLocales: null,
         type: expect.any(String),
+        isActive: expect.any(Boolean),
         __typename: 'DiscountGroup',
       })
     );

--- a/standalone/src/models/discount/discount-group/discount-group-draft/builders.spec.ts
+++ b/standalone/src/models/discount/discount-group/discount-group-draft/builders.spec.ts
@@ -10,6 +10,7 @@ describe('DiscountGroupDraft Builder', () => {
         sortOrder: expect.any(String),
         name: null,
         description: null,
+        isActive: expect.any(Boolean),
       })
     );
   });
@@ -22,6 +23,7 @@ describe('DiscountGroupDraft Builder', () => {
         sortOrder: expect.any(String),
         name: null,
         description: null,
+        isActive: expect.any(Boolean),
       })
     );
   });

--- a/standalone/src/models/discount/discount-group/discount-group-draft/fields-config.ts
+++ b/standalone/src/models/discount/discount-group/discount-group-draft/fields-config.ts
@@ -11,6 +11,7 @@ const commonFieldsConfig = {
   sortOrder: fake((f) =>
     String(f.number.float({ min: 0.00000001, max: 0.99999999 }))
   ),
+  isActive: fake((f) => f.datatype.boolean()),
 };
 
 export const restFieldsConfig: TModelFieldsConfig<TDiscountGroupDraftRest> = {

--- a/standalone/src/models/discount/discount-group/fields-config.ts
+++ b/standalone/src/models/discount/discount-group/fields-config.ts
@@ -16,6 +16,7 @@ const commonFieldsConfig = {
   sortOrder: fake((f) =>
     String(f.number.float({ min: 0.00000001, max: 0.99999999 }))
   ),
+  isActive: fake((f) => f.datatype.boolean()),
 };
 
 export const restFieldsConfig: TModelFieldsConfig<TDiscountGroupRest> = {


### PR DESCRIPTION
This PR updates the Discount Group models with a new `isActive` field