### PR TITLE
chore(deps): TypeScript major version migration (pathfinder)

### DIFF
--- a/generators/package.json
+++ b/generators/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@types/lodash": "4.17.21",
     "@types/mustache": "4.2.6",
-    "@types/prompts": "2.4.9"
+    "@types/prompts": "2.4.9",
+    "typescript": "6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prettier": "3.7.4",
     "prettier-jest": "npm:prettier@3.7.4",
     "tsc-files": "1.1.4",
-    "typescript": "5.9.3"
+    "typescript": "7.0.2"
   },
   "packageManager": "pnpm@11.10.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+packageExtensionsChecksum: sha256-o2pQxcN05k0XVnhXXkq4L4rjHMAV8Rh+/PLO3KEnkkU=
+
 importers:
 
   .:
@@ -25,10 +27,10 @@ importers:
         version: 24.12.0(eslint@8.57.1)(jest@30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0))
       '@commercetools-frontend/mc-scripts':
         specifier: 24.12.0
-        version: 24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(eslint@8.57.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@4.2.1))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)(redux@4.2.1)(rollup@2.80.0)(terser@5.46.0)(tsx@4.21.0)(type-fest@0.21.3)(typescript@5.9.3)(yaml@2.8.2)
+        version: 24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(eslint@8.57.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@4.2.1))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)(redux@4.2.1)(rollup@2.80.0)(terser@5.46.0)(tsx@4.21.0)(type-fest@0.21.3)(typescript@7.0.2)(yaml@2.8.2)
       '@commitlint/cli':
         specifier: 19.8.1
-        version: 19.8.1(@types/node@24.10.9)(typescript@5.9.3)
+        version: 19.8.1(@types/node@24.10.9)(typescript@7.0.2)
       '@commitlint/config-conventional':
         specifier: 19.8.1
         version: 19.8.1
@@ -37,7 +39,7 @@ importers:
         version: 5.0.3(graphql@16.11.0)
       '@graphql-codegen/cli':
         specifier: 5.0.7
-        version: 5.0.7(@types/node@24.10.9)(enquirer@2.4.1)(graphql@16.11.0)(typescript@5.9.3)
+        version: 5.0.7(@types/node@24.10.9)(enquirer@2.4.1)(graphql@16.11.0)(typescript@7.0.2)
       '@graphql-codegen/introspection':
         specifier: 4.0.3
         version: 4.0.3(graphql@16.11.0)
@@ -97,7 +99,7 @@ importers:
         version: 30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0)
       jest-extended:
         specifier: 6.0.0
-        version: 6.0.0(jest@30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 6.0.0(jest@30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0))(typescript@7.0.2)
       jest-fail-on-console:
         specifier: 3.3.3
         version: 3.3.3(@jest/globals@30.2.0)
@@ -121,10 +123,10 @@ importers:
         version: prettier@3.7.4
       tsc-files:
         specifier: 1.1.4
-        version: 1.1.4(typescript@5.9.3)
+        version: 1.1.4(typescript@7.0.2)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 7.0.2
+        version: 7.0.2
 
   generators:
     dependencies:
@@ -159,6 +161,9 @@ importers:
       '@types/prompts':
         specifier: 2.4.9
         version: 2.4.9
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
   standalone:
     dependencies:
@@ -170,7 +175,7 @@ importers:
         version: 7.28.4
       '@commercetools-frontend/application-config':
         specifier: 24.13.0
-        version: 24.13.0(@types/node@24.10.9)(typescript@5.9.3)
+        version: 24.13.0(@types/node@24.10.9)(typescript@6.0.3)
       '@commercetools-frontend/constants':
         specifier: 24.13.0
         version: 24.13.0
@@ -189,6 +194,10 @@ importers:
       omit-deep:
         specifier: 0.3.0
         version: 0.3.0
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -3335,20 +3344,12 @@ packages:
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@typescript-eslint/parser@5.62.0':
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@typescript-eslint/scope-manager@5.62.0':
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
@@ -3359,10 +3360,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@typescript-eslint/types@5.62.0':
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
@@ -3371,11 +3368,6 @@ packages:
   '@typescript-eslint/typescript-estree@5.62.0':
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@typescript-eslint/utils@5.62.0':
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
@@ -3386,6 +3378,126 @@ packages:
   '@typescript-eslint/visitor-keys@5.62.0':
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -8316,6 +8428,16 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -9836,38 +9958,38 @@ snapshots:
       redux: 4.2.1
       redux-thunk: 3.1.0(redux@4.2.1)
 
-  '@commercetools-frontend/application-components@24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@4.2.1))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)(redux@4.2.1)(typescript@5.9.3)':
+  '@commercetools-frontend/application-components@24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@4.2.1))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)(redux@4.2.1)(typescript@7.0.2)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
       '@commercetools-frontend/actions-global': 24.12.0(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@4.2.1))(react@19.2.4)(redux@4.2.1)
-      '@commercetools-frontend/application-config': 24.12.0(@types/node@24.10.9)(typescript@5.9.3)
-      '@commercetools-frontend/application-shell-connectors': 24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(react@19.2.4)(typescript@5.9.3)
+      '@commercetools-frontend/application-config': 24.12.0(@types/node@24.10.9)(typescript@7.0.2)
+      '@commercetools-frontend/application-shell-connectors': 24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(react@19.2.4)(typescript@7.0.2)
       '@commercetools-frontend/assets': 24.12.0
       '@commercetools-frontend/constants': 24.12.0
-      '@commercetools-frontend/i18n': 24.12.0(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
+      '@commercetools-frontend/i18n': 24.12.0(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
       '@commercetools-frontend/l10n': 24.12.0(react@19.2.4)
       '@commercetools-frontend/sentry': 24.12.0(react@19.2.4)
       '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/card': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/constraints': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/flat-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@commercetools-uikit/flat-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)
       '@commercetools-uikit/hooks': 20.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/icon-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@commercetools-uikit/icon-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)
       '@commercetools-uikit/icons': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/label': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
-      '@commercetools-uikit/messages': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@commercetools-uikit/primary-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@commercetools-uikit/label': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
+      '@commercetools-uikit/messages': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)
+      '@commercetools-uikit/primary-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)
+      '@commercetools-uikit/secondary-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)
+      '@commercetools-uikit/secondary-icon-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)
       '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/stamp': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
