### PR TITLE
chore(deps): trivial major-version dependency migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "dotenv": "17.2.3",
     "eslint": "8.57.1",
     "eslint-formatter-pretty": "5.0.0",
-    "find-up": "7.0.0",
+    "find-up": "8.0.0",
     "husky": "9.1.7",
     "jest": "30.2.0",
     "jest-extended": "6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0
       find-up:
-        specifier: 7.0.0
-        version: 7.0.0
+        specifier: 8.0.0
+        version: 8.0.0
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -5139,6 +5139,10 @@ packages:
     resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
     engines: {node: '>=18'}
 
+  find-up@8.0.0:
+    resolution: {integrity: sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==}
+    engines: {node: '>=20'}
+
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -6381,6 +6385,10 @@ packages:
   locate-path@7.2.0:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  locate-path@8.0.0:
+    resolution: {integrity: sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==}
+    engines: {node: '>=20'}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -8358,6 +8366,10 @@ packages:
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
   universalify@0.1.2:
@@ -15237,6 +15249,11 @@ snapshots:
       path-exists: 5.0.0
       unicorn-magic: 0.1.0
 
+  find-up@8.0.0:
+    dependencies:
+      locate-path: 8.0.0
+      unicorn-magic: 0.3.0
+
   flat-cache@3.2.0:
     dependencies:
       flatted: 3.3.4
@@ -16790,6 +16807,10 @@ snapshots:
       p-locate: 5.0.0
 
   locate-path@7.2.0:
+    dependencies:
+      p-locate: 6.0.0
+
+  locate-path@8.0.0:
     dependencies:
       p-locate: 6.0.0
 
@@ -18828,6 +18849,8 @@ snapshots:
   unicode-property-aliases-ecmascript@2.2.0: {}
 
   unicorn-magic@0.1.0: {}
+
+  unicorn-magic@0.3.0: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
## Summary

Bumps `find-up` from `7.0.0` to `8.0.0` (devDependency only).

## Included

- **find-up**: `7.0.0` → `8.0.0` (devDependency). A full-repo grep confirmed the only occurrences of `find-up` are the `package.json` version string itself and a mention in `.github/renovate.json` — there are no source-code imports of `find-up` anywhere in this repo, and nothing imports `pathExists` from it. This bump required **no call-site code changes**, purely a manifest + lockfile update.
  - Upstream breaking changes for v7 → v8, both verified not applicable here:
    1. Requires Node.js >=20 — already satisfied, this repo is on Node 24 per `.nvmrc`.
    2. No longer re-exports `path-exists` — consumers must import `path-exists` directly if they used that re-export. Not used in this repo.

## Excluded as not trivial (context for reviewers)

The Dependency Dashboard has several other pending major-version bumps. Each was evaluated and excluded from this PR because it's a framework/tooling migration or otherwise out of scope for a "trivial mechanical bump" PR, not because it's risky in a specific way that was investigated in depth here:

| Dependency / group | Reason excluded |
| --- | --- |
| `actions/checkout`, `actions/setup-node`, `pnpm/action-setup` (GH Actions majors) | CI tooling major bumps — out of scope per policy |
| All `@commercetools-frontend/*` application-kit packages | Framework migration (24.x → 27.x) — out of scope per policy |
| All babel packages (major) | Framework/build-tooling migration — out of scope per policy |
| `@commitlint/cli`, `@commitlint/config-conventional`, `lint-staged` (git-workflow-tools major) | See note below — evaluated but not included |
| All `@graphql-codegen/*` packages | Code-generation tooling migration — out of scope per policy |
| All jest packages (major) | Test-framework migration — out of scope per policy |
| `eslint`, `eslint-formatter-pretty` | Linting framework migration — out of scope per policy |
| `@commercetools/platform-sdk` (v9) | SDK major migration — out of scope per policy |

### Flagged for manual review (not blind-included)

`@commitlint/cli`, `@commitlint/config-conventional`, and `lint-staged` were specifically evaluated for this batch and **not** included. They are git-hook/workflow tooling spanning two majors each, with real config-schema risk (commitlint rule changes, lint-staged config format changes) rather than a purely mechanical version bump. Recommending these go through manual review rather than blind inclusion in a "trivial" batch.

## Changeset

No changeset was added. Per `CONTRIBUTING.md`, "a changeset is not required, as things like documentation or other changes in the repository itself generally don't need a changeset," and PR #1033 (a comparable pure dependency-bump/consolidation PR) included zero changeset files. This PR mirrors that convention: it's a devDependency-only bump with no consumer-facing package version change.

## Verification

Ran the full local verification suite in an isolated worktree:

- `pnpm typecheck` (`tsc --noEmit`) — pass
- `pnpm build` (`preconstruct build`) — pass
- `pnpm test` (`jest`) — 535 suites / 1691 tests — pass
- `pnpm lint` (`jest --config jest.eslint.config.js`) — 2820 suites — pass

All green, consistent with `find-up` having zero source-code call sites in this repo.

## Notes

- This PR does not merge or close any other PR. It is separate from, and unrelated to, #1033 (`chore/renovate-batch-consolidation`), which was left untouched.
