### PR TITLE
fix(supply chain): add minimumReleaseAgeStrict + minimumReleaseAgeIgn…

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,11 @@ minimumReleaseAgeExclude:
   - '@commercetools-backend/*'
   - '@commercetools-uikit/*'
 
+# minimumReleaseAge set explicitly flips this to hard-fail; false restores pnpm's soft fall-back so clean CI/Vercel installs don't break.
+minimumReleaseAgeStrict: false
+# Skip the age gate for packages whose registry metadata lacks a publish time (pnpm/pnpm#11616).
+minimumReleaseAgeIgnoreMissingTime: true
+
 blockExoticSubdeps: true
 
 allowBuilds:


### PR DESCRIPTION
This pull request makes a configuration update to `pnpm-workspace.yaml` to improve CI and deployment reliability by adjusting how `minimumReleaseAge` is enforced. The main changes ensure that package installations do not fail unnecessarily due to missing publish times or strict age gating.

Configuration improvements:

* Added `minimumReleaseAgeStrict: false` to restore pnpm's soft fallback behavior, preventing hard failures during clean CI or Vercel installs.
* Added `minimumReleaseAgeIgnoreMissingTime: true` to skip the age check for packages lacking registry publish time metadata, addressing issues like pnpm/pnpm#11616.