+      '@commercetools-uikit/stamp': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
       '@commercetools-uikit/utils': 20.4.0(react@19.2.4)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
-      '@flopflip/react-broadcast': 15.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@flopflip/react-broadcast': 15.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)
       '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@react-hook/latest': 1.0.3(react@19.2.4)
       '@react-hook/resize-observer': 1.2.6(react@19.2.4)
@@ -9883,7 +10005,7 @@ snapshots:
       raf-schd: 4.0.3
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-intl: 7.1.14(react@19.2.4)(typescript@5.9.3)
+      react-intl: 7.1.14(react@19.2.4)(typescript@7.0.2)
       react-router-dom: 5.3.4(react@19.2.4)
     transitivePeerDependencies:
       - '@apollo/client'
@@ -9896,7 +10018,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@commercetools-frontend/application-config@24.12.0(@types/node@24.10.9)(typescript@5.9.3)':
+  '@commercetools-frontend/application-config@24.12.0(@types/node@24.10.9)(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/register': 7.28.6(@babel/core@7.29.0)
@@ -9907,8 +10029,8 @@ snapshots:
       '@types/react': 19.2.14
       ajv: 8.17.1
       core-js: 3.48.0
-      cosmiconfig: 9.0.0(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.10.9)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig: 9.0.0(typescript@7.0.2)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.10.9)(cosmiconfig@9.0.0(typescript@7.0.2))(typescript@7.0.2)
       dompurify: 3.3.2
       jsdom: 21.1.2
       lodash: 4.17.21
@@ -9921,7 +10043,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@commercetools-frontend/application-config@24.13.0(@types/node@24.10.9)(typescript@5.9.3)':
+  '@commercetools-frontend/application-config@24.13.0(@types/node@24.10.9)(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/register': 7.28.6(@babel/core@7.29.0)
@@ -9932,8 +10054,8 @@ snapshots:
       '@types/react': 19.2.14
       ajv: 8.17.1
       core-js: 3.48.0
-      cosmiconfig: 9.0.0(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.10.9)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig: 9.0.0(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.10.9)(cosmiconfig@9.0.0(typescript@6.0.3))(typescript@6.0.3)
       dompurify: 3.3.2
       jsdom: 21.1.2
       lodash: 4.17.21
@@ -9946,12 +10068,12 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@commercetools-frontend/application-shell-connectors@24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(react@19.2.4)(typescript@5.9.3)':
+  '@commercetools-frontend/application-shell-connectors@24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(react@19.2.4)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
-      '@commercetools-frontend/application-config': 24.12.0(@types/node@24.10.9)(typescript@5.9.3)
+      '@commercetools-frontend/application-config': 24.12.0(@types/node@24.10.9)(typescript@7.0.2)
       '@commercetools-frontend/browser-history': 24.12.0
       '@commercetools-frontend/constants': 24.12.0
       '@commercetools-frontend/sentry': 24.12.0(react@19.2.4)
@@ -10038,21 +10160,21 @@ snapshots:
       '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@8.57.1)
       '@commercetools-frontend/babel-preset-mc-app': 24.12.0
       '@rushstack/eslint-patch': 1.16.1
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint@8.57.1)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)
       confusing-browser-globals: 1.0.11
       eslint: 8.57.1
       eslint-config-prettier: 8.10.2(eslint@8.57.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-cypress: 2.15.2(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)(jest@30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0))
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-prettier: 4.2.5(eslint-config-prettier@8.10.2(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
-      eslint-plugin-testing-library: 5.11.1(eslint@8.57.1)(typescript@5.9.3)
+      eslint-plugin-testing-library: 5.11.1(eslint@8.57.1)
       prettier: 2.8.8
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10062,7 +10184,7 @@ snapshots:
       - supports-color
       - ts-jest
 
-  '@commercetools-frontend/i18n@24.12.0(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)':
+  '@commercetools-frontend/i18n@24.12.0(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
@@ -10076,7 +10198,7 @@ snapshots:
       moment: 2.30.1
       prop-types: 15.8.1
       react: 19.2.4
-      react-intl: 7.1.14(react@19.2.4)(typescript@5.9.3)
+      react-intl: 7.1.14(react@19.2.4)(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -10102,11 +10224,11 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
 
-  '@commercetools-frontend/mc-html-template@24.12.0(@types/node@24.10.9)(typescript@5.9.3)':
+  '@commercetools-frontend/mc-html-template@24.12.0(@types/node@24.10.9)(typescript@7.0.2)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
-      '@commercetools-frontend/application-config': 24.12.0(@types/node@24.10.9)(typescript@5.9.3)
+      '@commercetools-frontend/application-config': 24.12.0(@types/node@24.10.9)(typescript@7.0.2)
       '@commercetools-frontend/constants': 24.12.0
       serialize-javascript: 6.0.2
       uglify-js: 3.19.3
@@ -10119,19 +10241,19 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@commercetools-frontend/mc-scripts@24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(eslint@8.57.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@4.2.1))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)(redux@4.2.1)(rollup@2.80.0)(terser@5.46.0)(tsx@4.21.0)(type-fest@0.21.3)(typescript@5.9.3)(yaml@2.8.2)':
+  '@commercetools-frontend/mc-scripts@24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(eslint@8.57.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@4.2.1))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)(redux@4.2.1)(rollup@2.80.0)(terser@5.46.0)(tsx@4.21.0)(type-fest@0.21.3)(typescript@7.0.2)(yaml@2.8.2)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-do-expressions': 7.28.6(@babel/core@7.29.0)
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
-      '@commercetools-frontend/application-components': 24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@4.2.1))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)(redux@4.2.1)(typescript@5.9.3)
-      '@commercetools-frontend/application-config': 24.12.0(@types/node@24.10.9)(typescript@5.9.3)
+      '@commercetools-frontend/application-components': 24.12.0(@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.11.0)(ws@8.19.0))(graphql@16.11.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@24.10.9)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@4.2.1))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)(redux@4.2.1)(typescript@7.0.2)
+      '@commercetools-frontend/application-config': 24.12.0(@types/node@24.10.9)(typescript@7.0.2)
       '@commercetools-frontend/assets': 24.12.0
       '@commercetools-frontend/babel-preset-mc-app': 24.12.0
       '@commercetools-frontend/constants': 24.12.0
       '@commercetools-frontend/mc-dev-authentication': 24.12.0
