### PR TITLE
fix(supply-chain): adopt strict minimumReleaseAge posture

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,10 +9,10 @@ minimumReleaseAgeExclude:
   - '@commercetools-backend/*'
   - '@commercetools-uikit/*'
 
-# minimumReleaseAge set explicitly flips this to hard-fail; false restores pnpm's soft fall-back so clean CI/Vercel installs don't break.
-minimumReleaseAgeStrict: false
-# Skip the age gate for packages whose registry metadata lacks a publish time (pnpm/pnpm#11616).
-minimumReleaseAgeIgnoreMissingTime: true
+# Explicit minimumReleaseAge already makes pnpm hard-fail on a no-mature-match; true keeps that (no silent fall-back or auto-exclude).
+minimumReleaseAgeStrict: true
+# Deliberate tightening: enforce the gate even when registry metadata omits a publish time, so a time-less mirror can't waive the cooldown.
+minimumReleaseAgeIgnoreMissingTime: false
 
 blockExoticSubdeps: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,11 @@ minimumReleaseAgeExclude:
   - '@commercetools-backend/*'
   - '@commercetools-uikit/*'
 
+# minimumReleaseAge set explicitly flips this to hard-fail; false restores pnpm's soft fall-back so clean CI/Vercel installs don't break.
+minimumReleaseAgeStrict: false
+# Skip the age gate for packages whose registry metadata lacks a publish time (pnpm/pnpm#11616).
+minimumReleaseAgeIgnoreMissingTime: true
+
 blockExoticSubdeps: true
 
 allowBuilds:


### PR DESCRIPTION
Flip the pnpm age-gate from the soft fall-back to the strict posture, aligning with commercetools/nimbus#1859.

- `minimumReleaseAgeStrict: false -> true` — no silent fall-back (or auto-generated exclude) when no version satisfies a range within the 24h gate.
- `minimumReleaseAgeIgnoreMissingTime: true -> false` — enforce the gate even when a package's registry metadata omits a publish time.

No lockfile or dependency-graph change — these are resolution-policy flags only, so `--frozen-lockfile` stays valid; the flip just changes how the next resolution behaves.

Refs: FEC-1199 (epic FEC-964 — Supply Chain Hardening)