### PR TITLE
FEC-239: create attribute group draft model

### DIFF
--- a/.changeset/rude-kiwis-strive.md
+++ b/.changeset/rude-kiwis-strive.md
@@ -2,4 +2,20 @@
 '@commercetools/composable-commerce-test-data': minor
 ---
 
-Introduces the attribute-group-draft model.
+Introduces the attribute-group-draft model and an empty preset; and the attribute-reference, which is used internally by attribute-group-draft.
+
+```ts
+import {
+  AttributeGroupDraftGraphql,
+  AttributeGroupDraftRest,
+} from '@commercetools/composable-commerce-test-data/attribute-group';
+
+const graphqlModel = AttributeGroupDraftGraphql.random().build();
+
+const restModel = AttributeGroupDraftRest.random().build();
+
+// empty preset
+const emptyGraphqlModel = AttributeGroupDraftGraphql.presets.empty().build();
+
+const emptyRestModel = AttributeGroupDraftRest.presets.empty().build();
+```

--- a/.changeset/rude-kiwis-strive.md
+++ b/.changeset/rude-kiwis-strive.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/composable-commerce-test-data': minor
+---
+
+Introduces the attribute-group-draft model.

--- a/docs/guidelines/writing-changesets.md
+++ b/docs/guidelines/writing-changesets.md
@@ -31,7 +31,7 @@ The key items could be:
 
 Here we list some example for some common use cases.
 
-### If your adding a new test data model
+### If you are adding a new test data model
 
 #### Basic use case:
 

--- a/standalone/src/models/attribute-group/attribute-group-draft/builder.spec.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/builder.spec.ts
@@ -9,17 +9,13 @@ const validateRestModel = (model: TAttributeGroupDraftRest) => {
 
   expect(model).toEqual(
     expect.objectContaining({
-      key: expect.any(String),
+      key: null,
       name: expect.objectContaining({
         de: expect.any(String),
         en: expect.any(String),
         fr: expect.any(String),
       }),
-      description: expect.objectContaining({
-        de: expect.any(String),
-        en: expect.any(String),
-        fr: expect.any(String),
-      }),
+      description: null,
       attributes: expect.any(Array),
     })
   );
@@ -29,21 +25,16 @@ const validateGraphqlModel = (model: TAttributeGroupDraftGraphql) => {
   console.log('GraphQL model', model);
   expect(model).toEqual(
     expect.objectContaining({
-      key: expect.any(String),
+      key: null,
       name: expect.arrayContaining([
         expect.objectContaining({
           locale: expect.any(String),
           value: expect.any(String),
+          __typename: 'LocalizedString',
         }),
       ]),
-      description: expect.arrayContaining([
-        expect.objectContaining({
-          locale: expect.any(String),
-          value: expect.any(String),
-        }),
-      ]),
+      description: null,
       attributes: expect.any(Array),
-      __typename: 'AttributeGroupDraft',
     })
   );
 };

--- a/standalone/src/models/attribute-group/attribute-group-draft/builder.spec.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/builder.spec.ts
@@ -1,0 +1,85 @@
+import type {
+  TAttributeGroupDraftGraphql,
+  TAttributeGroupDraftRest,
+} from '../types';
+import {
+  AttributeGroupDraft,
+  AttributeGroupDraftGraphql,
+  AttributeGroupDraftRest,
+} from './index';
+
+const validateRestModel = (model: TAttributeGroupDraftRest) => {
+  console.log('Rest model', model);
+
+  expect(model).toEqual(
+    expect.objectContaining({
+      key: expect.any(String),
+      name: expect.objectContaining({
+        de: expect.any(String),
+        en: expect.any(String),
+        fr: expect.any(String),
+      }),
+      description: expect.objectContaining({
+        de: expect.any(String),
+        en: expect.any(String),
+        fr: expect.any(String),
+      }),
+      attributes: expect.any(Array),
+    })
+  );
+};
+
+const validateGraphqlModel = (model: TAttributeGroupDraftGraphql) => {
+  console.log('GraphQL model', model);
+  expect(model).toEqual(
+    expect.objectContaining({
+      key: expect.any(String),
+      name: expect.arrayContaining([
+        expect.objectContaining({
+          locale: expect.any(String),
+          value: expect.any(String),
+        }),
+      ]),
+      description: expect.arrayContaining([
+        expect.objectContaining({
+          locale: expect.any(String),
+          value: expect.any(String),
+        }),
+      ]),
+      attributes: expect.any(Array),
+      nameAllLocales: expect.any(Array),
+      descriptionAllLocales: expect.any(Array),
+      __typename: 'AttributeGroupDraft',
+    })
+  );
+};
+
+describe('AttributeGroupDraft builders', () => {
+  it('should create a REST model object', () => {
+    const restDraft = AttributeGroupDraftRest.random().build();
+    validateRestModel(restDraft);
+  });
+
+  it('should create a GraphQL model object', () => {
+    const graphqlDraft = AttributeGroupDraftGraphql.random().build();
+    validateGraphqlModel(graphqlDraft);
+  });
+});
+
+describe('AttributeGroupDraft compatibility builders', () => {
+  it('should create a default compatibility model object', () => {
+    const compatDraft = AttributeGroupDraft.random().build();
+    validateRestModel(compatDraft);
+  });
+
+  it('should create a REST compatibility model object', () => {
+    const compatDraft = AttributeGroupDraft.random().buildRest();
+    validateRestModel(compatDraft);
+  });
+
+  it('should create a GraphQL compatibility model object', () => {
+    const compatDraft =
+      AttributeGroupDraft.random().buildGraphql<TAttributeGroupDraftGraphql>();
+    validateGraphqlModel(compatDraft);
+  });
+});

--- a/standalone/src/models/attribute-group/attribute-group-draft/builder.spec.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/builder.spec.ts
@@ -47,8 +47,6 @@ const validateGraphqlModel = (model: TAttributeGroupDraftGraphql) => {
         }),
       ]),
       attributes: expect.any(Array),