-      '@commercetools-frontend/mc-html-template': 24.12.0(@types/node@24.10.9)(typescript@5.9.3)
+      '@commercetools-frontend/mc-html-template': 24.12.0(@types/node@24.10.9)(typescript@7.0.2)
       '@commercetools/http-user-agent': 3.0.0
       '@emotion/babel-plugin': 11.13.5
       '@formatjs/cli-lib': 6.6.6
@@ -10179,7 +10301,7 @@ snapshots:
       prettier: 2.8.8
       prompts: 2.4.2
       querystring-es3: 0.2.1
-      react-dev-utils: 12.0.1(eslint@8.57.1)(typescript@5.9.3)(webpack@5.101.1)
+      react-dev-utils: 12.0.1(eslint@8.57.1)(typescript@7.0.2)(webpack@5.101.1)
       react-refresh: 0.17.0
       rollup-plugin-visualizer: 5.14.0(rollup@2.80.0)
       serve-handler: 6.1.6
@@ -10332,20 +10454,20 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/flat-button@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@commercetools-uikit/flat-button@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
       '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
       '@commercetools-uikit/utils': 20.4.0(react@19.2.4)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       lodash: 4.17.23
       react: 19.2.4
-      react-intl: 7.1.14(react@19.2.4)(typescript@5.9.3)
+      react-intl: 7.1.14(react@19.2.4)(typescript@7.0.2)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -10368,20 +10490,20 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
 
-  '@commercetools-uikit/icon-button@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@commercetools-uikit/icon-button@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
       '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
       '@commercetools-uikit/utils': 20.4.0(react@19.2.4)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       lodash: 4.17.23
       react: 19.2.4
-      react-intl: 7.1.14(react@19.2.4)(typescript@5.9.3)
+      react-intl: 7.1.14(react@19.2.4)(typescript@7.0.2)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -10405,92 +10527,92 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/label@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)':
+  '@commercetools-uikit/label@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
       '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
       '@commercetools-uikit/utils': 20.4.0(react@19.2.4)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-intl: 7.1.14(react@19.2.4)(typescript@5.9.3)
+      react-intl: 7.1.14(react@19.2.4)(typescript@7.0.2)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/messages@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@commercetools-uikit/messages@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
       '@commercetools-uikit/utils': 20.4.0(react@19.2.4)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-intl: 7.1.14(react@19.2.4)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/primary-button@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@babel/runtime-corejs3': 7.28.4
-      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
-      '@commercetools-uikit/utils': 20.4.0(react@19.2.4)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
-      lodash: 4.17.23
-      react: 19.2.4
-      react-intl: 7.1.14(react@19.2.4)(typescript@5.9.3)
+      react-intl: 7.1.14(react@19.2.4)(typescript@7.0.2)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/secondary-button@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)':
+  '@commercetools-uikit/primary-button@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
       '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
       '@commercetools-uikit/utils': 20.4.0(react@19.2.4)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       lodash: 4.17.23
       react: 19.2.4
-      react-intl: 7.1.14(react@19.2.4)(typescript@5.9.3)
+      react-intl: 7.1.14(react@19.2.4)(typescript@7.0.2)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+      - supports-color
+      - typescript
+
+  '@commercetools-uikit/secondary-button@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react-router-dom@5.3.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@babel/runtime-corejs3': 7.28.4
+      '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
+      '@commercetools-uikit/utils': 20.4.0(react@19.2.4)
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
+      lodash: 4.17.23
+      react: 19.2.4
+      react-intl: 7.1.14(react@19.2.4)(typescript@7.0.2)
       react-router-dom: 5.3.4(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/secondary-icon-button@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@commercetools-uikit/secondary-icon-button@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
       '@commercetools-uikit/accessible-button': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/spacings': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
       '@commercetools-uikit/utils': 20.4.0(react@19.2.4)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       lodash: 4.17.23
       react: 19.2.4
-      react-intl: 7.1.14(react@19.2.4)(typescript@5.9.3)
+      react-intl: 7.1.14(react@19.2.4)(typescript@7.0.2)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -10563,13 +10685,13 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/stamp@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)':
+  '@commercetools-uikit/stamp@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
       '@commercetools-uikit/design-system': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@commercetools-uikit/spacings-inline': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)
+      '@commercetools-uikit/text': 20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)
       '@commercetools-uikit/utils': 20.4.0(react@19.2.4)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
@@ -10579,7 +10701,7 @@ snapshots:
       - react-intl
       - supports-color
 
-  '@commercetools-uikit/text@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@5.9.3))(react@19.2.4)':
+  '@commercetools-uikit/text@20.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-intl@7.1.14(react@19.2.4)(typescript@7.0.2))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.4
@@ -10588,7 +10710,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       lodash: 4.17.23
       react: 19.2.4
-      react-intl: 7.1.14(react@19.2.4)(typescript@5.9.3)
+      react-intl: 7.1.14(react@19.2.4)(typescript@7.0.2)
       warning: 4.0.3
     transitivePeerDependencies:
       - '@types/react'
