### PR TITLE
chore(CODEOWNERS): fix path for product-selection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,7 @@
 /standalone/src/models/product @commercetools/pdm-team-fe
 /standalone/src/models/product-discount @commercetools/priceless-team-fe
 /standalone/src/models/product-projection @commercetools/pdm-team-fe
-/standalone/src/models/product-selection @commercetools/context-team-fe
+/standalone/src/models/product/product-selection @commercetools/context-team-fe
 /standalone/src/models/product-type @commercetools/pdm-team-fe
 /standalone/src/models/project @commercetools/bots-team-engineers
 /standalone/src/models/quote @commercetools/customers-team-fe


### PR DESCRIPTION
This pull request makes a minor update to the `.github/CODEOWNERS` file, correcting the path assignment for the `product-selection` model to ensure the correct team is assigned ownership. Currently, the @commercetools/pdm-team-fe is wrongly being assigned instead of @commercetools/context-team-fe.