### PR TITLE
chore(renovate): hold pnpm at 11.10.0 until deploy --legacy regression is fixed

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,11 @@
         "tsc-files"
       ],
       "groupName": "build and dev tools"
+    },
+    {
+      "description": "pnpm is pinned to 11.10.0 via packageManager. Versions past 11.14.0 have broken `deploy: legacy` support. We don't currently run `pnpm deploy --legacy` here, but holding as a precaution until that's fixed upstream, then remove this rule.",
+      "matchPackageNames": ["pnpm"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a `packageRules` entry to `.github/renovate.json` that disables Renovate-proposed `pnpm` version bumps, holding the current pin at `pnpm@11.10.0`.

## Why

pnpm/pnpm#13618 documents a regression in `pnpm deploy --legacy`, first appearing in pnpm 11.19.0 and still present in 11.20.0 (the current published latest). A workspace dependency that has `peerDependencies` is left as a symlink escaping the deploy directory instead of being packed into it. In a typical Docker flow (`COPY ./deploy .` into an image), the symlink dangles inside the container and the app crashes at runtime, not at build time.

The fix (pnpm/pnpm#13755) merged upstream but has not shipped in any published pnpm release yet.

This repo does not currently run `pnpm deploy --legacy` in a Docker build, so this hold is precautionary rather than a response to an observed break here. It mirrors the guard already in place on `commercetools/nimbus`'s `.github/renovate.json`.

## Follow-up

Remove this rule once a pnpm release ships with the fix from pnpm/pnpm#13755.