@@ -10612,11 +10734,11 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@commitlint/cli@19.8.1(@types/node@24.10.9)(typescript@5.9.3)':
+  '@commitlint/cli@19.8.1(@types/node@24.10.9)(typescript@7.0.2)':
     dependencies:
       '@commitlint/format': 19.8.1
       '@commitlint/lint': 19.8.1
-      '@commitlint/load': 19.8.1(@types/node@24.10.9)(typescript@5.9.3)
+      '@commitlint/load': 19.8.1(@types/node@24.10.9)(typescript@7.0.2)
       '@commitlint/read': 19.8.1
       '@commitlint/types': 19.8.1
       tinyexec: 1.0.2
@@ -10663,15 +10785,15 @@ snapshots:
       '@commitlint/rules': 19.8.1
       '@commitlint/types': 19.8.1
 
-  '@commitlint/load@19.8.1(@types/node@24.10.9)(typescript@5.9.3)':
+  '@commitlint/load@19.8.1(@types/node@24.10.9)(typescript@7.0.2)':
     dependencies:
       '@commitlint/config-validator': 19.8.1
       '@commitlint/execute-rule': 19.8.1
       '@commitlint/resolve-extends': 19.8.1
       '@commitlint/types': 19.8.1
       chalk: 5.6.2
-      cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.2.0(@types/node@24.10.9)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@7.0.2)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@24.10.9)(cosmiconfig@9.0.1(typescript@7.0.2))(typescript@7.0.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -11040,36 +11162,36 @@ snapshots:
 
   '@fastify/busboy@3.2.0': {}
 
-  '@flopflip/cache@15.1.5(typescript@5.9.3)':
+  '@flopflip/cache@15.1.5(typescript@7.0.2)':
     dependencies:
-      '@flopflip/localstorage-cache': 15.1.5(typescript@5.9.3)
-      '@flopflip/sessionstorage-cache': 15.1.5(typescript@5.9.3)
-      '@flopflip/types': 15.1.5(typescript@5.9.3)
+      '@flopflip/localstorage-cache': 15.1.5(typescript@7.0.2)
+      '@flopflip/sessionstorage-cache': 15.1.5(typescript@7.0.2)
+      '@flopflip/types': 15.1.5(typescript@7.0.2)
     transitivePeerDependencies:
       - typescript
 
-  '@flopflip/localstorage-cache@15.1.5(typescript@5.9.3)':
+  '@flopflip/localstorage-cache@15.1.5(typescript@7.0.2)':
     dependencies:
-      '@flopflip/types': 15.1.5(typescript@5.9.3)
+      '@flopflip/types': 15.1.5(typescript@7.0.2)
     transitivePeerDependencies:
       - typescript
 
-  '@flopflip/react-broadcast@15.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@flopflip/react-broadcast@15.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@flopflip/react': 15.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@flopflip/types': 15.1.5(typescript@5.9.3)
+      '@flopflip/react': 15.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)
+      '@flopflip/types': 15.1.5(typescript@7.0.2)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
     transitivePeerDependencies:
       - typescript
 
-  '@flopflip/react@15.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@flopflip/react@15.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@7.0.2)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@flopflip/cache': 15.1.5(typescript@5.9.3)
-      '@flopflip/types': 15.1.5(typescript@5.9.3)
+      '@flopflip/cache': 15.1.5(typescript@7.0.2)
+      '@flopflip/types': 15.1.5(typescript@7.0.2)
       '@types/react-is': 19.2.0
       lodash: 4.17.21
       react: 19.2.4
@@ -11080,16 +11202,16 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@flopflip/sessionstorage-cache@15.1.5(typescript@5.9.3)':
+  '@flopflip/sessionstorage-cache@15.1.5(typescript@7.0.2)':
     dependencies:
-      '@flopflip/types': 15.1.5(typescript@5.9.3)
+      '@flopflip/types': 15.1.5(typescript@7.0.2)
     transitivePeerDependencies:
       - typescript
 
-  '@flopflip/types@15.1.5(typescript@5.9.3)':
+  '@flopflip/types@15.1.5(typescript@7.0.2)':
     dependencies:
       launchdarkly-js-client-sdk: 3.9.0
-      typescript: 5.9.3
+      typescript: 7.0.2
 
   '@formatjs/cli-lib@6.6.6':
     dependencies:
@@ -11184,7 +11306,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@formatjs/intl@3.1.8(typescript@5.9.3)':
+  '@formatjs/intl@3.1.8(typescript@7.0.2)':
     dependencies:
       '@formatjs/ecma402-abstract': 2.3.6
       '@formatjs/fast-memoize': 2.2.7
@@ -11192,7 +11314,7 @@ snapshots:
       intl-messageformat: 10.7.18
       tslib: 2.8.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
 
   '@formatjs/ts-transformer@3.13.23':
     dependencies:
@@ -11219,7 +11341,7 @@ snapshots:
       graphql: 16.11.0
       tslib: 2.6.3
 
-  '@graphql-codegen/cli@5.0.7(@types/node@24.10.9)(enquirer@2.4.1)(graphql@16.11.0)(typescript@5.9.3)':
+  '@graphql-codegen/cli@5.0.7(@types/node@24.10.9)(enquirer@2.4.1)(graphql@16.11.0)(typescript@7.0.2)':
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/template': 7.28.6
@@ -11239,11 +11361,11 @@ snapshots:
       '@graphql-tools/utils': 10.11.0(graphql@16.11.0)
       '@whatwg-node/fetch': 0.10.13
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      cosmiconfig: 8.3.6(typescript@7.0.2)
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 16.11.0
-      graphql-config: 5.1.5(@types/node@24.10.9)(graphql@16.11.0)(typescript@5.9.3)
+      graphql-config: 5.1.5(@types/node@24.10.9)(graphql@16.11.0)(typescript@7.0.2)
       inquirer: 8.2.7(@types/node@24.10.9)
       is-glob: 4.0.3
       jiti: 1.21.7
