### PR TITLE
chore(deps): bump pnpm to 11.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,5 @@
     "tsc-files": "1.1.4",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@11.10.0"
+  "packageManager": "pnpm@11.14.0+sha512.66c1ac4c7d4762d6d7dde44c7f3e5a73591ed0a0806e751d4ed32d4f004f25b2285a906b1fd8a9e3e621df3b4e2858bf88e50e0cf626bedbe977fe434a5caf85"
 }


### PR DESCRIPTION
## What

Bumps the pinned `packageManager` field from `pnpm@11.10.0` to:

```
pnpm@11.14.0+sha512.66c1ac4c7d4762d6d7dde44c7f3e5a73591ed0a0806e751d4ed32d4f004f25b2285a906b1fd8a9e3e621df3b4e2858bf88e50e0cf626bedbe977fe434a5caf85
```

## Why

This matches the exact pnpm version already running cleanly in sibling repos (merchant-center-application-kit, nimbus, ui-kit, merchant-center-frontend).

When pinned to 11.10.0, this repo predates two confirmed, since-fixed upstream pnpm memory regressions:

- [pnpm/pnpm#12868](https://github.com/pnpm/pnpm/issues/12868): pnpm 11 resolution uses ~47% more memory than pnpm 10 on a cold metadata cache, fixed by [pnpm/pnpm#12870](https://github.com/pnpm/pnpm/pull/12870), merged 2026-07-09.
- [pnpm/pnpm#13077](https://github.com/pnpm/pnpm/issues/13077): pnpm 11.11+ OOMs by re-serializing full package metadata for concurrent workspace cache hits, fixed by [pnpm/pnpm#13079](https://github.com/pnpm/pnpm/pull/13079), merged 2026-07-16.

There is no known active OOM crash evidence in this repo (unlike some siblings). This is a proactive bump to bring it in line with siblings and past both regressions.

## Verification

Installed and used pnpm 11.14.0 via `corepack use pnpm@11.14.0`, then ran a full `pnpm install` (not `--lockfile-only`) to regenerate the lockfile against the new pnpm version.

- `pnpm-lock.yaml`: no diff. Matches what sibling repos saw when they made the same bump.
- `pnpm typecheck` (`tsc --noEmit`): passes, no errors.
- `pnpm build` (`preconstruct build`): passes.
- `pnpm lint` (`jest --config jest.eslint.config.js`): 2820 suites passed.
- `pnpm test` (`jest --config jest.test.config.js`): 535 suites, 1691 tests, 42 snapshots, all passed.

Nothing broke as a result of the pnpm version bump.

## Notes

- Draft PR, not merged per convention. `pnpm-lock.yaml` unchanged, only `package.json`'s `packageManager` field is touched.