-      nameAllLocales: expect.any(Array),
-      descriptionAllLocales: expect.any(Array),
       __typename: 'AttributeGroupDraft',
     })
   );

--- a/standalone/src/models/attribute-group/attribute-group-draft/builder.spec.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/builder.spec.ts
@@ -2,11 +2,7 @@ import type {
   TAttributeGroupDraftGraphql,
   TAttributeGroupDraftRest,
 } from '../types';
-import {
-  AttributeGroupDraft,
-  AttributeGroupDraftGraphql,
-  AttributeGroupDraftRest,
-} from './index';
+import { AttributeGroupDraftGraphql, AttributeGroupDraftRest } from './index';
 
 const validateRestModel = (model: TAttributeGroupDraftRest) => {
   console.log('Rest model', model);
@@ -61,23 +57,5 @@ describe('AttributeGroupDraft builders', () => {
   it('should create a GraphQL model object', () => {
     const graphqlDraft = AttributeGroupDraftGraphql.random().build();
     validateGraphqlModel(graphqlDraft);
-  });
-});
-
-describe('AttributeGroupDraft compatibility builders', () => {
-  it('should create a default compatibility model object', () => {
-    const compatDraft = AttributeGroupDraft.random().build();
-    validateRestModel(compatDraft);
-  });
-
-  it('should create a REST compatibility model object', () => {
-    const compatDraft = AttributeGroupDraft.random().buildRest();
-    validateRestModel(compatDraft);
-  });
-
-  it('should create a GraphQL compatibility model object', () => {
-    const compatDraft =
-      AttributeGroupDraft.random().buildGraphql<TAttributeGroupDraftGraphql>();
-    validateGraphqlModel(compatDraft);
   });
 });

--- a/standalone/src/models/attribute-group/attribute-group-draft/builders.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/builders.ts
@@ -1,0 +1,37 @@
+import {
+  createCompatibilityBuilder,
+  createSpecializedBuilder,
+  TModelFieldsConfig,
+} from '@/core';
+import type {
+  TAttributeGroupDraftGraphql,
+  TAttributeGroupDraftRest,
+} from '../types';
+import { restFieldsConfig, graphqlFieldsConfig } from './fields-config';
+
+export const RestModelBuilder = () =>
+  createSpecializedBuilder({
+    name: 'AttributeGroupDraftRestBuilder',
+    type: 'rest',
+    modelFieldsConfig: restFieldsConfig,
+  });
+
+export const GraphqlModelBuilder = () =>
+  createSpecializedBuilder({
+    name: 'AttributeGroupDraftGraphqlBuilder',
+    type: 'graphql',
+    modelFieldsConfig: graphqlFieldsConfig,
+  });
+
+export const AttributeGroupDraftCompatBuilder = <
+  TModel extends
+    | TAttributeGroupDraftRest
+    | TAttributeGroupDraftGraphql = TAttributeGroupDraftRest,
+>() =>
+  createCompatibilityBuilder<TModel>({
+    name: 'AttributeGroupDraftCompatBuilder',
+    modelFieldsConfig: {
+      rest: restFieldsConfig as TModelFieldsConfig<TModel>,
+      graphql: graphqlFieldsConfig as TModelFieldsConfig<TModel>,
+    },
+  });

--- a/standalone/src/models/attribute-group/attribute-group-draft/builders.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/builders.ts
@@ -1,12 +1,4 @@
-import {
-  createCompatibilityBuilder,
-  createSpecializedBuilder,
-  TModelFieldsConfig,
-} from '@/core';
-import type {
-  TAttributeGroupDraftGraphql,
-  TAttributeGroupDraftRest,
-} from '../types';
+import { createSpecializedBuilder } from '@/core';
 import { restFieldsConfig, graphqlFieldsConfig } from './fields-config';
 
 export const RestModelBuilder = () =>
@@ -21,17 +13,4 @@ export const GraphqlModelBuilder = () =>
     name: 'AttributeGroupDraftGraphqlBuilder',
     type: 'graphql',
     modelFieldsConfig: graphqlFieldsConfig,
-  });
-
-export const AttributeGroupDraftCompatBuilder = <
-  TModel extends
-    | TAttributeGroupDraftRest
-    | TAttributeGroupDraftGraphql = TAttributeGroupDraftRest,
->() =>
-  createCompatibilityBuilder<TModel>({
-    name: 'AttributeGroupDraftCompatBuilder',
-    modelFieldsConfig: {
-      rest: restFieldsConfig as TModelFieldsConfig<TModel>,
-      graphql: graphqlFieldsConfig as TModelFieldsConfig<TModel>,
-    },
   });