@@ -13072,34 +13194,32 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint@8.57.1)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)
       debug: 4.4.3
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.7.4
-      tsutils: 3.21.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
+      tsutils: 3.21.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@5.62.0(eslint@8.57.1)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 5.62.0
       debug: 4.4.3
       eslint: 8.57.1
-    optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13108,21 +13228,20 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 5.62.0
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)
       debug: 4.4.3
       eslint: 8.57.1
-      tsutils: 3.21.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
+      tsutils: 3.21.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@5.62.0': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -13130,31 +13249,90 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.4
-      tsutils: 3.21.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
+      tsutils: 3.21.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 5.62.0
       eslint: 8.57.1
       eslint-scope: 5.1.1
       semver: 7.7.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-      - typescript
 
   '@typescript-eslint/visitor-keys@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.3
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -14128,19 +14306,26 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@24.10.9)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@24.10.9)(cosmiconfig@9.0.0(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       '@types/node': 24.10.9
-      cosmiconfig: 9.0.0(typescript@5.9.3)
+      cosmiconfig: 9.0.0(typescript@6.0.3)
       jiti: 2.6.1
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  cosmiconfig-typescript-loader@6.2.0(@types/node@24.10.9)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@24.10.9)(cosmiconfig@9.0.0(typescript@7.0.2))(typescript@7.0.2):
     dependencies:
       '@types/node': 24.10.9
-      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig: 9.0.0(typescript@7.0.2)
       jiti: 2.6.1
-      typescript: 5.9.3
+      typescript: 7.0.2
+
+  cosmiconfig-typescript-loader@6.2.0(@types/node@24.10.9)(cosmiconfig@9.0.1(typescript@7.0.2))(typescript@7.0.2):
+    dependencies:
+      '@types/node': 24.10.9
+      cosmiconfig: 9.0.1(typescript@7.0.2)
+      jiti: 2.6.1
+      typescript: 7.0.2
 
   cosmiconfig@6.0.0:
     dependencies:
@@ -14158,32 +14343,41 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  cosmiconfig@8.3.6(typescript@5.9.3):
+  cosmiconfig@8.3.6(typescript@7.0.2):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
 
-  cosmiconfig@9.0.0(typescript@5.9.3):
+  cosmiconfig@9.0.0(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  cosmiconfig@9.0.1(typescript@5.9.3):
+  cosmiconfig@9.0.0(typescript@7.0.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
+
+  cosmiconfig@9.0.1(typescript@7.0.2):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 7.0.2
 
   create-jest-runner@0.11.2:
     dependencies:
@@ -14811,7 +15005,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -14822,18 +15016,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14842,7 +15036,7 @@ snapshots:
       eslint: 8.57.1
       globals: 13.24.0
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14853,7 +15047,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14865,7 +15059,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -14878,16 +15072,15 @@ snapshots:
       eslint: 8.57.1
       requireindex: 1.2.0
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)(jest@30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0)):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)
       eslint: 8.57.1
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1))(eslint@8.57.1)
       jest: 30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - supports-color
-      - typescript
 
   eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1):
     dependencies:
@@ -14942,13 +15135,12 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-testing-library@5.11.1(eslint@8.57.1)(typescript@5.9.3):
+  eslint-plugin-testing-library@5.11.1(eslint@8.57.1):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
-      - typescript
 
   eslint-rule-docs@1.1.235: {}
 
@@ -15256,7 +15448,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.1)(typescript@5.9.3)(webpack@5.101.1):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.1)(typescript@7.0.2)(webpack@5.101.1):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@types/json-schema': 7.0.15
@@ -15271,7 +15463,7 @@ snapshots:
       schema-utils: 2.7.0
       semver: 7.7.4
       tapable: 1.1.3
-      typescript: 5.9.3
+      typescript: 7.0.2
       webpack: 5.101.1
     optionalDependencies:
       eslint: 8.57.1
@@ -15483,7 +15675,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-config@5.1.5(@types/node@24.10.9)(graphql@16.11.0)(typescript@5.9.3):
+  graphql-config@5.1.5(@types/node@24.10.9)(graphql@16.11.0)(typescript@7.0.2):
     dependencies:
       '@graphql-tools/graphql-file-loader': 8.1.11(graphql@16.11.0)
       '@graphql-tools/json-file-loader': 8.0.26(graphql@16.11.0)
@@ -15491,7 +15683,7 @@ snapshots:
       '@graphql-tools/merge': 9.1.7(graphql@16.11.0)
       '@graphql-tools/url-loader': 8.0.33(@types/node@24.10.9)(graphql@16.11.0)
       '@graphql-tools/utils': 10.11.0(graphql@16.11.0)
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      cosmiconfig: 8.3.6(typescript@7.0.2)
       graphql: 16.11.0
       jiti: 2.6.1
       minimatch: 9.0.9
@@ -16233,10 +16425,10 @@ snapshots:
       jest-util: 30.2.0
       jest-validate: 30.2.0
 
-  jest-extended@6.0.0(jest@30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  jest-extended@6.0.0(jest@30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0))(typescript@7.0.2):
     dependencies:
       jest-diff: 29.7.0
-      typescript: 5.9.3
+      typescript: 7.0.2
     optionalDependencies:
       jest: 30.2.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0)
 
@@ -17719,7 +17911,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dev-utils@12.0.1(eslint@8.57.1)(typescript@5.9.3)(webpack@5.101.1):
+  react-dev-utils@12.0.1(eslint@8.57.1)(typescript@7.0.2)(webpack@5.101.1):
     dependencies:
       '@babel/code-frame': 7.29.0
       address: 1.2.2
@@ -17730,7 +17922,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.1)(typescript@5.9.3)(webpack@5.101.1)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.1)(typescript@7.0.2)(webpack@5.101.1)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -17747,7 +17939,7 @@ snapshots:
       text-table: 0.2.0
       webpack: 5.101.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -17764,11 +17956,11 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  react-intl@7.1.14(react@19.2.4)(typescript@5.9.3):
