### PR TITLE
Fix AttributeGroupDraft test-data model

### DIFF
--- a/.changeset/olive-icons-stare.md
+++ b/.changeset/olive-icons-stare.md
@@ -1,0 +1,18 @@
+---
+'@commercetools/composable-commerce-test-data': patch
+---
+
+We've fixed an error in the `AttributeGroupDraft` test-data model as its name was not populated with a draft model.
+
+Also, we've updated the entry point of the `@commercetools/composable-commerce-test-data/attribute-group` package entry point so it also exports the `AttributeReference` model.
+It can be used like this:
+
+```ts
+import {
+  AttributeReferenceGraphql,
+  AttributeReferenceRest,
+} from '@commercetools/composable-commerce-test-data/attribute-group';
+
+const graphqlModel = AttributeReferenceGraphql.random().build();
+const restModel = AttributeReferenceRest.random().build();
+```

--- a/standalone/src/models/attribute-group/attribute-group-draft/builder.spec.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/builder.spec.ts
@@ -5,8 +5,6 @@ import type {
 import { AttributeGroupDraftGraphql, AttributeGroupDraftRest } from './index';
 
 const validateRestModel = (model: TAttributeGroupDraftRest) => {
-  console.log('Rest model', model);
-
   expect(model).toEqual(
     expect.objectContaining({
       key: null,
@@ -22,7 +20,6 @@ const validateRestModel = (model: TAttributeGroupDraftRest) => {
 };
 
 const validateGraphqlModel = (model: TAttributeGroupDraftGraphql) => {
-  console.log('GraphQL model', model);
   expect(model).toEqual(
     expect.objectContaining({
       key: null,
@@ -30,7 +27,6 @@ const validateGraphqlModel = (model: TAttributeGroupDraftGraphql) => {
         expect.objectContaining({
           locale: expect.any(String),
           value: expect.any(String),
-          __typename: 'LocalizedString',
         }),
       ]),
       description: null,

--- a/standalone/src/models/attribute-group/attribute-group-draft/fields-config.ts
+++ b/standalone/src/models/attribute-group/attribute-group-draft/fields-config.ts
@@ -1,5 +1,5 @@
 import { fake, type TModelFieldsConfig } from '@/core';
-import { LocalizedString } from '@/models/commons';
+import { LocalizedStringDraft } from '@/models/commons';
 import {
   AttributeReferenceRest,
   AttributeReferenceGraphql,
@@ -14,7 +14,7 @@ import type {
 const commonFieldsConfig = {
   key: null,
   description: null,
-  name: fake(() => LocalizedString.random()),
+  name: fake(() => LocalizedStringDraft.random()),
 };
 
 export const restFieldsConfig: TModelFieldsConfig<TAttributeGroupDraftRest> = {

--- a/standalone/src/models/attribute-group/index.ts
+++ b/standalone/src/models/attribute-group/index.ts
@@ -5,3 +5,4 @@ export * as presets from './presets';
 export * from './types';
 
 export * from './attribute-group-draft';
+export * from './attribute-reference';


### PR DESCRIPTION
## Description

We've fixed an error in the `AttributeGroupDraft` test-data model as its name was not populated with a draft model.

Also, we've updated the entry point of the `@commercetools/composable-commerce-test-data/attribute-group` package entry point so it also exports the `AttributeReference` model.
It can be used like this:
```ts
import {
  AttributeReferenceGraphql,
  AttributeReferenceRest,
} from '@commercetools/composable-commerce-test-data/attribute-group';

const graphqlModel = AttributeReferenceGraphql.random().build();
const restModel = AttributeReferenceRest.random().build();
```


I want to also migrate the `AttributeGroup` test-data model as a follow-up, but on it's own PR.