--- a/standalone/src/models/attribute-group/attribute-group-draft/fields-config.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/fields-config.ts
@@ -5,10 +5,12 @@ import type {
   TAttributeGroupDraftRest,
 } from '../types';
 
+// https://docs.commercetools.com/api/projects/attribute-groups#attributegroupdraft
+
 const commonFieldsConfig = {
-  key: fake((f) => f.lorem.slug(2)),
+  key: null,
+  description: null,
   name: fake(() => LocalizedString.random()),
-  description: fake((f) => LocalizedString.random().en(f.lorem.sentences(2))),
   attributes: fake(() => []), // TODO: attributeReference[]
 };
 
@@ -21,8 +23,6 @@ export const restFieldsConfig: TModelFieldsConfig<TAttributeGroupDraftRest> = {
 export const graphqlFieldsConfig: TModelFieldsConfig<TAttributeGroupDraftGraphql> =
   {
     fields: {
-      // TODO: name and description have unique types
       ...commonFieldsConfig,
-      __typename: 'AttributeGroupDraft',
     },
   };

--- a/standalone/src/models/attribute-group/attribute-group-draft/fields-config.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/fields-config.ts
@@ -1,5 +1,9 @@
 import { fake, type TModelFieldsConfig } from '@/core';
 import { LocalizedString } from '@/models/commons';
+import {
+  AttributeReferenceRest,
+  AttributeReferenceGraphql,
+} from '../attribute-reference';
 import type {
   TAttributeGroupDraftGraphql,
   TAttributeGroupDraftRest,
@@ -11,12 +15,12 @@ const commonFieldsConfig = {
   key: null,
   description: null,
   name: fake(() => LocalizedString.random()),
-  attributes: fake(() => []), // TODO: attributeReference[]
 };
 
 export const restFieldsConfig: TModelFieldsConfig<TAttributeGroupDraftRest> = {
   fields: {
     ...commonFieldsConfig,
+    attributes: fake(() => [AttributeReferenceRest.random().build()]),
   },
 };
 
@@ -24,5 +28,6 @@ export const graphqlFieldsConfig: TModelFieldsConfig<TAttributeGroupDraftGraphql
   {
     fields: {
       ...commonFieldsConfig,
+      attributes: fake(() => [AttributeReferenceGraphql.random().build()]),
     },
   };

--- a/standalone/src/models/attribute-group/attribute-group-draft/fields-config.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/fields-config.ts
@@ -1,0 +1,35 @@
+import { fake, type TModelFieldsConfig } from '@/core';
+import { LocalizedStringDraft, LocalizedString } from '@/models/commons';
+import type {
+  TAttributeGroupDraftGraphql,
+  TAttributeGroupDraftRest,
+} from '../types';
+
+const commonFieldsConfig = {
+  key: fake((f) => f.lorem.slug(2)),
+  name: fake(() => LocalizedStringDraft.random()),
+  description: fake((f) =>
+    LocalizedStringDraft.random().en(f.lorem.sentences(2))
+  ),
+  attributes: [],
+};
+
+export const restFieldsConfig: TModelFieldsConfig<TAttributeGroupDraftRest> = {
+  fields: {
+    ...commonFieldsConfig,
+  },
+};
+
+export const graphqlFieldsConfig: TModelFieldsConfig<TAttributeGroupDraftGraphql> =
+  {
+    fields: {
+      ...commonFieldsConfig,
+      nameAllLocales: fake(() =>
+        LocalizedString.toLocalizedField(LocalizedString.random())
+      ),
+      descriptionAllLocales: fake(() =>
+        LocalizedString.toLocalizedField(LocalizedString.random())
+      ),
+      __typename: 'AttributeGroupDraft',
+    },
+  };

--- a/standalone/src/models/attribute-group/attribute-group-draft/fields-config.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/fields-config.ts
@@ -1,5 +1,5 @@
 import { fake, type TModelFieldsConfig } from '@/core';
-import { LocalizedStringDraft, LocalizedString } from '@/models/commons';
+import { LocalizedString } from '@/models/commons';
 import type {
   TAttributeGroupDraftGraphql,
   TAttributeGroupDraftRest,
@@ -7,11 +7,9 @@ import type {
 
 const commonFieldsConfig = {
   key: fake((f) => f.lorem.slug(2)),
-  name: fake(() => LocalizedStringDraft.random()),
-  description: fake((f) =>
-    LocalizedStringDraft.random().en(f.lorem.sentences(2))
-  ),
-  attributes: [],
+  name: fake(() => LocalizedString.random()),
+  description: fake((f) => LocalizedString.random().en(f.lorem.sentences(2))),
+  attributes: fake(() => []), // TODO: attributeReference[]
 };
 
 export const restFieldsConfig: TModelFieldsConfig<TAttributeGroupDraftRest> = {
@@ -23,13 +21,8 @@ export const restFieldsConfig: TModelFieldsConfig<TAttributeGroupDraftRest> = {
 export const graphqlFieldsConfig: TModelFieldsConfig<TAttributeGroupDraftGraphql> =
   {
     fields: {
+      // TODO: name and description have unique types
       ...commonFieldsConfig,
-      nameAllLocales: fake(() =>
-        LocalizedString.toLocalizedField(LocalizedString.random())
-      ),
-      descriptionAllLocales: fake(() =>
-        LocalizedString.toLocalizedField(LocalizedString.random())
-      ),
       __typename: 'AttributeGroupDraft',
     },
   };

--- a/standalone/src/models/attribute-group/attribute-group-draft/index.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/index.ts
@@ -1,0 +1,25 @@
+import {
+  RestModelBuilder,
+  GraphqlModelBuilder,
+  AttributeGroupDraftCompatBuilder,
+} from './builders';
+import * as modelPresets from './presets';
+
+// Presets can be added here if needed in the future
+export const AttributeGroupDraftRest = {
+  random: RestModelBuilder,
+  presets: modelPresets.restPresets,
+};
+
+export const AttributeGroupDraftGraphql = {
+  random: GraphqlModelBuilder,
+  presets: modelPresets.graphqlPresets,
+};
+
+/**
+ * @deprecated Use `AttributeGroupDraftRest` or `AttributeGroupDraftGraphql` exported models instead of `AttributeGroupDraft`.
+ */
+export const AttributeGroupDraft = {
+  random: AttributeGroupDraftCompatBuilder,
+  presets: modelPresets.compatPresets,
+};

--- a/standalone/src/models/attribute-group/attribute-group-draft/index.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/index.ts
@@ -1,11 +1,6 @@
-import {
-  RestModelBuilder,
-  GraphqlModelBuilder,
-  AttributeGroupDraftCompatBuilder,
-} from './builders';
+import { RestModelBuilder, GraphqlModelBuilder } from './builders';
 import * as modelPresets from './presets';
 
-// Presets can be added here if needed in the future
 export const AttributeGroupDraftRest = {
   random: RestModelBuilder,
   presets: modelPresets.restPresets,
@@ -14,12 +9,4 @@ export const AttributeGroupDraftRest = {
 export const AttributeGroupDraftGraphql = {
   random: GraphqlModelBuilder,
   presets: modelPresets.graphqlPresets,
-};
-
-/**
- * @deprecated Use `AttributeGroupDraftRest` or `AttributeGroupDraftGraphql` exported models instead of `AttributeGroupDraft`.
- */
-export const AttributeGroupDraft = {
-  random: AttributeGroupDraftCompatBuilder,
-  presets: modelPresets.compatPresets,
 };

--- a/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.spec.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.spec.ts
@@ -2,7 +2,7 @@ import type {
   TAttributeGroupDraftGraphql,
   TAttributeGroupDraftRest,
 } from '../../types';
-import { restPreset, graphqlPreset, compatPreset } from './empty';
+import { restPreset, graphqlPreset } from './empty';
 
 const validateCommonFields = (
   model: TAttributeGroupDraftRest | TAttributeGroupDraftGraphql
@@ -16,27 +16,12 @@ const validateCommonFields = (
 
 describe('attribute-group-draft with empty fields', () => {
   it('[REST] should set all specified fields to empty', () => {
-    const model = restPreset().buildRest();
+    const model = restPreset().build();
     validateCommonFields(model);
   });
 
   it('[GraphQL] should set all specified fields to empty', () => {
-    const model = graphqlPreset().buildGraphql();
-    validateCommonFields(model);
-  });
-
-  it('[Compat - DEFAULT] should set all specified fields to empty', () => {
-    const model = compatPreset().build();
-    validateCommonFields(model);
-  });
-
-  it('[Compat - REST] should set all specified fields to empty', () => {
-    const model = compatPreset().buildRest();
-    validateCommonFields(model);
-  });
-
-  it('[Compat - GraphQL] should set all specified fields to empty', () => {
-    const model = compatPreset().buildGraphql();
+    const model = graphqlPreset().build();
     validateCommonFields(model);
   });
 });

--- a/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.spec.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.spec.ts
@@ -1,0 +1,43 @@
+import type {
+  TAttributeGroupDraftGraphql,
+  TAttributeGroupDraftRest,
+} from '../../types';
+import { restPreset, graphqlPreset, compatPreset } from './empty';
+
+const validateCommonFields = (
+  model: TAttributeGroupDraftRest | TAttributeGroupDraftGraphql
+) => {
+  expect(model).toMatchObject({
+    key: expect.any(String),
+    name: expect.any(String),
+    description: undefined,
+    attributes: expect.any(Array),
+  });
+};
+
+describe('attribute-group-draft with empty fields', () => {
+  it('[REST] should set all specified fields to empty', () => {
+    const model = restPreset().buildRest();
+    validateCommonFields(model);
+  });
+
+  it('[GraphQL] should set all specified fields to empty', () => {
+    const model = graphqlPreset().buildGraphql();
+    validateCommonFields(model);
+  });
+
+  it('[Compat - DEFAULT] should set all specified fields to empty', () => {
+    const model = compatPreset().build();
+    validateCommonFields(model);
+  });
+
+  it('[Compat - REST] should set all specified fields to empty', () => {
+    const model = compatPreset().buildRest();
+    validateCommonFields(model);
+  });
+
+  it('[Compat - GraphQL] should set all specified fields to empty', () => {
+    const model = compatPreset().buildGraphql();
+    validateCommonFields(model);
+  });
+});

--- a/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.spec.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.spec.ts
@@ -8,8 +8,7 @@ const validateCommonFields = (
   model: TAttributeGroupDraftRest | TAttributeGroupDraftGraphql
 ) => {
   expect(model).toMatchObject({
-    key: expect.any(String),
-    name: expect.any(String),
+    key: undefined,
     description: undefined,
     attributes: expect.any(Array),
   });

--- a/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.ts
@@ -3,11 +3,7 @@ import {
   TAttributeGroupDraftGraphql,
   TAttributeGroupDraftRest,
 } from '../../types';
-import {
-  AttributeGroupDraftGraphql,
-  AttributeGroupDraftRest,
-  AttributeGroupDraft,
-} from '../index';
+import { AttributeGroupDraftGraphql, AttributeGroupDraftRest } from '../index';
 
 const populatePreset = <
   TModel extends TAttributeGroupDraftRest | TAttributeGroupDraftGraphql,
@@ -22,7 +18,3 @@ export const restPreset = (): TBuilder<TAttributeGroupDraftRest> =>
 
 export const graphqlPreset = (): TBuilder<TAttributeGroupDraftGraphql> =>
   populatePreset(AttributeGroupDraftGraphql.random());
-
-export const compatPreset = (): TBuilder<
-  TAttributeGroupDraftRest | TAttributeGroupDraftGraphql
-> => populatePreset(AttributeGroupDraft.random());

--- a/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.ts
@@ -1,0 +1,28 @@
+import { TBuilder } from '@/core';
+import {
+  TAttributeGroupDraftGraphql,
+  TAttributeGroupDraftRest,
+} from '../../types';
+import {
+  AttributeGroupDraftGraphql,
+  AttributeGroupDraftRest,
+  AttributeGroupDraft,
+} from '../index';
+
+const populatePreset = <
+  TModel extends TAttributeGroupDraftRest | TAttributeGroupDraftGraphql,
+>(
+  builder: TBuilder<TModel>
+) => {
+  return builder.name('').description(undefined).attributes([]);
+};
+
+export const restPreset = (): TBuilder<TAttributeGroupDraftRest> =>
+  populatePreset(AttributeGroupDraftRest.random());
+
+export const graphqlPreset = (): TBuilder<TAttributeGroupDraftGraphql> =>
+  populatePreset(AttributeGroupDraftGraphql.random());
+
+export const compatPreset = (): TBuilder<
+  TAttributeGroupDraftRest | TAttributeGroupDraftGraphql
+> => populatePreset(AttributeGroupDraft.random());

--- a/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/presets/empty.ts
@@ -14,7 +14,7 @@ const populatePreset = <
 >(
   builder: TBuilder<TModel>
 ) => {
-  return builder.name('').description(undefined).attributes([]);
+  return builder.description(undefined).key(undefined);
 };
 
 export const restPreset = (): TBuilder<TAttributeGroupDraftRest> =>

--- a/standalone/src/models/attribute-group/attribute-group-draft/presets/index.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/presets/index.ts
@@ -7,7 +7,3 @@ export const restPresets = {
 export const graphqlPresets = {
   empty: empty.graphqlPreset,
 };
-
-export const compatPresets = {
-  empty: empty.compatPreset,
-};

--- a/standalone/src/models/attribute-group/attribute-group-draft/presets/index.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/presets/index.ts
@@ -1,0 +1,13 @@
+import * as empty from './empty';
+
+export const restPresets = {
+  empty: empty.restPreset,
+};
+
+export const graphqlPresets = {
+  empty: empty.graphqlPreset,
+};
+
+export const compatPresets = {
+  empty: empty.compatPreset,
+};

--- a/standalone/src/models/attribute-group/attribute-reference/builders.spec.ts
+++ b/standalone/src/models/attribute-group/attribute-reference/builders.spec.ts
@@ -1,0 +1,23 @@
+import { AttributeReferenceRest, AttributeReferenceGraphql } from './index';
+
+describe('AttributeReference Builder', () => {
+  it('should build properties for the REST representation', () => {
+    const restModel = AttributeReferenceRest.random().build();
+
+    expect(restModel).toEqual(
+      expect.objectContaining({
+        key: expect.any(String),
+      })
+    );
+  });
+  it('should build properties for the GraphQL representation', () => {
+    const graphqlModel = AttributeReferenceGraphql.random().build();
+
+    expect(graphqlModel).toEqual(
+      expect.objectContaining({
+        key: expect.any(String),
+        __typename: 'AttributeReference',
+      })
+    );
+  });
+});

--- a/standalone/src/models/attribute-group/attribute-reference/builders.ts
+++ b/standalone/src/models/attribute-group/attribute-reference/builders.ts
@@ -1,0 +1,25 @@
+import { createSpecializedBuilder } from '@/core';
+import { restFieldsConfig, graphqlFieldsConfig } from './fields-config';
+import type {
+  TCreateAttributeReferenceBuilder,
+  TAttributeReferenceGraphql,
+  TAttributeReferenceRest,
+} from './types';
+
+export const RestModelBuilder: TCreateAttributeReferenceBuilder<
+  TAttributeReferenceRest
+> = () =>
+  createSpecializedBuilder({
+    name: 'AttributeReferenceRestBuilder',
+    type: 'rest',
+    modelFieldsConfig: restFieldsConfig,
+  });
+
+export const GraphqlModelBuilder: TCreateAttributeReferenceBuilder<
+  TAttributeReferenceGraphql
+> = () =>
+  createSpecializedBuilder({
+    name: 'AttributeReferenceGraphqlBuilder',
+    type: 'graphql',
+    modelFieldsConfig: graphqlFieldsConfig,
+  });

--- a/standalone/src/models/attribute-group/attribute-reference/fields-config.ts
+++ b/standalone/src/models/attribute-group/attribute-reference/fields-config.ts
@@ -1,0 +1,27 @@
+import { fake, type TModelFieldsConfig } from '@/core';
+import type {
+  TAttributeReferenceGraphql,
+  TAttributeReferenceRest,
+} from './types';
+
+// https://docs.commercetools.com/api/projects/attribute-groups#attributereference
+
+const commonFieldsConfig = {
+  key: fake((f) => f.lorem.slug(2)),
+};
+
+// TODO: You just need to place here fields initializers that don't match with the REST API
+export const restFieldsConfig: TModelFieldsConfig<TAttributeReferenceRest> = {
+  fields: {
+    ...commonFieldsConfig,
+  },
+};
+
+// TODO: You just need to place here fields initializers that don't match with the GraphQL API
+export const graphqlFieldsConfig: TModelFieldsConfig<TAttributeReferenceGraphql> =
+  {
+    fields: {
+      ...commonFieldsConfig,
+      __typename: 'AttributeReference',
+    },
+  };

--- a/standalone/src/models/attribute-group/attribute-reference/index.ts
+++ b/standalone/src/models/attribute-group/attribute-reference/index.ts
@@ -1,0 +1,13 @@
+import { RestModelBuilder, GraphqlModelBuilder } from './builders';
+import * as AttributeReferencePresets from './presets';
+export * from './types';
+
+export const AttributeReferenceRest = {
+  random: RestModelBuilder,
+  presets: AttributeReferencePresets.restPresets,
+};
+
+export const AttributeReferenceGraphql = {
+  random: GraphqlModelBuilder,
+  presets: AttributeReferencePresets.graphqlPresets,
+};

--- a/standalone/src/models/attribute-group/attribute-reference/presets/index.ts
+++ b/standalone/src/models/attribute-group/attribute-reference/presets/index.ts
@@ -1,0 +1,2 @@
+export const restPresets = {};
+export const graphqlPresets = {};

--- a/standalone/src/models/attribute-group/attribute-reference/types.ts
+++ b/standalone/src/models/attribute-group/attribute-reference/types.ts
@@ -1,0 +1,10 @@
+import { AttributeReference } from '@commercetools/platform-sdk';
+import type { TBuilder } from '@/core';
+import { TCtpAttributeReference } from '@/graphql-types';
+
+export type TAttributeReferenceRest = AttributeReference;
+export type TAttributeReferenceGraphql = TCtpAttributeReference;
+
+export type TCreateAttributeReferenceBuilder<
+  TModel extends TAttributeReferenceRest | TAttributeReferenceGraphql,
+> = () => TBuilder<TModel>;

--- a/standalone/src/models/attribute-group/index.ts
+++ b/standalone/src/models/attribute-group/index.ts
@@ -1,5 +1,7 @@
+// Main AttributeGroup exports (if any)
 export * as AttributeGroup from '.';
-
 export { default as random } from './builder';
 export * as presets from './presets';
 export * from './types';
+
+export * from './attribute-group-draft';

--- a/standalone/src/models/attribute-group/types.ts
+++ b/standalone/src/models/attribute-group/types.ts
@@ -1,7 +1,6 @@
 import type {
   AttributeGroup,
   AttributeGroupDraft,
-  AttributeReference,
 } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@/core';
 import type { TCtpAttributeGroupDraft } from '@/graphql-types';
@@ -23,10 +22,11 @@ export type TAttributeGroupGraphql = Omit<
 export type TAttributeGroupBuilder = TBuilder<AttributeGroup>;
 export type TCreateAttributeGroupBuilder = () => TAttributeGroupBuilder;
 
-export type TAttributeGroupDraft = AttributeGroupDraft;
-export type TAttributeGroupDraftRest = TAttributeGroupDraft;
+export type TAttributeGroupDraftRest = AttributeGroupDraft;
 export type TAttributeGroupDraftGraphql = TCtpAttributeGroupDraft;
 
-export type TAttributeGroupDraftBuilder = TBuilder<TAttributeGroupDraft>;
+export type TAttributeGroupDraftBuilder = TBuilder<
+  TAttributeGroupDraftRest | TAttributeGroupDraftGraphql
+>;
 export type TCreateAttributeGroupDraftBuilder =
   () => TAttributeGroupDraftBuilder;

--- a/standalone/src/models/attribute-group/types.ts
+++ b/standalone/src/models/attribute-group/types.ts
@@ -1,6 +1,9 @@
 import type { AttributeGroup } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@/core';
-import { TLocalizedStringGraphql } from '@/models/commons';
+import {
+  TLocalizedStringDraft,
+  TLocalizedStringGraphql,
+} from '@/models/commons';
 
 export type TAttributeGroup = AttributeGroup;
 
@@ -17,3 +20,31 @@ export type TAttributeGroupGraphql = Omit<
 
 export type TAttributeGroupBuilder = TBuilder<AttributeGroup>;
 export type TCreateAttributeGroupBuilder = () => TAttributeGroupBuilder;
+
+export type TAttributeGroupDraftRest = TAttributeGroupDraft;
+
+export type TAttributeReference = {
+  key: string;
+};
+
+export type TAttributeGroupDraft = {
+  key: string;
+  name: TLocalizedStringDraft;
+  description?: TLocalizedStringDraft;
+  attributes?: TAttributeReference[];
+};
+
+export type TAttributeGroupDraftGraphql = Omit<
+  TAttributeGroupDraft,
+  'name' | 'description'
+> & {
+  name: string;
+  nameAllLocales?: TLocalizedStringGraphql | null;
+  description?: string | null;
+  descriptionAllLocales?: TLocalizedStringGraphql | null;
+  __typename: 'AttributeGroupDraft';
+};
+
+export type TAttributeGroupDraftBuilder = TBuilder<TAttributeGroupDraft>;
+export type TCreateAttributeGroupDraftBuilder =
+  () => TAttributeGroupDraftBuilder;

--- a/standalone/src/models/attribute-group/types.ts
+++ b/standalone/src/models/attribute-group/types.ts
@@ -1,9 +1,11 @@
-import type { AttributeGroup } from '@commercetools/platform-sdk';
+import type {
+  AttributeGroup,
+  AttributeGroupDraft,
+  AttributeReference,
+} from '@commercetools/platform-sdk';
 import type { TBuilder } from '@/core';
-import {
-  TLocalizedStringDraft,
-  TLocalizedStringGraphql,
-} from '@/models/commons';
+import type { TCtpLocalizedStringItemInputType } from '@/graphql-types';
+import { TLocalizedStringGraphql } from '@/models/commons';
 
 export type TAttributeGroup = AttributeGroup;
 
@@ -21,27 +23,18 @@ export type TAttributeGroupGraphql = Omit<
 export type TAttributeGroupBuilder = TBuilder<AttributeGroup>;
 export type TCreateAttributeGroupBuilder = () => TAttributeGroupBuilder;
 
+export type TAttributeGroupDraft = AttributeGroupDraft;
+
 export type TAttributeGroupDraftRest = TAttributeGroupDraft;
-
-export type TAttributeReference = {
-  key: string;
-};
-
-export type TAttributeGroupDraft = {
-  key: string;
-  name: TLocalizedStringDraft;
-  description?: TLocalizedStringDraft;
-  attributes?: TAttributeReference[];
-};
 
 export type TAttributeGroupDraftGraphql = Omit<
   TAttributeGroupDraft,
   'name' | 'description'
 > & {
-  name: string;
-  nameAllLocales?: TLocalizedStringGraphql | null;
-  description?: string | null;
-  descriptionAllLocales?: TLocalizedStringGraphql | null;
+  name: TCtpLocalizedStringItemInputType[];
+  description?: TCtpLocalizedStringItemInputType[] | null;
+  attributes: AttributeReference[];
+  key?: string;
   __typename: 'AttributeGroupDraft';
 };
 

--- a/standalone/src/models/attribute-group/types.ts
+++ b/standalone/src/models/attribute-group/types.ts
@@ -4,7 +4,7 @@ import type {
   AttributeReference,
 } from '@commercetools/platform-sdk';
 import type { TBuilder } from '@/core';
-import type { TCtpLocalizedStringItemInputType } from '@/graphql-types';
+import type { TCtpAttributeGroupDraft } from '@/graphql-types';
 import { TLocalizedStringGraphql } from '@/models/commons';
 
 export type TAttributeGroup = AttributeGroup;
@@ -24,19 +24,8 @@ export type TAttributeGroupBuilder = TBuilder<AttributeGroup>;
 export type TCreateAttributeGroupBuilder = () => TAttributeGroupBuilder;
 
 export type TAttributeGroupDraft = AttributeGroupDraft;
-
 export type TAttributeGroupDraftRest = TAttributeGroupDraft;
-
-export type TAttributeGroupDraftGraphql = Omit<
-  TAttributeGroupDraft,
-  'name' | 'description'
-> & {
-  name: TCtpLocalizedStringItemInputType[];
-  description?: TCtpLocalizedStringItemInputType[] | null;
-  attributes: AttributeReference[];
-  key?: string;
-  __typename: 'AttributeGroupDraft';
-};
+export type TAttributeGroupDraftGraphql = TCtpAttributeGroupDraft;
 
 export type TAttributeGroupDraftBuilder = TBuilder<TAttributeGroupDraft>;
 export type TCreateAttributeGroupDraftBuilder =


### PR DESCRIPTION
Creates the `attribute-group-draft` model, an empty preset, and the attribute-reference(used internally). 