+  react-intl@7.1.14(react@19.2.4)(typescript@7.0.2):
     dependencies:
       '@formatjs/ecma402-abstract': 2.3.6
       '@formatjs/icu-messageformat-parser': 2.11.4
-      '@formatjs/intl': 3.1.8(typescript@5.9.3)
+      '@formatjs/intl': 3.1.8(typescript@7.0.2)
       '@types/hoist-non-react-statics': 3.3.7(@types/react@19.2.14)
       '@types/react': 19.2.14
       hoist-non-react-statics: 3.3.2
@@ -17776,7 +17968,7 @@ snapshots:
       react: 19.2.4
       tslib: 2.8.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
 
   react-is@16.13.1: {}
 
@@ -18718,9 +18910,9 @@ snapshots:
 
   ts-log@2.2.7: {}
 
-  tsc-files@1.1.4(typescript@5.9.3):
+  tsc-files@1.1.4(typescript@7.0.2):
     dependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -18737,10 +18929,10 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsutils@3.21.0(typescript@5.9.3):
+  tsutils@3.21.0(typescript@6.0.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tsx@4.21.0:
     dependencies:
@@ -18798,6 +18990,31 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uglify-js@3.19.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,32 @@ allowBuilds:
   esbuild: false
   sharp: false
   unrs-resolver: false
+
+# TypeScript 7.0 dropped the classic JS "Strada" Program/type-checker API that
+# ships as the `typescript` package's public surface (only version metadata is
+# exported now). `typescript-eslint` v5 (pulled in transitively via
+# @commercetools-frontend/eslint-config-mc-app) still calls into that classic
+# API (e.g. `ts.TypeFlags`) for type-aware lint rules, so it must resolve an
+# older, API-compatible TypeScript instead of the repo's TS 7 devDependency.
+# 6.0.3 is the last TypeScript release built on the classic JS compiler.
+# `typescript` is declared as an *optional peer* (`typescript: '*'`) on these
+# packages, so a plain `overrides` entry doesn't pin it (peers are resolved
+# from the nearest matching instance in the graph, not from overrides).
+# `packageExtensions` promotes it to a hard dependency instead, which pnpm
+# always honors.
+packageExtensions:
+  '@typescript-eslint/eslint-plugin@5.62.0':
+    dependencies:
+      typescript: '6.0.3'
+  '@typescript-eslint/parser@5.62.0':
+    dependencies:
+      typescript: '6.0.3'
+  '@typescript-eslint/type-utils@5.62.0':
+    dependencies:
+      typescript: '6.0.3'
+  '@typescript-eslint/typescript-estree@5.62.0':
+    dependencies:
+      typescript: '6.0.3'
+  '@typescript-eslint/utils@5.62.0':
+    dependencies:
+      typescript: '6.0.3'

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -140,5 +140,8 @@
     "@types/lodash": "4.17.21",
     "lodash": "4.17.23",
     "omit-deep": "0.3.0"
+  },
+  "devDependencies": {
+    "typescript": "6.0.3"
   }
 }

