### PR TITLE
feat(supply-chain): upgrade pnpm to 11, workspace updates, deps and a…

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", ":pinOnlyDevDependencies", "schedule:monthly"],
+  "extends": ["github>commercetools/renovate-config", "config:base", ":pinOnlyDevDependencies", "schedule:monthly"],
   "separateMajorMinor": true,
   "packageRules": [
     {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,16 +11,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4.2.0
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         id: pnpm-install
         with:
           run_install: false
 
       - name: Setup Node (uses version in .nvmrc)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
@@ -18,13 +18,13 @@ jobs:
           git checkout -
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4.2.0
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         id: pnpm-install
         with:
           run_install: false
 
       - name: Setup Node (uses version in .nvmrc)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
        # Get GitHub token via the CT Changesets App
       - name: Generate GitHub token (via CT Changesets App)
         id: generate_github_token
-        uses: tibdex/github-app-token@v2.1.0
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
           private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
           
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           # Pass a personal access token (using our `ct-changesets` app) to be able to trigger other workflows
           # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
@@ -27,13 +27,13 @@ jobs:
           token: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4.2.0
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         id: pnpm-install
         with:
           run_install: false
 
       - name: Setup Node (uses version in .nvmrc)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -55,7 +55,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: pnpm changeset publish
           version: pnpm changeset:version-and-format

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "generate-model": "pnpm --filter @commercetools-test-data/generators generate"
   },
   "dependencies": {
-    "@babel/core": "^7.21.0",
+    "@babel/core": "7.26.10",
     "@changesets/changelog-github": "0.5.1",
     "@changesets/cli": "2.29.7",
     "@commercetools-frontend/babel-preset-mc-app": "24.8.0",
@@ -45,15 +45,15 @@
     "@manypkg/cli": "0.25.1",
     "@manypkg/find-root": "3.1.0",
     "@preconstruct/cli": "2.8.12",
-    "@types/jest": "^29.4.0",
+    "@types/jest": "29.5.14",
     "@types/node": "22.18.9",
     "babel-jest": "29.7.0",
-    "babel-plugin-module-resolver": "^5.0.2",
+    "babel-plugin-module-resolver": "5.0.2",
     "cross-env": "10.1.0",
     "dotenv": "17.2.3",
     "eslint": "8.57.1",
     "eslint-formatter-pretty": "5.0.0",
-    "find-up": "^7.0.0",
+    "find-up": "7.0.0",
     "husky": "9.1.7",
     "jest": "29.7.0",
     "jest-extended": "6.0.0",
@@ -63,9 +63,9 @@
     "jest-watch-typeahead": "2.2.2",
     "lint-staged": "15.5.2",
     "prettier": "3.6.2",
-    "prettier-jest": "npm:prettier@^3.0.0",
-    "tsc-files": "^1.1.3",
+    "prettier-jest": "npm:prettier@3.5.3",
+    "tsc-files": "1.1.4",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@10.18.2"
+  "packageManager": "pnpm@11.10.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@babel/core':
-        specifier: ^7.21.0
+        specifier: 7.26.10
         version: 7.26.10
       '@changesets/changelog-github':
         specifier: 0.5.1
@@ -60,7 +60,7 @@ importers:
         specifier: 2.8.12
         version: 2.8.12
       '@types/jest':
-        specifier: ^29.4.0
+        specifier: 29.5.14
         version: 29.5.14
       '@types/node':
         specifier: 22.18.9
@@ -69,7 +69,7 @@ importers:
         specifier: 29.7.0
         version: 29.7.0(@babel/core@7.26.10)
       babel-plugin-module-resolver:
-        specifier: ^5.0.2
+        specifier: 5.0.2
         version: 5.0.2
       cross-env:
         specifier: 10.1.0
@@ -84,7 +84,7 @@ importers:
         specifier: 5.0.0
         version: 5.0.0
       find-up:
-        specifier: ^7.0.0
+        specifier: 7.0.0
         version: 7.0.0
       husky:
         specifier: 9.1.7
@@ -114,10 +114,10 @@ importers:
         specifier: 3.6.2
         version: 3.6.2
       prettier-jest:
-        specifier: npm:prettier@^3.0.0
+        specifier: npm:prettier@3.5.3
         version: prettier@3.5.3
       tsc-files:
-        specifier: ^1.1.3
+        specifier: 1.1.4
         version: 1.1.4(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
@@ -160,31 +160,31 @@ importers:
   standalone:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.17.9
+        specifier: 7.26.10
         version: 7.26.10
       '@babel/runtime-corejs3':
-        specifier: ^7.17.9
+        specifier: 7.26.10
         version: 7.26.10
       '@commercetools-frontend/application-config':
-        specifier: ^24.0.0
+        specifier: 24.2.1
         version: 24.2.1(@types/node@22.18.9)(typescript@5.9.3)
       '@commercetools-frontend/constants':
-        specifier: ^24.0.0
+        specifier: 24.2.1
         version: 24.2.1
       '@commercetools/platform-sdk':
         specifier: 8.18.0
         version: 8.18.0
       '@faker-js/faker':
-        specifier: ^9.0.0
+        specifier: 9.6.0
         version: 9.6.0
       '@types/lodash':
-        specifier: ^4.17.0
+        specifier: 4.17.16
         version: 4.17.16
       lodash:
-        specifier: ^4.17.21
+        specifier: 4.17.21
         version: 4.17.21
       omit-deep:
-        specifier: ^0.3.0
+        specifier: 0.3.0
         version: 0.3.0
 
 packages:
@@ -1967,6 +1967,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-darwin-arm64@1.3.3':
     resolution: {integrity: sha512-EpRILdWr3/xDa/7MoyfO7JuBIJqpBMphtu4+80BK1bRfFcniVT74h3Z7q1+WOc92FuIAYatB1vn9TJR67sORGw==}
@@ -1997,31 +1998,37 @@ packages:
     resolution: {integrity: sha512-v81R2wjqcWXJlQY23byqYHt9221h4anQ6wwN64oMD/WAE+FmxPHFZee5bhRkNVtzqO/q7wki33VFWlhiADwUeQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.3.3':
     resolution: {integrity: sha512-cAOx/j0u5coMg4oct/BwMzvWJdVciVauUvsd+GQB/1FZYKQZmqPy0EjJzJGbVzFc6gbnfEcSqvQE6gvbGf2N8Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.3.3':
     resolution: {integrity: sha512-mq2blqwErgDJD4gtFDlTX/HZ7lNP8YCHYFij2gkXPtMzrXxPW1hOtxL6xg4NWxvnj4bppppb0W3s/buvM55yfg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.3.3':
     resolution: {integrity: sha512-u0VRzfFYysarYHnztj2k2xr+eu9rmgoTUUgCCIT37Nr+j0A05Xk2c3RY8Mh5+DhCl2aYibihnaAEJHeR0UOFIQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.3.3':
     resolution: {integrity: sha512-OrVo5ZsG29kBF0Ug95a2KidS16PqAMmQNozM6InbquOfW/udouk063e25JVLqIBhHLB2WyBnixOQ19tmeC/hIg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.3.3':
     resolution: {integrity: sha512-PYnmrwZ4HMp9SkrOhqPghY/aoL+Rtd4CQbr93GlrRTjK6kDzfMfgz3UH3jt6elrQAfupa1qyr1uXzeVmoEAxUA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.3.3':
     resolution: {integrity: sha512-81AnQY6fShmktQw4hWDUIilsKSdvr/acdJ5azAreu2IWNlaJOKphJSsUVWE+yCk6kBMoQyG9ZHCb/krb5K0PEA==}
@@ -3256,6 +3263,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-base@0.3.0:
@@ -3275,11 +3283,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -5366,6 +5375,7 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -6572,7 +6582,7 @@ snapshots:
       confusing-browser-globals: 1.0.11
       eslint: 8.57.1
       eslint-config-prettier: 8.10.0(eslint@8.57.1)
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-cypress: 2.15.2(eslint@8.57.1)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@29.7.0(@types/node@22.18.9)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
@@ -9162,7 +9172,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -9177,14 +9187,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9204,7 +9214,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,17 @@
 packages:
-- "generators"
-- "standalone"
+  - "generators"
+  - "standalone"
+
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@commercetools/*'
+  - '@commercetools-frontend/*'
+  - '@commercetools-backend/*'
+  - '@commercetools-uikit/*'
+
+blockExoticSubdeps: true
+
+allowBuilds:
+  core-js: false
+  core-js-pure: false
+  esbuild: false

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -131,14 +131,14 @@
     ]
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
-    "@babel/runtime-corejs3": "^7.17.9",
-    "@commercetools-frontend/application-config": "^24.0.0",
-    "@commercetools-frontend/constants": "^24.0.0",
+    "@babel/runtime": "7.26.10",
+    "@babel/runtime-corejs3": "7.26.10",
+    "@commercetools-frontend/application-config": "24.2.1",
+    "@commercetools-frontend/constants": "24.2.1",
     "@commercetools/platform-sdk": "8.18.0",
-    "@faker-js/faker": "^9.0.0",
-    "@types/lodash": "^4.17.0",
-    "lodash": "^4.17.21",
-    "omit-deep": "^0.3.0"
+    "@faker-js/faker": "9.6.0",
+    "@types/lodash": "4.17.16",
+    "lodash": "4.17.21",
+    "omit-deep": "0.3.0"
   }
 }


### PR DESCRIPTION
## FEC-963 Supply Chain Hardening

Pilot supply chain hardening for this repo as part of [FEC-964](https://commercetools.atlassian.net/browse/FEC-964). Applies the full set of hardening measures described in the epic.

### Changes

**pnpm v11 upgrade**

Bumped `packageManager` from `pnpm@10.18.2` to `pnpm@11.10.0`. pnpm v11 ships with supply chain protections built-in that back the settings below.

**Supply chain settings in `pnpm-workspace.yaml`**

Added explicit security configuration at the workspace level:

- `minimumReleaseAge: 1440` — new package versions must be at least 24 hours old before pnpm will install them, guarding against "package planting" attacks on freshly published versions.
- `minimumReleaseAgeExclude` — bypasses the age check for all `@commercetools/*`, `@commercetools-frontend/*`, `@commercetools-backend/*`, and `@commercetools-uikit/*` packages so internal releases aren't gated.
- `blockExoticSubdeps: true` — prevents installation of dependencies with unusual or non-standard resolution strategies.
- `allowBuilds` — explicit allowlist controlling which packages can run lifecycle scripts (postinstall/install) during `pnpm install`. See note below.

**`allowBuilds` exceptions**

Three packages declared lifecycle scripts and were surfaced by `pnpm approve-builds` after the initial install. All three were set to `false` (blocked):

- `core-js` and `core-js-pure` — their postinstall script only prints a donation/sponsor message; the packages function correctly without running it.
- `esbuild` — since esbuild 0.17+, the platform-specific binary is delivered via optional dependencies (`@esbuild/darwin-arm64`, `@esbuild/linux-x64`, etc.), which pnpm already resolves. The postinstall script is only a fallback for package managers that skip optional deps; it is not needed here.

**Exact dependency pinning**

Removed all `^` ranges from direct dependencies and replaced them with the exact versions already present in the lockfile. Affected packages:

- Root `package.json`: `@babel/core`, `@types/jest`, `babel-plugin-module-resolver`, `find-up`, `prettier-jest`, `tsc-files`
- `standalone/package.json`: `@babel/runtime`, `@babel/runtime-corejs3`, `@commercetools-frontend/application-config`, `@commercetools-frontend/constants`, `@faker-js/faker`, `@types/lodash`, `lodash`, `omit-deep`

`generators/package.json` was already fully pinned.

**GitHub Actions pinned to commit SHAs**

All action references in all three workflow files (`main.yml`, `pull-request.yml`, `release.yml`) are now pinned to full-length commit SHAs with trailing version comments, preventing tag-mutation attacks:

- `actions/checkout` → `93cb6efe...` <!-- v5.0.1 -->
- `pnpm/action-setup` → `41ff7265...` <!-- v4.2.0 -->
- `actions/setup-node` → `49933ea5...` <!-- v4.4.0 -->
- `tibdex/github-app-token` → `3beb63f4...` <!-- v2.1.0 -->
- `changesets/action` → `a45c4d59...` <!-- v1.9.0 -->

**Renovate config**

Added `"github>commercetools/renovate-config"` as the first entry in `renovate.json`'s `extends` array so this repo inherits the shared security presets introduced in FEC-962. Existing local rules are preserved.


[FEC-964]: https://commercetools.atlassian.net/browse/FEC-964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