--- a/standalone/src/models/cart/cart/custom-line-item/custom-line-item-draft/builders.spec.ts
+++ b/standalone/src/models/cart/cart/custom-line-item/custom-line-item-draft/builders.spec.ts
@@ -100,7 +100,7 @@ describe('CustomLineItemDraft compatibility builders', () => {
   it('builds a GraphQL model', () => {
     const customLineItemDraftGraphql = CustomLineItemDraft.random()
       .custom(CustomFieldBooleanType.random())
-      .buildGraphql();
+      .buildGraphql<TCustomLineItemDraftGraphql>();
     validateGraphqlFields(customLineItemDraftGraphql);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,10 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
     "allowJs": false,
+    // TypeScript 6.0+ defaults `types` to `[]` instead of auto-discovering every
+    // package under node_modules/@types. Our spec files rely on Jest's ambient
+    // globals (describe/it/expect) and @types/node globals, so list them explicitly.
+    "types": ["jest", "node"],
     "paths": {
       "@/core": ["./standalone/src/core"],
       "@/core/test-utils": ["./standalone/src/core/test-utils"],


### PR DESCRIPTION
## MIGRATION RECIPE (for fan-out to other repos)

This section is written to be copied verbatim into the other 8 repos
(`audit-log`, `identity`, `merchant-center-application-kit`,
`merchant-center-frontend`, `merchant-center-prices`,
`merchant-center-services`, `nimbus`, `ui-kit`).

### What changed

| | Before | After |
|---|---|---|
| `typescript` | `5.9.3` | `7.0.2` |

TypeScript's real current latest major on npm is **7** (`7.0.2`, released
2026-07-08 — "Project Corsa", a full port of the compiler/language service to
Go). TypeScript 6 (`6.0.3`) existed as an intermediate major and was the last
release built on the classic JS compiler; read its release notes too, because
every 6.0 breaking change also applies to 7.0 (7.0 is a superset).

References read:
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html
- https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-rc/

### tsconfig.json changes

Added one compiler option, no removals were needed for this repo's existing
config (it already used `moduleResolution: "Bundler"`, `module: "ESNext"`,
`target: "ESNext"`, so none of the hard-removed options — `target: es5`,
`moduleResolution: classic`, `module: amd/umd/systemjs/none`, `baseUrl`,
`downlevelIteration` — were in play):

```jsonc
{
  "compilerOptions": {
    // TypeScript 6.0+ defaults `types` to `[]` instead of auto-discovering
    // every package under node_modules/@types. Spec files that use Jest's
    // ambient globals (describe/it/expect) without importing them from
    // '@jest/globals' will fail to compile unless you list them explicitly.
    "types": ["jest", "node"]
  }
}
```

**Watch for in other repos:** any repo relying on ambient `@types/*` global
augmentation (jest, mocha, node, cypress, testing-library matchers, etc.)
without an explicit `types` array needs this same fix. Grep for
`describe(`/`it(`/`expect(` used without a corresponding import, and for any
other ambient global usage (e.g. `process`, `Buffer`) that depended on
`@types/node` being auto-included.

If your repo *does* use any of the hard-removed/changed options, here's the
mapping (from the TS 6.0/7.0 release notes):

- `target: "es5"` → bump to `es2015`+ (`es5` is a hard error now)
- `downlevelIteration` → remove (no longer has any effect below es5, which no
  longer exists)
- `moduleResolution: "node"` / `"node10"` → migrate to `"nodenext"` or
  `"bundler"`
- `moduleResolution: "classic"` → hard error, must move to `"bundler"` or
  `"node16"/"nodenext"`
- `module: "amd" | "umd" | "systemjs" | "none"` → hard error, migrate to
  `"esnext"`/`"commonjs"`/bundler-appropriate value
- `baseUrl` (used as a module-resolution root) → hard error; switch to
  explicit `paths` with relative globs, or a bundler/`tsconfig-paths`-style
  resolution
- `esModuleInterop: false` / `allowSyntheticDefaultImports: false` /
  `alwaysStrict: false` → can no longer be set to `false`; delete the line
  (safer interop / strict mode is now unconditional)
- `outFile` → removed entirely
- Legacy `module Foo { ... }` namespace syntax → error; rename to
  `namespace Foo { ... }`
- `rootDir` now defaults to `.` (the tsconfig's directory) instead of being
  inferred from your source layout — if your repo's `tsconfig.json` lives
  outside `src/`, add an explicit `"rootDir": "./src"` (or equivalent) to
  avoid unexpected emit-path changes (this only matters if you emit; a
  `noEmit`/`--noEmit` typecheck-only repo like this one is unaffected)

### Error categories found and fix patterns

Running `tsc --noEmit` right after the bump (before any tsconfig changes)
produced **~8,442 `TS2304`/`2593` errors + 4 `TS2694` + 1 `TS2345`** across the
repo. All but one category collapsed to a single tsconfig fix; only one file
needed an actual source-code change.

**1. `TS2304`/`TS2593` "Cannot find name 'describe'/'it'/'expect'"  (~8,442
occurrences, ~530 files)**

Cause: `types` defaults to `[]` in TS 6.0+ (see tsconfig section above).

Fix: add `"types": ["jest", "node"]` to `tsconfig.json`. One-line fix,
resolved the entire category at once — no per-file changes needed.

**2. `TS2345` type mismatch on a compatibility-builder call (1 occurrence)**

```ts
// before — TS 7 infers the untyped generic default (a union of the REST
// and GraphQL variant types) instead of narrowing, so the argument no
// longer matches the GraphQL-only validator:
const customLineItemDraftGraphql = CustomLineItemDraft.random()
  .custom(CustomFieldBooleanType.random())
  .buildGraphql();
validateGraphqlFields(customLineItemDraftGraphql); // TS2345

// after — supply the same explicit generic the rest of the codebase
// already uses for this pattern:
const customLineItemDraftGraphql = CustomLineItemDraft.random()
  .custom(CustomFieldBooleanType.random())
  .buildGraphql<TCustomLineItemDraftGraphql>();
validateGraphqlFields(customLineItemDraftGraphql); // OK
```

This is a genuine generic-default inference difference between TS 5.9 and
TS 7, not a TS 6/7-documented breaking change — it slipped through because
one spec file omitted the explicit type argument that ~40 other, nearly
identical spec files in this repo already pass. **Watch for this pattern in
other repos**: any call site that relies on an *unspecified* generic type
argument defaulting through two levels of generics (an untyped factory call
feeding an untyped `build*()` call) is worth grepping for and double-checking
under TS 7, even if `tsc` doesn't flag it — in our case it did, but the
failure mode if it silently type-checked wrong would be a false green.

**3. Runtime tool breakage: `@preconstruct/cli`'s declaration bundler
(build-time, not a `tsc` error)**

`pnpm build` failed with:

```
TypeError: Cannot read properties of undefined (reading 'fileExists')
    at retrieveConfigFilenameOrThrow (.../@preconstruct/cli/.../preconstruct-cli-cli.cjs.js)
    ...
  plugin: 'typescript-declarations'
```

**Root cause (the single most important gotcha for fan-out repos):**
TypeScript 7.0 is a full Go port ("Project Corsa"). The `typescript` npm
package's public API surface is no longer the classic JS "Strada"
Program/LanguageService API — `require('typescript')` on 7.0.2 resolves to
`lib/version.cjs`, which exports only version metadata. There is **no**
`ts.sys`, `ts.createProgram`, `ts.findConfigFile`, `ts.TypeFlags`, etc. Any
tool that calls into that classic API directly (declaration bundlers, custom
build scripts, ts-jest, `rollup-plugin-typescript2`-style plugins,
`typescript-eslint` for type-aware rules, `ts-morph`, etc.) will crash or
silently misbehave the moment `typescript` resolves to 7.x for that tool,
even though `tsc` itself works fine.

Fix pattern — pin a classic-API-compatible TypeScript (**6.0.3**, the last
JS-based release) as an explicit dependency scoped to just the
package/tool that needs it, while keeping 7.0.2 as the repo's primary
devDependency for `tsc`/editors/CI typecheck:

- For a **workspace package** whose own bundler resolves `typescript` from
  that package's own directory (verify via
  `require.resolve('typescript', { paths: [packageDir] })` — preconstruct
  does this via `resolveFrom(packageDir, 'typescript')`), just add:
  ```jsonc
  // <package>/package.json
  "devDependencies": {
    "typescript": "6.0.3"
  }
  ```
  pnpm's per-package node_modules isolation means that package now resolves
  its own 6.0.3 instead of falling back up to the root's 7.0.2.

- For a **transitive tool with an optional peer dependency on `typescript`**
  (e.g. `typescript-eslint` v5, which declares `typescript: '*'` as an
  *optional* peer) — a plain `pnpm.overrides`/`pnpm-workspace.yaml overrides`
  entry with `'pkg>typescript': '6.0.3'` syntax **does not work**, because
  optional peers are resolved from whatever instance is nearest in the graph,
  not from `overrides`. Use `packageExtensions` instead, which rewrites the
  package's own manifest to declare it as a hard dependency:
  ```yaml
  # pnpm-workspace.yaml
  packageExtensions:
    '@typescript-eslint/eslint-plugin@5.62.0':
      dependencies:
        typescript: '6.0.3'
    '@typescript-eslint/parser@5.62.0':
      dependencies:
        typescript: '6.0.3'
    '@typescript-eslint/type-utils@5.62.0':
      dependencies:
        typescript: '6.0.3'
    '@typescript-eslint/typescript-estree@5.62.0':
      dependencies:
        typescript: '6.0.3'
    '@typescript-eslint/utils@5.62.0':
      dependencies:
        typescript: '6.0.3'
  ```
  After this, `require.resolve('typescript', { paths: [thatPackageDir] })`
  returns 6.0.3's `lib/typescript.js` (the classic entrypoint) instead of
  7.0.2's `lib/version.cjs`. Confirm with a quick `node -e` resolve check
  before assuming the fix landed — pnpm silently keeps the old lockfile
  resolution ("Already up to date") until you delete `node_modules` and
  reinstall, or otherwise force a re-resolution.

  This exact symptom hit ESLint type-aware rules here:
  `TypeError: Cannot read properties of undefined (reading 'Any')` from
  `@typescript-eslint/type-utils` reading `ts.TypeFlags.Any` — same root
  cause, same fix.

**If you're on a newer `typescript-eslint` (v8/v9+) in your repo**, check
first whether it has already added TS 7 support before reaching for this
workaround — v5 (used here, via
`@commercetools-frontend/eslint-config-mc-app@24.12.0`) predates TS 7 by a
wide margin and has no chance of supporting it natively.

### Time taken

Roughly 1.5-2 hours of agent wall-clock time end-to-end (version research,
bump, iterative fixing, three tool-compatibility investigations, and
verification runs), most of it in the `@preconstruct/cli`/`typescript-eslint`
Strada-API investigation rather than actual `tsc` type errors.

### Gotchas for fan-out agents

1. **Verify the real latest major yourself** — don't assume "current major +
   1". `npm view typescript versions --json` at the time of this migration
   showed 7.0.2 as `latest`, with 6.0.3 as a real, separate intermediate
   major worth reading release notes for even though we bumped straight to 7.
2. **`tsc --noEmit` passing clean is not sufficient to call the migration
   done.** Build tooling, ESLint, and any script that does
   `require('typescript')` directly can break even when the compiler itself
   is happy, because TS 7 removed the classic JS API. Always run the actual
   build and the actual CI lint/test command (not just `pnpm test`) before
   declaring success — this repo's `pnpm build` and `pnpm lint` both failed
   silently-differently from `tsc` and needed separate fixes.
3. **Check what `moduleResolution`/`module`/`target` this repo already
   uses before assuming you'll hit the hard-removed options.** This repo was
   already on `Bundler`/`ESNext`/`ESNext`, so none of the hard breaks applied
   here — other repos on older configs (`node`, `commonjs`, `es2020`, etc.)
   will likely hit several of the removed-option errors listed above.
4. **`ignoreDeprecations` won't save you for the hard-removed options** — it
   only covers the *deprecated-but-still-working* set (`moduleResolution:
   node`, `esModuleInterop: false`, etc.), not the ones that are now hard
   compiler errors (`target: es5`, `moduleResolution: classic`, `module:
   amd/umd/systemjs/none`, `baseUrl` as a resolution root, `outFile`).
5. **Any repo using `ts-jest`, `ts-node`, `ts-morph`, or a webpack/rollup/vite
   TypeScript plugin should expect the Strada-API-removal issue** and budget
   time for it — it was the majority of the effort here despite affecting
   only tooling, not source code.

---

## Summary of changes

Pathfinder migration of this repo's TypeScript major version, ahead of
fanning the same recipe out to 8 other commercetools frontend repos.

- **`typescript`: `5.9.3` → `7.0.2`** (root `package.json`)
- **`tsconfig.json`**: added `"types": ["jest", "node"]` (TS 6.0+ default for
  `types` changed from auto-discovery to `[]`)
- **`generators/package.json`, `standalone/package.json`**: added a scoped
  `typescript@6.0.3` devDependency so `@preconstruct/cli`'s declaration
  bundler (which needs the classic TS Program API, removed from TS 7's
  public npm package surface) keeps working
- **`pnpm-workspace.yaml`**: added `packageExtensions` pinning
  `typescript-eslint` v5's optional `typescript` peer to `6.0.3` for the same
  Strada-API reason (type-aware lint rules read `ts.TypeFlags`)
- **One source fix**: added an explicit generic type argument to a single
  `buildGraphql()` call in
  `standalone/src/models/cart/cart/custom-line-item/custom-line-item-draft/builders.spec.ts`
  where TS 7's generic-default inference surfaced a real (if narrow) type
  mismatch that TS 5.9 didn't catch

### Verification

- `pnpm install` — clean
- `pnpm typecheck` (`tsc --noEmit`) — clean, 0 errors
- `pnpm build` (`preconstruct build`) — clean
- `pnpm jest --projects jest.{eslint,test}.config.js` (this repo's actual CI
  gate, combining lint + tests) — **2820/2820 lint suites + 535/535 test
  suites (1691/1691 tests) passing**

All four checks were also run from a fully clean `node_modules` (not just
incrementally) to rule out stale-cache false positives.

Not merging — opening for review per the pathfinder migration process.
